### PR TITLE
fix typo in chapter_convolutional-neural-networks/padding-and-strides.md

### DIFF
--- a/chapter_convolutional-neural-networks/conv-layer.md
+++ b/chapter_convolutional-neural-networks/conv-layer.md
@@ -186,7 +186,7 @@ Next, in each iteration, we will use the squared error
 to compare `Y` and the output of the convolutional layer,
 then calculate the gradient to update the weight.
 For the sake of simplicity, in this convolutional layer,
-we will ignores the bias.
+we will ignore the bias.
 
 We previously constructed the `Conv2D` class.
 However, since we used single-element assignments,

--- a/chapter_convolutional-neural-networks/padding-and-strides.md
+++ b/chapter_convolutional-neural-networks/padding-and-strides.md
@@ -21,7 +21,8 @@ that means that after applying many successive convolutions,
 we will wind up with an output that is much smaller than our input.
 If we start with a $240 \times 240$ pixel image, $10$ layers of $5 \times 5$ convolutions
 reduce the image to $200 \times 200$ pixels, slicing off $30 \%$ of the image and with it obliterating any interesting information on the boundaries of the original image. *Padding* handles this issue.
-* In some cases, we want to reduce the resolution drastically if say we find our original input resolution to be unweildy. *Strides* can help in these instances.
+* In some cases, we want to reduce the resolution drastically if say we find our
+* original input resolution to be unwieldy. *Strides* can help in these instances.
 
 ## Padding
 
@@ -79,7 +80,7 @@ For any two-dimensional array `X`,
 when the kernels size is odd
 and the number of padding rows and columns
 on all sides are the same,
-producing an output with the have the same height and width as the input,
+producing an output with the same height and width as the input,
 we know that the output `Y[i, j]` is calculated
 by cross-correlation of the input and convolution kernel
 with the window centered on `X[i, j]`.

--- a/chapter_convolutional-neural-networks/why-conv.md
+++ b/chapter_convolutional-neural-networks/why-conv.md
@@ -37,7 +37,7 @@ that it typically takes to learn good hidden representations of images.
 Learning a binary classifier with so many parameters
 might seem to require that we collect an enormous dataset,
 perhaps comparable to the number of dogs and cats on the planet.
-And yet Yet both humans and computers are able to distinguish cats from dogs quite well, seemingly contradicting these conclusions.
+And yet both humans and computers are able to distinguish cats from dogs quite well, seemingly contradicting these conclusions.
 That is because images exhibit rich structure
 that is typically exploited by humans and machine learning models alike.
 

--- a/chapter_modern-convolutional-neural-networks/alexnet.md
+++ b/chapter_modern-convolutional-neural-networks/alexnet.md
@@ -82,7 +82,7 @@ Indeed, :cite:`Krizhevsky.Sutskever.Hinton.2012` proposed a new variant of a con
 which achieved excellent performance in the ImageNet challenge.
 
 Interestingly in the lowest layers of the network,
-the model learned featrue extractors that resembled some traditional filters.
+the model learned feature extractors that resembled some traditional filters.
 :numref:`fig_filters` is reproduced from this paper
 and describes lower-level image descriptors.
 


### PR DESCRIPTION
*Description of changes:*

1. "unweildy" ---> "unwieldy"
2. "with the have the same" ---> "with the same". 


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
