### PR TITLE
added loss from gluon in weight-decay.md

### DIFF
--- a/chapter_multilayer-perceptrons/weight-decay.md
+++ b/chapter_multilayer-perceptrons/weight-decay.md
@@ -303,6 +303,7 @@ def fit_and_plot_gluon(wd):
     net = nn.Sequential()
     net.add(nn.Dense(1))
     net.initialize(init.Normal(sigma=1))
+    loss = gloss.L2Loss()
     # The weight parameter has been decayed. Weight names generally end with
     # "weight".
     trainer_w = gluon.Trainer(net.collect_params('.*weight'), 'sgd',


### PR DESCRIPTION
In the scratch implementation, both net and loss were defined from d2l package. While in gluon implementation loss still points to d2l package. This change has reassigned the loss to take from gluon in order to maintain concise implementation.