### PR TITLE
Update softmax-regression-scratch.md

### DIFF
--- a/chapter_linear-networks/softmax-regression-scratch.md
+++ b/chapter_linear-networks/softmax-regression-scratch.md
@@ -282,6 +282,7 @@ class Animator(object):
         d2l.use_svg_display()
         self.fig, self.axes = d2l.plt.subplots(nrows, ncols, figsize=figsize)
         if nrows * ncols == 1: self.axes = [self.axes,]
+        if nrows > 1 and ncols > 1: self.axes = self.axes.flatten()
         # use a lambda to capture arguments
         self.config_axes = lambda : d2l.set_axes(
             self.axes[0], xlabel, ylabel, xlim, ylim, xscale, yscale, legend)


### PR DESCRIPTION
I am not sure why nrows and ncols are needed as input parameters of class Animator, but I would like to point out something about it. Animator works well when nrows is 1 or ncols is 1, but it does not work when both nrows and ncols are greater than 1, since self.axes[0].cla() will raise an error.
To prevent it, we may add the following line right after the line if nrows * ncols == 1: self.axes = [self.axes,]:

if nrows > 1 and ncols > 1: self.axes = self.axes.flatten()