### PR TITLE
Fix broken hyperlink

### DIFF
--- a/chapter_appendix/how-to-contribute.md
+++ b/chapter_appendix/how-to-contribute.md
@@ -27,7 +27,7 @@ Now, the code repository of this book will be copied to your username, such as `
 
 ### Clone the Repository
 
-To clone the repository (i.e. to make a local copy) we need to get its repository address. The green button on the picture below displays this. Make sure that your local copy is up to date with the main repository if you decide to keep this fork around for longer. For now simply follow the instructions in the [Installation](../chapter_prerequisite/install.md) section to get started. The main difference is that you're now downloading *your own fork* of the repository.
+To clone the repository (i.e. to make a local copy) we need to get its repository address. The green button on the picture below displays this. Make sure that your local copy is up to date with the main repository if you decide to keep this fork around for longer. For now simply follow the instructions in :numref:`chapter_installation` to get started. The main difference is that you're now downloading *your own fork* of the repository.
 
 ![Git clone.](../img/git-clone.png)
 :width:`700px`
@@ -41,7 +41,7 @@ On Unix the above command copies all the code from GitHub to the directory `d2l-
 
 ### Edit the Book and Push
 
-Now it's time to edit the book. It's best to edit the notebooks in Jupyter following the [instructions](../chapter_appendix/jupyter.md) in the appendix. Make the changes and check that they're OK. Assume we have modified a typo in the file `~/d2l-en/chapter_appendix/how-to-contribute.md`.
+Now it's time to edit the book. It's best to edit the notebooks in Jupyter following instructions in :numref:`chapter_jupyter`. Make the changes and check that they're OK. Assume we have modified a typo in the file `~/d2l-en/chapter_appendix/how-to-contribute.md`.
 You can then check which files you have changed:
 
 ```

--- a/chapter_appendix/jupyter.md
+++ b/chapter_appendix/jupyter.md
@@ -1,4 +1,5 @@
 # Using Jupyter
+:label:`chapter_jupyter`
 
 This section describes how to edit and run the code in the chapters of this book
 using Jupyter Notebooks. Make sure you have Jupyter installed and downloaded the

--- a/chapter_attention-mechanism/seq2seq-attention.md
+++ b/chapter_attention-mechanism/seq2seq-attention.md
@@ -68,7 +68,7 @@ class Seq2SeqAttentionDecoder(d2l.Decoder):
                                         enc_valid_len]
 ```
 
-Use the same hyper-parameters to create an encoder and decoder as the ["Sequence to Sequence"](../chapter_recurrent-neural-networks/seq2seq.md) section, we get the same decoder output shape, but the state structure is changed.
+Use the same hyper-parameters to create an encoder and decoder as in :numref:`chapter_seq2seq`, we get the same decoder output shape, but the state structure is changed.
 
 ```{.python .input  n=3}
 encoder = d2l.Seq2SeqEncoder(vocab_size=10, embed_size=8,

--- a/chapter_computational-performance/async-computation.md
+++ b/chapter_computational-performance/async-computation.md
@@ -149,7 +149,7 @@ def get_mem():
     return int(str(res).split()[15]) / 1e3
 ```
 
-Now we can begin testing. To initialize the `net` parameters we will try running the system once. See the section [“Deferred Initialization of Model Parameters”](../chapter_deep-learning-computation/deferred-init.md) for further discussions related to initialization.
+Now we can begin testing. To initialize the `net` parameters we will try running the system once. See :numref:`chapter_deferred_init` for further discussions related to initialization.
 
 ```{.python .input  n=14}
 for X, y in data_iter():

--- a/chapter_multilayer-perceptrons/mlp-scratch.md
+++ b/chapter_multilayer-perceptrons/mlp-scratch.md
@@ -91,7 +91,7 @@ loss = gluon.loss.SoftmaxCrossEntropyLoss()
 ## Training
 
 Steps for training the MLP are no different than for softmax regression.
-In the `d2l` package, we directly call the `train_ch3` function, whose implementation was introduced [here](softmax-regression-scratch.md).
+In the `d2l` package, we directly call the `train_ch3` function, whose implementation was introduced in :numref:`chapter_softmax_scratch`.
 We set the number of epochs to $10$ and the learning rate to $0.5$.
 
 ```{.python .input  n=7}

--- a/chapter_multilayer-perceptrons/weight-decay.md
+++ b/chapter_multilayer-perceptrons/weight-decay.md
@@ -1,4 +1,5 @@
 # Weight Decay
+:label:`chapter_weight_decay`
 
 Now that we have characterized the problem of overfitting
 and motivated the need for capacity control,

--- a/chapter_optimization/convexity.md
+++ b/chapter_optimization/convexity.md
@@ -188,13 +188,13 @@ Here the variables $\alpha_i$ are the so-called *Lagrange Multipliers* that ensu
 
 One way of satisfying constrained optimization problems at least approximately is to adapt the Lagrange function $L$. Rather than satisfying $c_i(\mathbf{x}) \leq 0$ we simply add $\alpha_i c_i(\mathbf{x})$ to the objective function $f(x)$. This ensures that the constraints won't be violated too badly. 
 
-In fact, we've been using this trick all along. Consider [weight-decay regularization](../chapter_multilayer-perceptrons/weight-decay.md). In it we add $\frac{\lambda}{2} \|\mathbf{w}\|^2$ to the objective function to ensure that $\mathbf{w}$ doesn't grow too large. Using the constrained optimization point of view we can see that this will ensure that $\|\mathbf{w}\|^2 - r^2 \leq 0$ for some radius $r$. Adjusting the value of $\lambda$ allows us to vary the size of $\mathbf{w}$.
+In fact, we've been using this trick all along. Consider weight decay in :numref:`chapter_weight_decay`. In it we add $\frac{\lambda}{2} \|\mathbf{w}\|^2$ to the objective function to ensure that $\mathbf{w}$ doesn't grow too large. Using the constrained optimization point of view we can see that this will ensure that $\|\mathbf{w}\|^2 - r^2 \leq 0$ for some radius $r$. Adjusting the value of $\lambda$ allows us to vary the size of $\mathbf{w}$.
 
 In general, adding penalties is a good way of ensuring approximate constraint satisfaction. In practice this turns out to be much more robust than exact satisfaction. Furthermore, for nonconvex problems many of the properties that make the exact approach so appealing in the convex case (e.g. optimality) no longer hold. 
 
 ### Projections
 
-An alternative strategy for satisfying constraints are projections. Again, we encountered them before, e.g. when dealing with [gradient clipping](../chapter_recurrent-neural-networks/rnn-scratch.md). There we ensured that a gradient has length bounded by $c$ via 
+An alternative strategy for satisfying constraints are projections. Again, we encountered them before, e.g. when dealing with gradient clipping in :numref:`chapter_rnn_scratch`. There we ensured that a gradient has length bounded by $c$ via
 
 $$\mathbf{g} \leftarrow \mathbf{g} \cdot \mathrm{min}(1, c/\|\mathbf{g}\|).$$
 


### PR DESCRIPTION
In many places, hyperlink is pointing to md file with relative path. This caused broken link when viewing the book on html. 