### PR TITLE
Fix pReLU formula

### DIFF
--- a/chapter_multilayer-perceptrons/mlp.md
+++ b/chapter_multilayer-perceptrons/mlp.md
@@ -114,7 +114,7 @@ xyplot(x, x.grad, 'grad of relu')
 
 Note that there are many variants to the ReLU function, such as the parameterized ReLU (pReLU) of [He et al., 2015](https://arxiv.org/abs/1502.01852). Effectively it adds a linear term to the ReLU, so some information still gets through, even when the argument is negative.
 
-$$\mathrm{pReLU}(x) = \max(0, x) - \alpha x$$
+$$\mathrm{pReLU}(x) = \max(0, x) + \alpha \min(0, x)$$
 
 The reason for using the ReLU is that its derivatives are particularly well behaved - either they vanish or they just let the argument through. This makes optimization better behaved and it reduces the issue of the vanishing gradient problem (more on this later).
 


### PR DESCRIPTION
Please, correct me if I'm wrong, but the formula for pReLU seems to be a bit different:
$$
pReLU(x) = \max(0, x) + \alpha \min(0, x)
$$
instead of currently
$$
pReLU(x) = \max(0, x) - \alpha x
$$

He et al 2015
<img width="415" alt="Screen Shot 2019-03-15 at 10 32 52" src="https://user-images.githubusercontent.com/2459423/54422304-759f5000-470e-11e9-84c4-9404fe517b46.png">


