### PR TITLE
sec_linear-algebra -> sec_linear_algebra

### DIFF
--- a/chapter_appendix_math/geometry-linear-algebric-ops.md
+++ b/chapter_appendix_math/geometry-linear-algebric-ops.md
@@ -1,12 +1,12 @@
 # Geometry and Linear Algebraic Operations
 :label:`sec_geometry-linear-algebric-ops`
 
-In :numref:`sec_linear-algebra`, we encountered the basics of linear algebra
+In :numref:`sec_linear_algebra`, we encountered the basics of linear algebra
 and saw how it could be used to express common operations for transforming our data.
 Linear algebra is one of the key mathematical pillars
 underlying much of the work that we do deep learning 
 and in machine learning more broadly.
-While :numref:`sec_linear-algebra` contained enough machinery
+While :numref:`sec_linear_algebra` contained enough machinery
 to communicate the mechanics of modern deep learning models, 
 there is a lot more to the subject.
 In this section, we will go deeper,
@@ -83,7 +83,7 @@ that takes us from the point $\mathbf{u}$ to the point $\mathbf{v}$.
 
 
 ## Dot Products and Angles
-As we saw in :numref:`sec_linear-algebra`, 
+As we saw in :numref:`sec_linear_algebra`, 
 if we take two column vectors say $\mathbf{u}$ and $\mathbf{v}$,
 we can form their dot product by computing:
 
@@ -318,7 +318,7 @@ np.mean(predictions.astype(y_test.dtype) == y_test, dtype=np.float64)
 
 ## Geometry of Linear Transformations
 
-Through :numref:`sec_linear-algebra` and the above discussions, 
+Through :numref:`sec_linear_algebra` and the above discussions, 
 we have a solid understanding of the geometry of vectors, lengths, and angles. 
 However, there is one important object we have omitted discussing, 
 and that is a geometric understanding of linear transformations represented by matrices.  Fully internalizing what matrices can do to transform data 
@@ -698,7 +698,7 @@ that $n\times n$ matrices scale $n$-dimensional volumes.
 
 ## Tensors and Common Linear Algebra Operations
 
-In :numref:`sec_linear-algebra` the concept of tensors was introduced.
+In :numref:`sec_linear_algebra` the concept of tensors was introduced.
 In this section, we will dive more deeply into tensor contractions 
 (the tensor equivalent of matrix multiplication),
 and see how it can provide a unified view 
@@ -756,7 +756,7 @@ In this way, we can replace a myriad of specialized notations with short tensor 
 
 ### Expressing in Code
 Tensors may flexibly be operated on in code as well.
-As seen in :numref:`sec_linear-algebra`, 
+As seen in :numref:`sec_linear_algebra`, 
 we can create tensors as is shown below.
 
 ```{.python .input}

--- a/chapter_appendix_math/information-theory.md
+++ b/chapter_appendix_math/information-theory.md
@@ -270,7 +270,7 @@ In this case, mutual information can help us resolve this ambiguity. We first fi
 
 ## Kullback–Leibler Divergence
 
-As what we have discussed in :numref:`sec_linear-algebra`, we can use norms to measure distance between two points in space of any dimensionality.  We would like to be able to do a similar task with probability distributions.  There are many ways to go about this, but information theory provides one of the nicest.  We now explore the *Kullback–Leibler (KL) divergence*, which provides a way to measure if two distributions are close together or not. 
+As what we have discussed in :numref:`sec_linear_algebra`, we can use norms to measure distance between two points in space of any dimensionality.  We would like to be able to do a similar task with probability distributions.  There are many ways to go about this, but information theory provides one of the nicest.  We now explore the *Kullback–Leibler (KL) divergence*, which provides a way to measure if two distributions are close together or not. 
 
 
 ### Definition

--- a/chapter_preliminaries/linear-algebra.md
+++ b/chapter_preliminaries/linear-algebra.md
@@ -1,5 +1,5 @@
 # Linear Algebra
-:label:`sec_linear-algebra`
+:label:`sec_linear_algebra`
 
 Now that you can store and manipulate data,
 let's briefly review the subset of basic linear algebra

--- a/chapter_preliminaries/ndarray.md
+++ b/chapter_preliminaries/ndarray.md
@@ -221,7 +221,7 @@ In addition to elementwise computations,
 we can also perform linear algebra operations, 
 including vector dot products and matrix multiplication.
 We will explain the crucial bits of linear algebra 
-(with no assumed prior knowledge) in :numref:`sec_linear-algebra`.
+(with no assumed prior knowledge) in :numref:`sec_linear_algebra`.
 
 We can also *concatenate* multiple `ndarray`s together,
 stacking them end-to-end to form a larger `ndarray`. 

--- a/chapter_preliminaries/reduction-norm.md
+++ b/chapter_preliminaries/reduction-norm.md
@@ -1,7 +1,7 @@
 # Reduction, Multiplication, and Norms
-:label:`sec_linear-algebra`
+:label:`sec_linear_algebra`
 
-We have introduced scalars, vectors, matrices, and tensors in :numref:`sec_linear-algebra`.
+We have introduced scalars, vectors, matrices, and tensors in :numref:`sec_linear_algebra`.
 Without operations on such basic mathematical objects in linear algebra,
 we cannot design any meaningful procedure for deep learning.
 Specifically, as we will see in subsequent chapters,
@@ -416,7 +416,7 @@ are expressed as norms.
 
 ## More on Linear Algebra
 
-In just :numref:`sec_linear-algebra` and this section,
+In just :numref:`sec_linear_algebra` and this section,
 we have taught you all the linear algebra
 that you will need to understand
 a remarkable chunk of modern deep learning.


### PR DESCRIPTION
Is this the reason that the link is not rendered?
https://d2l.ai/chapter_appendix_math/geometry-linear-algebric-ops.html