### PR TITLE
Fix formatting for ordered list so that it renders correctly

### DIFF
--- a/chapter_crashcourse/linear-algebra.md
+++ b/chapter_crashcourse/linear-algebra.md
@@ -379,10 +379,11 @@ For example, we would represent the norm of a vector $\mathbf{x}$
 or matrix $A$ as $\|\mathbf{x}\|$ or $\|A\|$, respectively.
 
 All norms must satisfy a handful of properties:
+
 1. $\|\alpha A\| = |\alpha| \|A\|$
-2. $\|A + B\| \leq \|A\| + \|B\|$
-3. $\|A\| \geq 0$
-4. If $\forall {i,j}, a_{ij} = 0$, then $\|A\|=0$
+1. $\|A + B\| \leq \|A\| + \|B\|$
+1. $\|A\| \geq 0$
+1. If $\forall {i,j}, a_{ij} = 0$, then $\|A\|=0$
 
 To put it in words, the first rule says
 that if we scale all the components of a matrix or vector


### PR DESCRIPTION
<img width="1024" alt="screen shot 2018-12-26 at 9 50 56 pm" src="https://user-images.githubusercontent.com/649249/50467541-5dfacb80-0958-11e9-9ea6-8a1e59653a67.png">

Currently it shows up in a single line