### PR TITLE
Small fix, missing 'we'

### DIFF
--- a/chapter_introduction/index.md
+++ b/chapter_introduction/index.md
@@ -1,7 +1,7 @@
 # Introduction
 :label:`chap_introduction`
 
-Until recently, nearly every computer program that interact with daily
+Until recently, nearly every computer program that we interact with daily
 were coded by software developers from first principles.
 Say that we wanted to write an application to manage an e-commerce platform.  After huddling around a whiteboard for a few hours to ponder the problem,
 we would come up with the broad strokes of a working solution that might probably look something like this:


### PR DESCRIPTION
*Description of changes:* I believe the word "we" is missing in the first sentence.


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
