### PR TITLE
Fix the condition of vector derivative formulas in math.md

### DIFF
--- a/chapter_appendix/math.md
+++ b/chapter_appendix/math.md
@@ -1,4 +1,4 @@
-# Mathematical Basis
+﻿# Mathematical Basis
 
 This section summarizes the basic knowledge of linear algebra, differentiation, and probability required to understand the contents in this book. To avoid long discussions of mathematical knowledge not required to understand this book, a few definitions in this section are slightly simplified.
 
@@ -255,7 +255,7 @@ $$\nabla_{\boldsymbol{x}} f(\boldsymbol{x}) = \bigg[\frac{\partial f(\boldsymbol
 
 To be concise, we sometimes use $\nabla f(\boldsymbol{x})$ to replace $\nabla_{\boldsymbol{x}} f(\boldsymbol{x})$.
 
-If $\boldsymbol{A}$ is a matrix with $m$ rows and $n$ columns, and $\boldsymbol{x}$ is an $n$-dimensional vector, the following identities hold:
+If $\boldsymbol{A}$ is a square matrix of order $n$, and $\boldsymbol{x}$ is an $n$-dimensional vector, the following identities hold:
 
 $$
 \begin{aligned}


### PR DESCRIPTION
For all the identities hold, **A** must be a square matrix of order n.

> "If **A** is a matrix with m rows and n columns, and **x** is an n-dimensional vector, the following identities hold..."

 -> 

> "If **A** is a square matrix of order n,..."