### PR TITLE
Typos in DL computation chapter.

### DIFF
--- a/chapter_deep-learning-computation/deferred-init.md
+++ b/chapter_deep-learning-computation/deferred-init.md
@@ -52,7 +52,7 @@ The main difference to before is that as soon as we knew the input dimensionalit
 
 ## Deferred Initialization in Practice
 
-Now that we know how it works in theory, let's see when the initialization is actually triggered. In order to do so, we mock up an initializer which does nothing but report a debug message stating when it was invoked and with which paramers.
+Now that we know how it works in theory, let's see when the initialization is actually triggered. In order to do so, we mock up an initializer which does nothing but report a debug message stating when it was invoked and with which parameters.
 
 ```{.python .input  n=22}
 class MyInit(init.Initializer):

--- a/chapter_deep-learning-computation/model-construction.md
+++ b/chapter_deep-learning-computation/model-construction.md
@@ -54,7 +54,7 @@ class MLP(nn.Block):
 
 Let's look at it a bit more closely. The `forward` method invokes a network simply by evaluating the hidden layer `self.hidden(x)` and subsequently by evaluating the output layer `self.output( ... )`. This is what we expect in the forward pass of this block.
 
-In order for the block to know what it needs to evaluate, we first need to define the layers. This is what the `__init__` method does. It first initializes all of the Block-related parameters and then constructs the requisite layers. This attached the coresponding layers and the required parameters to the class. Note that there is no need to define a backpropagation method in the class. The system automatically generates the `backward` method needed for back propagation by automatically finding the gradient. The same applies to the `initialize` method, which is generated automatically. Let's try this out:
+In order for the block to know what it needs to evaluate, we first need to define the layers. This is what the `__init__` method does. It first initializes all of the Block-related parameters and then constructs the requisite layers. This attached the corresponding layers and the required parameters to the class. Note that there is no need to define a backpropagation method in the class. The system automatically generates the `backward` method needed for back propagation by automatically finding the gradient. The same applies to the `initialize` method, which is generated automatically. Let's try this out:
 
 ```{.python .input  n=2}
 net = MLP()

--- a/chapter_deep-learning-computation/parameters.md
+++ b/chapter_deep-learning-computation/parameters.md
@@ -41,7 +41,7 @@ print(net[1].bias)
 print(net[1].bias.data())
 ```
 
-The first returns the bias of the second layer. Sine this is an object containing data, gradients, and additional information, we need to request the data explicitly. Note that the bias is all 0 since we initialized the bias to contain all zeros. Note that we can also access the parameters by name, such as `dense0_weight`. This is possible since each layer comes with its own parameter dictionary that can be accessed directly. Both methods are entirely equivalent but the first method leads to much more readable code.
+The first returns the bias of the second layer. Since this is an object containing data, gradients, and additional information, we need to request the data explicitly. Note that the bias is all 0 since we initialized the bias to contain all zeros. Note that we can also access the parameters by name, such as `dense0_weight`. This is possible since each layer comes with its own parameter dictionary that can be accessed directly. Both methods are entirely equivalent but the first method leads to much more readable code.
 
 ```{.python .input  n=4}
 print(net[0].params['dense0_weight'])
@@ -203,7 +203,7 @@ net[1].weight.data()[0,0] = 100
 print(net[1].weight.data()[0] == net[2].weight.data()[0])
 ```
 
-The above exampe shows that the parameters of the second and third layer are tied. They are identical rather than just being equal. That is, by changing one of the parameters the other one changes, too. What happens to the gradients is quite ingenious. Since the model parameters contain gradients, the gradients of the second hidden layer and the third hidden layer are accumulated in the `shared.params.grad( )` during backpropagation.
+The above example shows that the parameters of the second and third layer are tied. They are identical rather than just being equal. That is, by changing one of the parameters the other one changes, too. What happens to the gradients is quite ingenious. Since the model parameters contain gradients, the gradients of the second hidden layer and the third hidden layer are accumulated in the `shared.params.grad( )` during backpropagation.
 
 ## Summary
 

--- a/chapter_deep-learning-computation/read-write.md
+++ b/chapter_deep-learning-computation/read-write.md
@@ -4,7 +4,7 @@ So far we discussed how to process data, how to build, train and test deep learn
 
 ## NDArray
 
-In its siplest form, we can directly use the `save` and `load` functions to store and read NDArrays separately. This works just as expected.
+In its simplest form, we can directly use the `save` and `load` functions to store and read NDArrays separately. This works just as expected.
 
 ```{.python .input}
 from mxnet import nd


### PR DESCRIPTION
Typos.
paramers -> parameters
coresponding -> corresponding
exampe -> example
siplest -> simplest
sine -> since