### PR TITLE
s/it's/its.

### DIFF
--- a/chapter_crashcourse/introduction.md
+++ b/chapter_crashcourse/introduction.md
@@ -238,7 +238,7 @@ This observation, *heart attack* or *no heart attack*,
 would be our label $y$.
 The input data $\boldsymbol{x}$ might be vital signs such as heart rate, diastolic and systolic blood pressure, etc.
 
-The supervision comes into play because for choosing the parameters $\theta$, we (the supervisors) provide the model with a collection of *labeled examples* ($\boldsymbol{x}_i, y_i$), where each example $\boldsymbol{x}_i$ is matched up against it's correct label.
+The supervision comes into play because for choosing the parameters $\theta$, we (the supervisors) provide the model with a collection of *labeled examples* ($\boldsymbol{x}_i, y_i$), where each example $\boldsymbol{x}_i$ is matched up against its correct label.
 
 In probabilistic terms, we typically are interested estimating
 the conditional probability $P(y|x)$.


### PR DESCRIPTION
Correct grammar: "it's" is a contraction for "it is". The possessive is "its".