### PR TITLE
LeNet first conv layer size

### DIFF
--- a/chapter_convolutional-neural-networks/lenet.md
+++ b/chapter_convolutional-neural-networks/lenet.md
@@ -144,7 +144,7 @@ The convolutional layer uses a kernel
 with a height and width of 5,
 which with only $2$ pixels of padding in the first convolutional layer
 and none in the second convolutional layer
-leads to reductions in both height and width by 2 and 4 pixels, respectively.
+leads to reductions in both height and width by 0 and 4 pixels, respectively.
 Moreover each pooling layer halves the height and width.
 However, as we go up the stack of layers,
 the number of channels increases layer-over-layer


### PR DESCRIPTION
`X = nd.random.uniform(shape=(1, 1, 28, 28))`
`net.initialize()`
`for layer in net:`
`  X = layer(X)`
`  print(layer.name, 'output shape:\t', X.shape)`

Based on the above code, the height and width of first convolution layer is same as the input which is 28 X 28 with kernel_size = 5 and padding = 2 as initialized in network. However, the explanation says that both height and width reduced by 2 and 4 pixels in first and second convolution layers respectively. I feel that the explanation needs to be revisited and make changes according to the code.