### PR TITLE
Update why-conv.md

### DIFF
--- a/chapter_convolutional-neural-networks/why-conv.md
+++ b/chapter_convolutional-neural-networks/why-conv.md
@@ -93,7 +93,7 @@ as four-dimensional weight tensors.
 
 We could formally express this dense layer as follows:
 
-$$h[i,j] = \sum_{k,l} W[i,j,k,l] \cdot x[k,l] =
+$$h[i,j] = u[i,j] + \sum_{k,l} W[i,j,k,l] \cdot x[k,l] =  u[i,j] +
 \sum_{a, b} V[i,j,a,b] \cdot x[i+a,j+b]$$
 
 The switch from $W$ to $V$ is entirely cosmetic (for now)
@@ -111,11 +111,11 @@ centered around $(i,j)$ and weighted by $V[i,j,a,b]$.
 Now let's invoke the first principle we established above—*translation invariance*.
 This implies that a shift in the inputs $x$
 should simply lead to a shift in the activations $h$.
-This is only possible if $V$ doesn't actually depend on $(i,j)$,
-i.e., we have $V[i,j,a,b] = V[a,b]$.
+This is only possible if $V$ and $u$ don't actually depend on $(i,j)$,
+i.e., we have $V[i,j,a,b] = V[a,b]$ and $u$ is a constant.
 As a result we can simplify the definition for $h$.
 
-$$h[i,j] = \sum_{a, b} V[a,b] \cdot x[i+a,j+b]$$
+$$h[i,j] = u + \sum_{a, b} V[a,b] \cdot x[i+a,j+b]$$
 
 This is a convolution!
 We are effectively weighting pixels $(i+a, j+b)$
@@ -132,7 +132,7 @@ This means that outside some range $|a|, |b| > \Delta$,
 we should set $V[a,b] = 0$.
 Equivalently, we can rewrite $h[i,j]$ as
 
-$$h[i,j] = \sum_{a = -\Delta}^{\Delta} \sum_{b = -\Delta}^{\Delta} V[a,b] \cdot x[i+a,j+b]$$
+$$h[i,j] = u + \sum_{a = -\Delta}^{\Delta} \sum_{b = -\Delta}^{\Delta} V[a,b] \cdot x[i+a,j+b]$$
 
 This, in a nutshell is the convolutional layer.
 When the local region (also called a *receptive field*) is small,


### PR DESCRIPTION
The equations in 6.1.2 do not express a bias term explicitly and class Conv2D implemented in 6.2.2 has a bias term. I think that it would be better if you express a bias term in 6.1.2 clearly. For example, we can add u[i,j] to the summation in each equation. By translation invariance, it's clear that u[i,j] does not depend on i or j. Thus u[i,j] is a constant.

It would be better to use b[i,j] instead of u[i,j], but the symbol b is already used as index of summation.