### PR TITLE
Update requests to 2.20.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,5 +5,5 @@ dependencies:
 - matplotlib=2.2.2
 - pandas=0.23.4
 - pip:
-  - requests==2.18.4
+  - requests==2.20.0
   - mxnet==1.5.0b20181215


### PR DESCRIPTION
Otherwise conda env create -f environment.yml fails with:

mxnet 1.5.0b20181215 has requirement requests>=2.20.0,
but you'll have requests 2.18.4 which is incompatible.