### PR TITLE
[MRG] Correct the probability

### DIFF
--- a/chapter_crashcourse/probability.md
+++ b/chapter_crashcourse/probability.md
@@ -334,7 +334,7 @@ Let us work out the requisite probabilities to invoke Bayes' Theorem.
 
 * $\Pr(D_1 = 1 \text{ and } D_2 = 1 | H = 0) = 0.01 \cdot 0.03 = 0.0003$
 * $\Pr(D_1 = 1 \text{ and } D_2 = 1 | H = 1) = 1 \cdot 0.98 = 0.98$
-* $\Pr(D_1 = 1 \text{ and } D_2 = 1) = 0.0001 \cdot 0.9985 + 0.98 \cdot 0.0015 = 0.00176955$
+* $\Pr(D_1 = 1 \text{ and } D_2 = 1) = 0.0003 \cdot 0.9985 + 0.98 \cdot 0.0015 = 0.00176955$
 * $\Pr(H = 1 | D_1 = 1 \text{ and } D_2 = 1) = \frac{0.98 \cdot 0.0015}{0.00176955} = 0.831$
 
 That is, the second test allowed us to gain much higher confidence that not all is well.


### PR DESCRIPTION
$\Pr(D_1 = 1 \text{ and } D_2 = 1 | H = 0) = 0.01 \cdot 0.03 = 0.0003$ but mistakenly was put $0.0003$ in the third equation. This commit fixes the problem.