### PR TITLE
fix featrue typo in chapter_modern-convolutional-neural-networks/alex…

### DIFF
--- a/chapter_convolutional-neural-networks/conv-layer.md
+++ b/chapter_convolutional-neural-networks/conv-layer.md
@@ -186,7 +186,7 @@ Next, in each iteration, we will use the squared error
 to compare `Y` and the output of the convolutional layer,
 then calculate the gradient to update the weight.
 For the sake of simplicity, in this convolutional layer,
-we will ignores the bias.
+we will ignore the bias.
 
 We previously constructed the `Conv2D` class.
 However, since we used single-element assignments,

--- a/chapter_convolutional-neural-networks/why-conv.md
+++ b/chapter_convolutional-neural-networks/why-conv.md
@@ -37,7 +37,7 @@ that it typically takes to learn good hidden representations of images.
 Learning a binary classifier with so many parameters
 might seem to require that we collect an enormous dataset,
 perhaps comparable to the number of dogs and cats on the planet.
-And yet Yet both humans and computers are able to distinguish cats from dogs quite well, seemingly contradicting these conclusions.
+And yet both humans and computers are able to distinguish cats from dogs quite well, seemingly contradicting these conclusions.
 That is because images exhibit rich structure
 that is typically exploited by humans and machine learning models alike.
 

--- a/chapter_modern-convolutional-neural-networks/alexnet.md
+++ b/chapter_modern-convolutional-neural-networks/alexnet.md
@@ -82,7 +82,7 @@ Indeed, :cite:`Krizhevsky.Sutskever.Hinton.2012` proposed a new variant of a con
 which achieved excellent performance in the ImageNet challenge.
 
 Interestingly in the lowest layers of the network,
-the model learned featrue extractors that resembled some traditional filters.
+the model learned feature extractors that resembled some traditional filters.
 :numref:`fig_filters` is reproduced from this paper
 and describes lower-level image descriptors.
 


### PR DESCRIPTION
…net.md

*Description of changes:*
 I am reading the <Dive into deep learning> book, and find a typo in the "Deep Convolutional Neural Networks (AlexNet)".
    The original text is : 
      Interestingly in the lowest layers of the network, the model learned featrue extractors that resembled some traditional filters.

     I think it should be "feature extractors".


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
