### PR TITLE
Correct links to deep learning computation chapter.

### DIFF
--- a/chapter_computational-performance/async-computation.md
+++ b/chapter_computational-performance/async-computation.md
@@ -156,7 +156,7 @@ def get_mem():
     return int(str(res).split()[15]) / 1e3
 ```
 
-Now we can begin testing. To initialize the `net` parameters we will try running the system once. See the section [“Deferred Initialization of Model Parameters”](../chapter_deep-learning-computation/deferred-init.md) for further discussions related to initialization.
+Now we can begin testing. To initialize the `net` parameters we will try running the system once. See the section [“Deferred Initialization of Model Parameters”](../chapter_gluon-fundamentals/deferred-init.md) for further discussions related to initialization.
 
 ```{.python .input  n=14}
 for X, y in data_iter():

--- a/chapter_convolutional-neural-networks/lenet.md
+++ b/chapter_convolutional-neural-networks/lenet.md
@@ -84,7 +84,7 @@ ctx = try_gpu()
 ctx
 ```
 
-Accordingly, we slightly modify the `evaluate_accuracy` function described when [implementing the SoftMax from scratch](../chapter_deep-learning-basics/softmax-regression-scratch.md).  Since the data arrives in the CPU when loading we need to copy it to the GPU before any computation can occur. This is accomplished via the `as_in_context` function described in the [GPU Computing](../chapter_deep-learning-computation/use-gpu.md) section. Note that we accumulate the errors on the same device as where the data eventually lives (in `acc`). This avoids intermediate copy operations that would destroy performance.
+Accordingly, we slightly modify the `evaluate_accuracy` function described when [implementing the SoftMax from scratch](../chapter_deep-learning-basics/softmax-regression-scratch.md).  Since the data arrives in the CPU when loading we need to copy it to the GPU before any computation can occur. This is accomplished via the `as_in_context` function described in the [GPU Computing](../chapter_gluon-fundamentals/use-gpu.md) section. Note that we accumulate the errors on the same device as where the data eventually lives (in `acc`). This avoids intermediate copy operations that would destroy performance.
 
 ```{.python .input}
 # This function has been saved in the d2l package for future use. The function

--- a/chapter_preface/preface.md
+++ b/chapter_preface/preface.md
@@ -195,7 +195,7 @@ such as multi-layer perceptrons and regularization.
 about the most basic concepts and techniques of deep learning,
 it is sufficient to read the first section only.-->
 * The next three chapters focus on modern deep learning techniques.
-[Deep Learning Computation](../chapter_deep-learning-computation/index.md)
+[Deep Learning Computation](../chapter_gluon-fundamentals/index.md)
 describes the various key components of deep learning calculations
 and lays the groundwork for the later implementation of more complex models.
 Next we explain [Convolutional Neural Networks](../chapter_convolutional-neural-networks/index.md),


### PR DESCRIPTION
Three links currently point to deep-learning-computation which seems to be an old path name for the Deep Learning Computation chapter. The current one is chapter_gluon-fundamentals. You can verify the links don't work. For example, 

https://d2l.ai/chapter_convolutional-neural-networks/lenet.html#LeNet contains the link
> https://d2l.ai/chapter_deep-learning-computation/use-gpu.md

This change will correct those links.


