### PR TITLE
Calculus typo fixes

### DIFF
--- a/chapter_multilayer-perceptrons/environment.md
+++ b/chapter_multilayer-perceptrons/environment.md
@@ -279,7 +279,7 @@ we can correct for that by using the following simple identity:
 
 $$
 \begin{aligned}
-\int p(\mathbf{x}) f(\mathbf{x}) dx & = \int p(\mathbf{x}) f(\mathbf{x}) \frac{q(\mathbf{x})}{p(\mathbf{x})} dx \\
+\int p(\mathbf{x}) f(\mathbf{x}) dx 
 & = \int q(\mathbf{x}) f(\mathbf{x}) \frac{p(\mathbf{x})}{q(\mathbf{x})} dx.
 \end{aligned}
 $$
@@ -501,3 +501,7 @@ Should what news someone is exposed to be determined by which Facebook pages the
 ## [Discussions](https://discuss.mxnet.io/t/2347)
 
 ![](../img/qr_environment.svg)
+
+```{.python .input}
+
+```

--- a/chapter_multilayer-perceptrons/environment.md
+++ b/chapter_multilayer-perceptrons/environment.md
@@ -501,7 +501,3 @@ Should what news someone is exposed to be determined by which Facebook pages the
 ## [Discussions](https://discuss.mxnet.io/t/2347)
 
 ![](../img/qr_environment.svg)
-
-```{.python .input}
-
-```

--- a/chapter_preliminaries/calculus.md
+++ b/chapter_preliminaries/calculus.md
@@ -259,9 +259,9 @@ where $\nabla_{\mathbf{x}} f(\mathbf{x})$ is often replaced by $\nabla f(\mathbf
 
 Let $\mathbf{x}$ be an $n$-dimensional vector, the following rules are often used when differentiating multivariate functions:
 
-* If $\mathbf{A} \in \mathbb{R}^{m \times n}$, then $\nabla_{\mathbf{x}} \mathbf{A} \mathbf{x} = \mathbf{A}^\top$,
-* If $\mathbf{A} \in \mathbb{R}^{n \times m}$, then $\nabla_{\mathbf{x}} \mathbf{x}^\top \mathbf{A}  = \mathbf{A}$,
-* If $\mathbf{A} \in \mathbb{R}^{n \times n}$, then $\nabla_{\mathbf{x}} \mathbf{x}^\top \mathbf{A} \mathbf{x}  = (\mathbf{A} + \mathbf{A}^\top)\mathbf{x}$,
+* For all $\mathbf{A} \in \mathbb{R}^{m \times n}$, $\nabla_{\mathbf{x}} \mathbf{A} \mathbf{x} = \mathbf{A}^\top$,
+* For all  $\mathbf{A} \in \mathbb{R}^{n \times m}$, $\nabla_{\mathbf{x}} \mathbf{x}^\top \mathbf{A}  = \mathbf{A}$,
+* For all  $\mathbf{A} \in \mathbb{R}^{n \times n}$, $\nabla_{\mathbf{x}} \mathbf{x}^\top \mathbf{A} \mathbf{x}  = (\mathbf{A} + \mathbf{A}^\top)\mathbf{x}$,
 * $\nabla_{\mathbf{x}} \|\mathbf{x} \|^2 = \nabla_{\mathbf{x}} \mathbf{x}^\top \mathbf{x} = 2\mathbf{x}$.
 
 Similarly, for any matrix $\mathbf{X}$, we have $\nabla_{\mathbf{X}} \|\mathbf{X} \|_F^2 = 2\mathbf{X}$. As we will see later, gradients are useful for designing optimization algorithms in deep learning. 

--- a/chapter_preliminaries/calculus.md
+++ b/chapter_preliminaries/calculus.md
@@ -314,7 +314,3 @@ for any $i = 1, 2, \ldots, n$.
 ## [Discussions](https://discuss.mxnet.io/t/5008)
 
 ![](../img/qr_calculus.svg)
-
-```{.python .input}
-
-```

--- a/chapter_preliminaries/calculus.md
+++ b/chapter_preliminaries/calculus.md
@@ -257,11 +257,11 @@ $$\nabla_{\mathbf{x}} f(\mathbf{x}) = \bigg[\frac{\partial f(\mathbf{x})}{\parti
 
 where $\nabla_{\mathbf{x}} f(\mathbf{x})$ is often replaced by $\nabla f(\mathbf{x})$ when there is no ambiguity.
 
-Let $\mathbf{A}$ be a matrix with $m$ rows and $n$ columns, and $\mathbf{x}$ be an $n$-dimensional vector, the following rules are often used when differentiating multivariate functions:
+Let $\mathbf{x}$ be an $n$-dimensional vector, the following rules are often used when differentiating multivariate functions:
 
-* $\nabla_{\mathbf{x}} \mathbf{A} \mathbf{x} = \mathbf{A}^\top$,
-* $\nabla_{\mathbf{x}} \mathbf{x}^\top \mathbf{A}  = \mathbf{A}$,
-* $\nabla_{\mathbf{x}} \mathbf{x}^\top \mathbf{A} \mathbf{x}  = (\mathbf{A} + \mathbf{A}^\top)\mathbf{x}$,
+* If $\mathbf{A} \in \mathbb{R}^{m \times n}$, then $\nabla_{\mathbf{x}} \mathbf{A} \mathbf{x} = \mathbf{A}^\top$,
+* If $\mathbf{A} \in \mathbb{R}^{n \times m}$, then $\nabla_{\mathbf{x}} \mathbf{x}^\top \mathbf{A}  = \mathbf{A}$,
+* If $\mathbf{A} \in \mathbb{R}^{n \times n}$, then $\nabla_{\mathbf{x}} \mathbf{x}^\top \mathbf{A} \mathbf{x}  = (\mathbf{A} + \mathbf{A}^\top)\mathbf{x}$,
 * $\nabla_{\mathbf{x}} \|\mathbf{x} \|^2 = \nabla_{\mathbf{x}} \mathbf{x}^\top \mathbf{x} = 2\mathbf{x}$.
 
 Similarly, for any matrix $\mathbf{X}$, we have $\nabla_{\mathbf{X}} \|\mathbf{X} \|_F^2 = 2\mathbf{X}$. As we will see later, gradients are useful for designing optimization algorithms in deep learning. 
@@ -314,3 +314,7 @@ for any $i = 1, 2, \ldots, n$.
 ## [Discussions](https://discuss.mxnet.io/t/5008)
 
 ![](../img/qr_calculus.svg)
+
+```{.python .input}
+
+```


### PR DESCRIPTION
Change origin to:

![image](https://user-images.githubusercontent.com/37914843/69661635-98248f80-1037-11ea-89f4-66e64047af2b.png)
