### PR TITLE
chore: add .gitattributes and set eof=lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
_This was originally #566, but reposted here by an author's request._

Motivated by https://github.com/d2l-ai/data/pull/2. This will prevent CRLF to be committed.