### PR TITLE
Update linear-regression-gluon.md

### DIFF
--- a/chapter_linear-networks/linear-regression-gluon.md
+++ b/chapter_linear-networks/linear-regression-gluon.md
@@ -33,11 +33,7 @@ features, labels = d2l.synthetic_data(true_w, true_b, 1000)
 
 Rather than rolling our own iterator,
 we can call upon Gluon's `data` module to read data.
-Since `data` is often used as a variable name,
-we will replace it with the pseudonym `gdata`
-(adding the first letter of Gluon),
-to differentiate the imported `data` module
-from a variable we might define.
+
 The first step will be to instantiate an `ArrayDataset`,
 which takes in one or more NDArrays as arguments.
 Here, we pass in `features` and `labels` as arguments.


### PR DESCRIPTION
gdata is not used in the section. It was used in an old version of the book.