### PR TITLE
Add one `asnumpy()` as we do not support mixed dispatch for `broadcast_arrays` yet

### DIFF
--- a/chapter_preliminaries/probability.md
+++ b/chapter_preliminaries/probability.md
@@ -225,7 +225,7 @@ axes = axes.flatten()
 for i in range(1, 100001):
     counts[random.randint(0, 99)] += 1
     if i in [100, 1000, 10000, 100000]:
-        axes[int(np.log10(i))-2].bar(np.arange(1, 101).asnumpy(), counts)
+        axes[int(np.log10(i))-2].bar(np.arange(1, 101).asnumpy(), counts.asnumpy())
 ```
 
 We can see from these figures that the initial number of counts looks *strikingly* uneven. If we sample fewer than 100 draws from a distribution over


### PR DESCRIPTION
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-13-79a10713c29a> in <module>
      7     counts[random.randint(0, 99)] += 1
      8     if i in [100, 1000, 10000, 100000]:
----> 9         axes[int(np.log10(i))-2].bar(np.arange(1, 101).asnumpy(), counts)

~/.local/lib/python3.6/site-packages/matplotlib/__init__.py in inner(ax, data, *args, **kwargs)
   1599     def inner(ax, *args, data=None, **kwargs):
   1600         if data is None:
-> 1601             return func(ax, *map(sanitize_sequence, args), **kwargs)
   1602 
   1603         bound = new_sig.bind(ax, *args, **kwargs)

~/.local/lib/python3.6/site-packages/matplotlib/axes/_axes.py in bar(self, x, height, width, bottom, align, **kwargs)
   2373         x, height, width, y, linewidth = np.broadcast_arrays(
   2374             # Make args iterable too.
-> 2375             np.atleast_1d(x), height, width, y, linewidth)
   2376 
   2377         # Now that units have been converted, set the tick locations.

<__array_function__ internals> in broadcast_arrays(*args, **kwargs)

TypeError: no implementation found for 'numpy.broadcast_arrays' on types that implement __array_function__: [<class 'numpy.ndarray'>, <class 'mxnet.numpy.ndarray'>]
```
`broadcast_arrays` has 2 inputs, we do have a dispatch for the situation where both inputs are mxnet.numpy.ndarray, but in matplotlib they have a case where the input types are mixed. Adding an extra `asnumpy` call to make it work.
@astonzhang 