### PR TITLE
Fix wording, notation, and some math parts.

### DIFF
--- a/chapter_crashcourse/install.md
+++ b/chapter_crashcourse/install.md
@@ -12,12 +12,12 @@ To get started we need to download and install the code needed to run the notebo
 
 For simplicity we recommend [conda](https://conda.io), a popular Python package manager to install all libraries.
 
-1. Download and install [Miniconda](https://conda.io/miniconda.html) at [conda.io/miniconda.html](https://conda.io/miniconda.html) based on your operating system.
+1. Download and install [Miniconda](https://conda.io/en/latest/miniconda.html) at [conda.io/en/latest/miniconda.html](https://conda.io/en/latest/miniconda.html) based on your operating system.
 1. Update your shell by `source ~/.bashrc` (Linux) or `source ~/.bash_profile` (macOS). Make sure to add Anaconda to your PATH environment variable.
 1. Download the tarball containing the notebooks from this book. This can be found at [www.d2l.ai/d2l-en-1.0.zip](https://www.d2l.ai/d2l-en-1.0.zip). Alternatively feel free to clone the latest version from GitHub.
 1. Uncompress the ZIP file and move its contents to a folder for the tutorials.
 
-On Linux this can be accomplished as follows from the command line; For MacOS replace Linux by MacOSX in the first line, for Windows follow the links provided above.
+On Linux this can be accomplished as follows from the command line; For MacOS replace Linux by MacOSX in the first two lines, for Windows follow the links provided above.
 
 ```
 wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh

--- a/chapter_crashcourse/linear-algebra.md
+++ b/chapter_crashcourse/linear-algebra.md
@@ -260,10 +260,10 @@ We can visualize the matrix in terms of its row vectors
 
 $$A=
 \begin{pmatrix}
-\cdots & \mathbf{a}^T_{1} &...  \\
-\cdots & \mathbf{a}^T_{2} & \cdots \\
- & \vdots &  \\
- \cdots &\mathbf{a}^T_n & \cdots \\
+\mathbf{a}^T_{1} \\
+\mathbf{a}^T_{2} \\
+\vdots \\
+\mathbf{a}^T_n \\
 \end{pmatrix},$$
 
 where each $\mathbf{a}^T_{i} \in \mathbb{R}^{m}$
@@ -273,10 +273,10 @@ Then the matrix vector product $\mathbf{y} = A\mathbf{x}$ is simply a column vec
 
 $$A\mathbf{x}=
 \begin{pmatrix}
-\cdots & \mathbf{a}^T_{1} &...  \\
-\cdots & \mathbf{a}^T_{2} & \cdots \\
- & \vdots &  \\
- \cdots &\mathbf{a}^T_n & \cdots \\
+\mathbf{a}^T_{1}  \\
+\mathbf{a}^T_{2}  \\
+ \vdots  \\
+\mathbf{a}^T_n \\
 \end{pmatrix}
 \begin{pmatrix}
  x_{1}  \\
@@ -325,15 +325,13 @@ To produce the matrix product $C = AB$, it's easiest to think of $A$ in terms of
 
 $$A=
 \begin{pmatrix}
-\cdots & \mathbf{a}^T_{1} &...  \\
-\cdots & \mathbf{a}^T_{2} & \cdots \\
- & \vdots &  \\
- \cdots &\mathbf{a}^T_n & \cdots \\
+\mathbf{a}^T_{1} \\
+\mathbf{a}^T_{2} \\
+\vdots \\
+\mathbf{a}^T_n \\
 \end{pmatrix},
 \quad B=\begin{pmatrix}
-\vdots & \vdots &  & \vdots \\
  \mathbf{b}_{1} & \mathbf{b}_{2} & \cdots & \mathbf{b}_{m} \\
- \vdots & \vdots &  &\vdots\\
 \end{pmatrix}.
 $$
 
@@ -342,15 +340,13 @@ Note here that each row vector $\mathbf{a}^T_{i}$ lies in $\mathbb{R}^k$ and tha
 Then to produce the matrix product $C \in \mathbb{R}^{n \times m}$ we simply compute each entry $c_{ij}$ as the dot product $\mathbf{a}^T_i \mathbf{b}_j$.
 
 $$C = AB = \begin{pmatrix}
-\cdots & \mathbf{a}^T_{1} &...  \\
-\cdots & \mathbf{a}^T_{2} & \cdots \\
- & \vdots &  \\
- \cdots &\mathbf{a}^T_n & \cdots \\
+\mathbf{a}^T_{1} \\
+\mathbf{a}^T_{2} \\
+\vdots \\
+\mathbf{a}^T_n \\
 \end{pmatrix}
 \begin{pmatrix}
-\vdots & \vdots &  & \vdots \\
  \mathbf{b}_{1} & \mathbf{b}_{2} & \cdots & \mathbf{b}_{m} \\
- \vdots & \vdots &  &\vdots\\
 \end{pmatrix}
 = \begin{pmatrix}
 \mathbf{a}^T_{1} \mathbf{b}_1 & \mathbf{a}^T_{1}\mathbf{b}_2& \cdots & \mathbf{a}^T_{1} \mathbf{b}_m \\

--- a/chapter_crashcourse/linear-algebra.md
+++ b/chapter_crashcourse/linear-algebra.md
@@ -46,7 +46,7 @@ print('x / y = ', x / y)
 print('x ** y = ', nd.power(x,y))
 ```
 
-We can convert any NDArray to a Python float by calling its `asscalar` method. Note that this is typically a bad idea. While you are doing this, NDArray has to stop doing anything else in order to hand the result and the process control back to Python. And unfortunately isn't very good at doing things in parallel. So avoid sprinkling this operation liberally throughout your code or your networks will take a long time to train.
+We can convert any NDArray to a Python float by calling its `asscalar` method. Note that this is typically a bad idea. While you are doing this, NDArray has to stop doing anything else in order to hand the result and the process control back to Python. And unfortunately Python isn't very good at doing things in parallel. So avoid sprinkling this operation liberally throughout your code or your networks will take a long time to train.
 
 ```{.python .input}
 x.asscalar()
@@ -88,7 +88,7 @@ x[3]
 ## Length, dimensionality and shape
 
 Let's revisit some concepts from the previous section. A vector is just an array of numbers. And just as every array has a length, so does every vector.
-In math notation, if we want to say that a vector $x$ consists of $n$ real-valued scalars,
+In math notation, if we want to say that a vector $\mathbf{x}$ consists of $n$ real-valued scalars,
 we can express this as $\mathbf{x} \in \mathcal{R}^n$.
 The length of a vector is commonly called its $dimension$.
 As with an ordinary Python array, we can access the length of an NDArray
@@ -232,7 +232,7 @@ y = nd.ones(4)
 print(x, y, nd.dot(x, y))
 ```
 
-Note that we can express the dot product of two vectors ``nd.dot(u, v)`` equivalently by performing an element-wise multiplication and then a sum:
+Note that we can express the dot product of two vectors ``nd.dot(x, y)`` equivalently by performing an element-wise multiplication and then a sum:
 
 ```{.python .input}
 nd.sum(x * y)
@@ -292,11 +292,11 @@ $$A\mathbf{x}=
 \end{pmatrix}
 $$
 
-So you can think of multiplication by a matrix $A\in \mathbb{R}^{m \times n}$ as a transformation that projects vectors from $\mathbb{R}^{m}$ to $\mathbb{R}^{n}$.
+So you can think of multiplication by a matrix $A\in \mathbb{R}^{n \times m}$ as a transformation that projects vectors from $\mathbb{R}^{m}$ to $\mathbb{R}^{n}$.
 
 These transformations turn out to be quite useful. For example, we can represent rotations as multiplications by a square matrix. As we'll see in subsequent chapters, we can also use matrix-vector products to describe the calculations of each layer in a neural network.
 
-Expressing matrix-vector products in code with ``ndarray``, we use the same ``nd.dot()`` function as for dot products. When we call ``nd.dot(A, x)`` with a matrix ``A`` and a vector ``x``, ``MXNet`` knows to perform a matrix-vector product. Note that the column dimension of ``A`` must be the same as the dimension of ``x``.
+Expressing matrix-vector products in code with ``ndarray``, we use the same ``nd.dot()`` function as for dot products. When we call ``nd.dot(A, x)`` with a matrix ``A`` and a vector ``x``, MXNet knows to perform a matrix-vector product. Note that the column dimension of ``A`` must be the same as the dimension of ``x``.
 
 ```{.python .input}
 nd.dot(A, x)
@@ -360,7 +360,7 @@ $$C = AB = \begin{pmatrix}
 \end{pmatrix}
 $$
 
-You can think of the matrix-matrix multiplication $AB$ as simply performing $m$ matrix-vector products and stitching the results together to form an $n \times m$ matrix. Just as with ordinary dot products and matrix-vector products, we can compute matrix-matrix products in ``MXNet`` by using ``nd.dot()``.
+You can think of the matrix-matrix multiplication $AB$ as simply performing $m$ matrix-vector products and stitching the results together to form an $n \times m$ matrix. Just as with ordinary dot products and matrix-vector products, we can compute matrix-matrix products in MXNet by using ``nd.dot()``.
 
 ```{.python .input}
 B = nd.ones(shape=(4, 3))
@@ -478,6 +478,7 @@ There are a number of special matrices that we will use throughout this tutorial
 In just a few pages (or one Jupyter notebook) we've taught you all the linear algebra you'll need to understand a good chunk of neural networks. Of course there's a *lot* more to linear algebra. And a lot of that math *is* useful for machine learning. For example, matrices can be decomposed into factors, and these decompositions can reveal low-dimensional structure in real-world datasets. There are entire subfields of machine learning that focus on using matrix decompositions and their generalizations to high-order tensors to discover structure in datasets and solve prediction problems. But this book focuses on deep learning. And we believe you'll be much more inclined to learn more mathematics once you've gotten your hands dirty deploying useful machine learning models on real datasets. So while we reserve the right to introduce more math much later on, we'll wrap up this chapter here.
 
 If you're eager to learn more about linear algebra, here are some of our favorite resources on the topic
+
 * For a solid primer on basics, check out Gilbert Strang's book [Introduction to Linear Algebra](http://math.mit.edu/~gs/linearalgebra/)
 * Zico Kolter's [Linear Algebra Review and Reference](http://www.cs.cmu.edu/~zkolter/course/15-884/linalg-review.pdf)
 

--- a/chapter_crashcourse/ndarray.md
+++ b/chapter_crashcourse/ndarray.md
@@ -55,13 +55,13 @@ nd.empty((3, 4))
 
 The `empty` method just grabs some memory and hands us back a matrix without setting the values of any of its entries. This is very efficient but it means that the entries can have any form of values, including very big ones! But typically, we'll want our matrices initialized.
 
-Commonly, we want one of all zeros. For objects with more than two dimensions mathematicians don't have special names - they simply call them tensors. To create one with all elements set to 0 a shape of (2, 3, 4) we use
+Commonly, we want one of all zeros. For objects with more than two dimensions mathematicians don't have special names - they simply call them tensors. To create one with all elements set to 0 and a shape of (2, 3, 4) we use
 
 ```{.python .input  n=4}
 nd.zeros((2, 3, 4))
 ```
 
-Just like in numpy, creating tensors with each element being 1 works via
+Just like in NumPy, creating tensors with each element being 1 works via
 
 ```{.python .input  n=5}
 nd.ones((2, 3, 4))
@@ -111,7 +111,7 @@ Many more operations can be applied element-wise, such as exponentiation:
 x.exp()
 ```
 
-In addition to computations by element, we can also use the `dot` function for matrix operations. Next, we will perform matrix multiplication to transpose `x` and `y`. We define `x` as a matrix of 3 rows and 4 columns, and `y` is transposed into a matrix of 4 rows and 3 columns. The two matrices are multiplied to obtain a matrix of 3 rows and 3 columns (if you're confused about what this means, don't worry - we will explain matrix operations in much more detail in the chapter on [linear algebra](linear-algebra.md)).
+In addition to computations by element, we can also perform matrix operations, like matrix multiplication using the `dot` function. Next, we will perform matrix multiplication of `x` and the transpose of `y`. We define `x` as a matrix of 3 rows and 4 columns, and `y` is transposed into a matrix of 4 rows and 3 columns. The two matrices are multiplied to obtain a matrix of 3 rows and 3 columns (if you're confused about what this means, don't worry - we will explain matrix operations in much more detail in the chapter on [linear algebra](linear-algebra.md)).
 
 ```{.python .input  n=13}
 x = nd.arange(12).reshape((3,4))
@@ -126,7 +126,7 @@ nd.concat(x, y, dim=0)
 nd.concat(x, y, dim=1)
 ```
 
-Just like in Numpy, we can construct binary NDarrays by a logical statement. Take `x == y` as an example. If `x` and `y` are equal for some entry, the new NDArray has a value of 1 at the same position; otherwise, it is 0.
+Just like in NumPy, we can construct binary NDArrays by a logical statement. Take `x == y` as an example. If `x` and `y` are equal for some entry, the new NDArray has a value of 1 at the same position; otherwise, it is 0.
 
 ```{.python .input}
 x == y


### PR DESCRIPTION
This mainly fixes wording, notational inconsistencies and some small typos in formulas in some places. More explanations can be found in the commit messages.

The problem is, I was not able to test these changes by building the book.
I fought a bit with the Makefile, but I think there are some files missing from the repository. At least I couldn't build and look at the generated html, which at least for the changes in the LaTeX parts should be done. I think it would be nice if you could add some instructions in the "how to contribute" section.

Another thing that I noticed but couldn't really fix without building and testing:
Line 110 in linear-algebra.md gets rendered as 
"But if we say :math:`n`-dimensional vector, we mean a vector of length :math:`n`." 
in the book. Something is wrong here with LaTeX-math-mode and the markdown-emphasis.

Also the code example after that sentence does not seem to be really related to that section...
