### PR TITLE
[MRG] Resolve pep8 issues

### DIFF
--- a/build/conf.py
+++ b/build/conf.py
@@ -35,12 +35,12 @@ PygmentsBridge.latex_formatter = CustomLatexFormatter
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+# sys.path.insert(0, os.path.abspath('.'))
 
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+# needs_sphinx = '1.0'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -68,7 +68,7 @@ source_parsers = {'.md': CommonMarkParser}
 source_suffix = ['.rst', '.ipynb', '.md']
 
 # The encoding of source files.
-#source_encoding = 'utf-8-sig'
+# source_encoding = 'utf-8-sig'
 
 # The master toctree document.
 master_doc = 'index'
@@ -96,9 +96,9 @@ language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+# today = ''
 # Else, today_fmt is used as the format for a strftime call.
-#today_fmt = '%B %d, %Y'
+# today_fmt = '%B %d, %Y'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -108,27 +108,27 @@ exclude_patterns = ['_build', 'Thumbs.db',
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-#default_role = None
+# default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
+# add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
-#add_module_names = True
+# add_module_names = True
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.
-#show_authors = False
+# show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
 # A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
+# modindex_common_prefix = []
 
 # If true, keep warnings as "system message" paragraphs in the built documents.
-#keep_warnings = False
+# keep_warnings = False
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
@@ -159,17 +159,17 @@ html_theme_options = {
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+# html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+# html_theme_path = []
 
 # The name for this set of Sphinx documents.
 # "<project> v<release> documentation" by default.
-#html_title = 'Dive into Deep Learning v0.1'
+# html_title = 'Dive into Deep Learning v0.1'
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+# html_short_title = None
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
@@ -188,49 +188,49 @@ html_static_path = ['_static']
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-#html_extra_path = []
+# html_extra_path = []
 
 # If not None, a 'Last updated on:' timestamp is inserted at every page
 # bottom, using the given strftime format.
 # The empty string is equivalent to '%b %d, %Y'.
-#html_last_updated_fmt = None
+# html_last_updated_fmt = None
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+# html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
+# html_sidebars = {}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-#html_additional_pages = {}
+# html_additional_pages = {}
 
 # If false, no module index is generated.
-#html_domain_indices = True
+# html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+# html_use_index = True
 
 # If true, the index is split into individual pages for each letter.
-#html_split_index = False
+# html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+# html_show_sourcelink = True
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-#html_show_sphinx = True
+# html_show_sphinx = True
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
-#html_show_copyright = True
+# html_show_copyright = True
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-#html_use_opensearch = ''
+# html_use_opensearch = ''
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = None
+# html_file_suffix = None
 
 # Language to be used for generating the HTML full-text search index.
 # Sphinx supports the following languages:
@@ -244,7 +244,7 @@ html_search_language = 'en'
 
 # The name of a javascript file (relative to the configuration directory) that
 # implements a search results scorer. If empty, the default will be used.
-#html_search_scorer = 'scorer.js'
+# html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'DiveIntoDeepLearning'
@@ -308,16 +308,16 @@ latex_documents = [
 # latex_engine  = 'xelatex'
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+# latex_use_parts = False
 
 # If true, show page references after internal links.
-#latex_show_pagerefs = False
+# latex_show_pagerefs = False
 
 # If true, show URL addresses after external links.
-#latex_show_urls = False
+# latex_show_urls = False
 
 # Documents to append as an appendix to all manuals.
-#latex_appendices = []
+# latex_appendices = []
 
 # If false, no module index is generated.
 latex_domain_indices = False
@@ -329,7 +329,7 @@ latex_domain_indices = False
 # (source start file, name, description, authors, manual section).
 
 # If true, show URL addresses after external links.
-#man_show_urls = False
+# man_show_urls = False
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -339,16 +339,16 @@ latex_domain_indices = False
 #  dir menu entry, description, category)
 
 # Documents to append as an appendix to all manuals.
-#texinfo_appendices = []
+# texinfo_appendices = []
 
 # If false, no module index is generated.
-#texinfo_domain_indices = True
+# texinfo_domain_indices = True
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
-#texinfo_show_urls = 'footnote'
+# texinfo_show_urls = 'footnote'
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
-#texinfo_no_detailmenu = False
+# texinfo_no_detailmenu = False
 
 
 # Example configuration for intersphinx: refer to the Python standard library.

--- a/build/conf.py
+++ b/build/conf.py
@@ -22,10 +22,12 @@ from recommonmark.transform import AutoStructify
 from sphinx.highlighting import PygmentsBridge
 from pygments.formatters.latex import LatexFormatter
 
+
 class CustomLatexFormatter(LatexFormatter):
     def __init__(self, **options):
         super(CustomLatexFormatter, self).__init__(**options)
         self.verboptions = r"formatcom=\footnotesize"
+
 
 PygmentsBridge.latex_formatter = CustomLatexFormatter
 
@@ -101,7 +103,8 @@ language = 'en'
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'mx-theme', '**.ipynb_checkpoints']
+exclude_patterns = ['_build', 'Thumbs.db',
+                    '.DS_Store', 'mx-theme', '**.ipynb_checkpoints']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
@@ -141,12 +144,13 @@ html_theme = 'mxtheme'
 html_theme_options = {
     'primary_color': 'blue',
     'accent_color': 'deep_orange',
-    'header_links' : [
-        ('Berkeley Course 2019', 'https://courses.d2l.ai/berkeley-stat-157/index.html', True, 'fas fa-user-graduate'),
+    'header_links': [
+        ('Berkeley Course 2019', 'https://courses.d2l.ai/berkeley-stat-157/index.html',
+         True, 'fas fa-user-graduate'),
         ('PDF', 'https://en.d2l.ai/d2l-en.pdf', True, 'fas fa-file-pdf'),
         ('Jupyter Notebooks', 'https://en.d2l.ai/d2l-en.zip', True, 'fas fa-download'),
         ('Discuss', 'https://discuss.mxnet.io', True, 'fab fa-discourse'),
-		('GitHub', 'https://github.com/d2l-ai/d2l-en', True, 'fab fa-github'),
+        ('GitHub', 'https://github.com/d2l-ai/d2l-en', True, 'fab fa-github'),
         ('中文版', 'https://zh.d2l.ai', True, 'fas fa-external-link-alt'),
     ],
     'show_footer': False
@@ -250,10 +254,10 @@ htmlhelp_basename = 'DiveIntoDeepLearning'
 
 latex_elements = {
     # 'papersize' : 'a4paper',
-    'utf8extra' : '',
-    'inputenc'  : '',
-    'babel'     : r'''\usepackage[english]{babel}''',
-    'preamble' : r'''
+    'utf8extra': '',
+    'inputenc': '',
+    'babel': r'''\usepackage[english]{babel}''',
+    'preamble': r'''
 
 \usepackage{setspace}
 \singlespacing
@@ -275,18 +279,18 @@ latex_elements = {
      }
 \makeatother
 ''',
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
+    # The paper size ('letterpaper' or 'a4paper').
+    # 'papersize': 'letterpaper',
 
-# The font size ('10pt', '11pt' or '12pt').
-'pointsize': '10pt',
+    # The font size ('10pt', '11pt' or '12pt').
+    'pointsize': '10pt',
 
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
+    # Additional stuff for the LaTeX preamble.
+    # 'preamble': '',
 
-# Latex figure (float) alignment
-#'figure_align': 'htbp',
-'figure_align': 'H',
+    # Latex figure (float) alignment
+    # 'figure_align': 'htbp',
+    'figure_align': 'H',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
@@ -368,6 +372,7 @@ nbsphinx_execute = 'never'
 # let the source file format to be xxx.ipynb instead of xxx.ipynb.txt
 html_sourcelink_suffix = ''
 
+
 def image_caption(app, docname, source):
     for i, src in enumerate(source):
         out = ''
@@ -378,6 +383,7 @@ def image_caption(app, docname, source):
                 l = l.strip().replace(' ', 'Ⓐ')
             out += l + '\n'
         source[i] = out
+
 
 def setup(app):
     app.add_transform(AutoStructify)

--- a/build/post_latex.py
+++ b/build/post_latex.py
@@ -19,7 +19,8 @@ def unnumber_sections(source_file):
                 if l.startswith('\subsection'):
                     target_f.write(l.replace('\\subsection', '\subsection*'))
                 if l.startswith('\subsubsection'):
-                    target_f.write(l.replace('\\subsubsection', '\subsubsection*'))
+                    target_f.write(
+                        l.replace('\\subsubsection', '\subsubsection*'))
             else:
                 target_f.write(l)
     remove(source_file)

--- a/d2l/utils.py
+++ b/d2l/utils.py
@@ -39,6 +39,7 @@ def bbox_to_rect(bbox, color):
 
 class Benchmark():
     """Benchmark programs."""
+
     def __init__(self, prefix=None):
         self.prefix = prefix + ' ' if prefix else ''
 
@@ -84,28 +85,30 @@ def data_iter(batch_size, features, labels):
 def data_iter_consecutive(corpus_indices, batch_size, num_steps, ctx=None):
     """Sample mini-batches in a consecutive order from sequential data."""
     # Offset for the iterator over the data for uniform starts
-    offset = int(random.uniform(0,num_steps))
+    offset = int(random.uniform(0, num_steps))
     # Slice out data - ignore num_steps and just wrap around
     num_indices = ((len(corpus_indices) - offset) // batch_size) * batch_size
     indices = nd.array(corpus_indices[offset:(offset + num_indices)], ctx=ctx)
-    indices = indices.reshape((batch_size,-1))
+    indices = indices.reshape((batch_size, -1))
     # Need to leave one last token since targets are shifted by 1
     num_epochs = ((num_indices // batch_size) - 1) // num_steps
 
     for i in range(0, num_epochs * num_steps, num_steps):
-        X = indices[:,i:(i+num_steps)]
-        Y = indices[:,(i+1):(i+1+num_steps)]
+        X = indices[:, i:(i+num_steps)]
+        Y = indices[:, (i+1):(i+1+num_steps)]
         yield X, Y
+
 
 def data_iter_random(corpus_indices, batch_size, num_steps, ctx=None):
     """Sample mini-batches in a random order from sequential data."""
     # Offset for the iterator over the data
-    offset = int(random.uniform(0,num_steps))
+    offset = int(random.uniform(0, num_steps))
     # Subtract 1 extra since we need to account for the sequence length
     num_examples = ((len(corpus_indices) - offset - 1) // num_steps) - 1
     # Discard half empty batches
     num_batches = num_examples // batch_size
-    example_indices = list(range(offset, offset + num_examples * num_steps, num_steps))
+    example_indices = list(
+        range(offset, offset + num_examples * num_steps, num_steps))
     random.shuffle(example_indices)
 
     # This returns a sequence of the length num_steps starting from pos.
@@ -256,6 +259,7 @@ def load_data_jay_lyrics():
     corpus_indices = [char_to_idx[char] for char in corpus_chars]
     return corpus_indices, char_to_idx, idx_to_char, vocab_size
 
+
 def load_data_timemachine():
     with open('../data/timemachine.txt', 'r') as f:
         lines = f.readlines()
@@ -265,6 +269,7 @@ def load_data_timemachine():
     vocab_size = len(char_to_idx)
     corpus_indices = [char_to_idx[char] for char in raw_dataset]
     return corpus_indices, char_to_idx, idx_to_char, vocab_size
+
 
 def load_data_pikachu(batch_size, edge_size=256):
     """Download the pikachu dataest and then load into memory."""
@@ -393,6 +398,7 @@ def read_voc_images(root='../data/VOCdevkit/VOC2012', is_train=True):
 
 class Residual(nn.Block):
     """The residual block."""
+
     def __init__(self, num_channels, use_1x1conv=False, strides=1, **kwargs):
         super(Residual, self).__init__(**kwargs)
         self.conv1 = nn.Conv2D(num_channels, kernel_size=3, padding=1,
@@ -439,6 +445,7 @@ def resnet18(num_classes):
 
 class RNNModel(nn.Block):
     """RNN model."""
+
     def __init__(self, rnn_layer, vocab_size, **kwargs):
         super(RNNModel, self).__init__(**kwargs)
         self.rnn = rnn_layer
@@ -560,7 +567,7 @@ def train(train_iter, test_iter, net, loss, trainer, ctx, num_epochs):
             train_l_sum += sum([l.sum().asscalar() for l in ls])
             n += sum([l.size for l in ls])
             train_acc_sum += sum([(y_hat.argmax(axis=1) == y).sum().asscalar()
-                                 for y_hat, y in zip(y_hats, ys)])
+                                  for y_hat, y in zip(y_hats, ys)])
             m += sum([y.size for y in ys])
         test_acc = evaluate_accuracy(test_iter, net, ctx)
         print('epoch %d, loss %.4f, train acc %.3f, test acc %.3f, '
@@ -716,7 +723,8 @@ def train_ch7(trainer_fn, states, hyperparams, features, labels, batch_size=10,
               num_epochs=2):
     """Train a linear regression model."""
     net, loss = linreg, squared_loss
-    w, b = nd.random.normal(scale=0.01, shape=(features.shape[1], 1)), nd.zeros(1)
+    w, b = nd.random.normal(scale=0.01, shape=(
+        features.shape[1], 1)), nd.zeros(1)
     w.attach_grad()
     b.attach_grad()
 
@@ -821,6 +829,7 @@ def voc_rand_crop(feature, label, height, width):
 
 class VOCSegDataset(gdata.Dataset):
     """The Pascal VOC2012 Dataset."""
+
     def __init__(self, is_train, crop_size, voc_dir, colormap2label):
         self.rgb_mean = nd.array([0.485, 0.456, 0.406])
         self.rgb_std = nd.array([0.229, 0.224, 0.225])
@@ -847,4 +856,3 @@ class VOCSegDataset(gdata.Dataset):
 
     def __len__(self):
         return len(self.data)
-

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ VERSION = find_version('d2l', '__init__.py')
 requirements = [
     'numpy',
     'matplotlib',
-	'jupyter'
+    'jupyter'
 ]
 
 setup(


### PR DESCRIPTION
Flake8 reports several pep8 issues, this PR aims to fix them: 

PS: Here's is the list of reported pep8 issues: 

```$ flake8 . 
./setup.py:30:1: E101 indentation contains mixed spaces and tabs
./setup.py:30:1: W191 indentation contains tabs
./setup.py:30:2: E131 continuation line unaligned for hanging indent
./setup.py:34:1: E101 indentation contains mixed spaces and tabs
./build/conf.py:16:1: F401 'sys' imported but unused
./build/conf.py:17:1: F401 'os' imported but unused
./build/conf.py:25:1: E302 expected 2 blank lines, found 1
./build/conf.py:30:1: E305 expected 2 blank lines after class or function definition, found 1
./build/conf.py:36:1: E265 block comment should start with '# '
./build/conf.py:41:1: E265 block comment should start with '# '
./build/conf.py:69:1: E265 block comment should start with '# '
./build/conf.py:97:1: E265 block comment should start with '# '
./build/conf.py:99:1: E265 block comment should start with '# '
./build/conf.py:104:80: E501 line too long (91 > 79 characters)
./build/conf.py:108:1: E265 block comment should start with '# '
./build/conf.py:111:1: E265 block comment should start with '# '
./build/conf.py:115:1: E265 block comment should start with '# '
./build/conf.py:119:1: E265 block comment should start with '# '
./build/conf.py:125:1: E265 block comment should start with '# '
./build/conf.py:128:1: E265 block comment should start with '# '
./build/conf.py:144:19: E203 whitespace before ':'
./build/conf.py:145:80: E501 line too long (118 > 79 characters)
./build/conf.py:147:80: E501 line too long (87 > 79 characters)
./build/conf.py:149:1: E101 indentation contains mixed spaces and tabs
./build/conf.py:149:1: W191 indentation contains tabs
./build/conf.py:149:3: E131 continuation line unaligned for hanging indent
./build/conf.py:150:1: E101 indentation contains mixed spaces and tabs
./build/conf.py:158:1: E265 block comment should start with '# '
./build/conf.py:161:1: E265 block comment should start with '# '
./build/conf.py:165:1: E265 block comment should start with '# '
./build/conf.py:168:1: E265 block comment should start with '# '
./build/conf.py:175:80: E501 line too long (80 > 79 characters)
./build/conf.py:187:1: E265 block comment should start with '# '
./build/conf.py:192:1: E265 block comment should start with '# '
./build/conf.py:196:1: E265 block comment should start with '# '
./build/conf.py:199:1: E265 block comment should start with '# '
./build/conf.py:203:1: E265 block comment should start with '# '
./build/conf.py:206:1: E265 block comment should start with '# '
./build/conf.py:209:1: E265 block comment should start with '# '
./build/conf.py:212:1: E265 block comment should start with '# '
./build/conf.py:215:1: E265 block comment should start with '# '
./build/conf.py:218:1: E265 block comment should start with '# '
./build/conf.py:221:1: E265 block comment should start with '# '
./build/conf.py:226:1: E265 block comment should start with '# '
./build/conf.py:229:1: E265 block comment should start with '# '
./build/conf.py:243:1: E265 block comment should start with '# '
./build/conf.py:253:16: E203 whitespace before ':'
./build/conf.py:254:16: E203 whitespace before ':'
./build/conf.py:255:16: E203 whitespace before ':'
./build/conf.py:256:15: E203 whitespace before ':'
./build/conf.py:278:1: E122 continuation line missing indentation or outdented
./build/conf.py:279:1: E265 block comment should start with '# '
./build/conf.py:279:1: E122 continuation line missing indentation or outdented
./build/conf.py:281:1: E122 continuation line missing indentation or outdented
./build/conf.py:282:1: E122 continuation line missing indentation or outdented
./build/conf.py:284:1: E122 continuation line missing indentation or outdented
./build/conf.py:285:1: E265 block comment should start with '# '
./build/conf.py:285:1: E122 continuation line missing indentation or outdented
./build/conf.py:287:1: E122 continuation line missing indentation or outdented
./build/conf.py:288:1: E265 block comment should start with '# '
./build/conf.py:288:1: E122 continuation line missing indentation or outdented
./build/conf.py:289:1: E122 continuation line missing indentation or outdented
./build/conf.py:307:1: E265 block comment should start with '# '
./build/conf.py:310:1: E265 block comment should start with '# '
./build/conf.py:313:1: E265 block comment should start with '# '
./build/conf.py:316:1: E265 block comment should start with '# '
./build/conf.py:328:1: E265 block comment should start with '# '
./build/conf.py:338:1: E265 block comment should start with '# '
./build/conf.py:341:1: E265 block comment should start with '# '
./build/conf.py:344:1: E265 block comment should start with '# '
./build/conf.py:347:1: E265 block comment should start with '# '
./build/conf.py:371:1: E302 expected 2 blank lines, found 1
./build/conf.py:376:80: E501 line too long (83 > 79 characters)
./build/conf.py:378:17: E741 ambiguous variable name 'l'
./build/conf.py:382:1: E302 expected 2 blank lines, found 1
./build/post_latex.py:10:80: E501 line too long (80 > 79 characters)
./build/post_latex.py:12:80: E501 line too long (91 > 79 characters)
./build/post_latex.py:14:80: E501 line too long (87 > 79 characters)
./build/post_latex.py:17:18: W605 invalid escape sequence '\s'
./build/post_latex.py:18:22: W605 invalid escape sequence '\s'
./build/post_latex.py:19:18: W605 invalid escape sequence '\s'
./build/post_latex.py:20:22: W605 invalid escape sequence '\s'
./build/post_latex.py:21:18: W605 invalid escape sequence '\s'
./build/post_latex.py:22:22: W605 invalid escape sequence '\s'
./build/post_latex.py:22:80: E501 line too long (83 > 79 characters)
./d2l/__init__.py:1:1: F403 'from .utils import *' used; unable to detect undefined names
./d2l/__init__.py:1:1: F401 '.utils.*' imported but unused
./d2l/utils.py:87:34: E231 missing whitespace after ','
./d2l/utils.py:91:42: E231 missing whitespace after ','
./d2l/utils.py:96:22: E231 missing whitespace after ','
./d2l/utils.py:97:22: E231 missing whitespace after ','
./d2l/utils.py:100:1: E302 expected 2 blank lines, found 1
./d2l/utils.py:103:34: E231 missing whitespace after ','
./d2l/utils.py:108:80: E501 line too long (87 > 79 characters)
./d2l/utils.py:259:1: E302 expected 2 blank lines, found 1
./d2l/utils.py:269:1: E302 expected 2 blank lines, found 1
./d2l/utils.py:573:80: E501 line too long (84 > 79 characters)
./d2l/utils.py:613:17: E741 ambiguous variable name 'l'
./d2l/utils.py:650:17: E741 ambiguous variable name 'l'
./d2l/utils.py:675:17: E741 ambiguous variable name 'l'
./d2l/utils.py:701:17: E741 ambiguous variable name 'l'
./d2l/utils.py:719:80: E501 line too long (82 > 79 characters)
./d2l/utils.py:733:17: E741 ambiguous variable name 'l'
./d2l/utils.py:765:17: E741 ambiguous variable name 'l'
./d2l/utils.py:783:13: F841 local variable '_' is assigned to but never used
./d2l/utils.py:796:9: F841 local variable '_' is assigned to but never used
./d2l/utils.py:850:1: W391 blank line at end of file
```

Overall, the master branch has 107 pep8 alerts: 

```
$ git branch
* master
$ flake8 . | wc -l 
```

With this PR, the number of alerts is reduced to 27: 

```
$ git branch 
  master
* pep8
$ flake8 . | wc -l 
27
```