### PR TITLE
Minor revisions

### DIFF
--- a/chapter_natural-language-processing/word2vec.md
+++ b/chapter_natural-language-processing/word2vec.md
@@ -1,6 +1,6 @@
 # Word Embedding (word2vec)
 
-A natural language is a complex system that we use to express meanings. In this system, words are the basic unit of linguistic meaning. As its name implies, a word vector is a vector used to represent a word. It can also be thought of as the feature vector of a word. The technique of mapping words to vectors of real numbers is also known as word embedding. Over the last few years, word embedding has gradually become basic knowledge in natural language processing.
+A natural language is a complex system that we use to communicate. Words are commonly used as the unit of analysis in natural language processing. As its name implies, a word vector is a vector used to represent a word. It can also be thought of as the feature vector of a word. The technique of mapping words to vectors of real numbers is also known as word embedding. Over the last few years, word embedding has gradually become basic knowledge in natural language processing.
 
 ## Why not Use One-hot Vectors?
 


### PR DESCRIPTION
>> words are the basic unit of linguistic meaning
No, the basic unit of meaning in most frameworks for linguistic analysis is the morpheme. But no need to burden the reader with linguistic terminology.

I think the discussion on this page could motivate word2vec better. The primary issue with using one-hot encoding for words is data sparsity. Each word is its own idiosyncratic bundle of meaning, collocation and selectional restrictions but intuitively it feels like we could do a better job of representing less common words if we could generalize over sets of similar words.

Other ways to solve this problem of sparsity historically (before word2vec) include stemming and the use of part of speech tags.

The downside of using word2vec is that you're still not really solving the problem of morphology. This is a minor problem for the analysis of English and Chinese but more significant for many other languages.