### PR TITLE
fix typo/wrong word

### DIFF
--- a/chapter_introduction/index.md
+++ b/chapter_introduction/index.md
@@ -1500,7 +1500,7 @@ will become sentient and decide independently from their programmers
 (and masters) about things that directly affect the livelihood of humans.
 To some extent, AI already affects the livelihood of humans
 in an immediate way---creditworthiness is assessed automatically,
-autopilots mostly navigate cars, decisions about
+autopilots mostly navigate planes, decisions about
 whether to grant bail use statistical data as input.
 More frivolously, we can ask Alexa to switch on the coffee machine.
 


### PR DESCRIPTION
In the following sentence:

To some extent, AI already affects the livelihood of humans
in an immediate way---creditworthiness is assessed automatically,
autopilots mostly navigate cars, decisions about
whether to grant bail use statistical data as input.
More frivolously, we can ask Alexa to switch on the coffee machine.

I think the authors meant to say planes instead of cars. 

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
