### PR TITLE
"as is show in in" -> "as is show in" typo

### DIFF
--- a/chapter_appendix-mathematics-for-deep-learning/maximum-likelihood.md
+++ b/chapter_appendix-mathematics-for-deep-learning/maximum-likelihood.md
@@ -73,7 +73,7 @@ This has three solutions: $0$, $1$ and $9/13$.  The first two are clearly minima
 
 The previous example is nice, but what if we have billions of parameters and data points.
 
-First notice that, if we make the assumption that all the data points are independent, we can no longer practically consider the likelihood itself as it is a product of many probabilities.  Indeed, each probability is in $[0,1]$, say typically of size about $1/2$, and the product of $(1/2)^{1000000000}$ is far below machine precision.  We cannot work with that directly.  
+First notice that, if we make the assumption that all the data points are independent, we can no longer practically consider the likelihood itself as it is a product of many probabilities.  Indeed, each probability is in $[0,1]$, say typically of value about $1/2$, and the product of $(1/2)^{1000000000}$ is far below machine precision.  We cannot work with that directly.  
 
 However, recall that the logarithm turns products to sums, in which case 
 

--- a/chapter_appendix-mathematics-for-deep-learning/maximum-likelihood.md
+++ b/chapter_appendix-mathematics-for-deep-learning/maximum-likelihood.md
@@ -91,7 +91,7 @@ Since the function $x \mapsto \log(x)$ is increasing, maximizing the likelihood 
 
 We often work with loss functions, where we wish to minimize the loss.  We may turn maximum likelihood into the minimization of a loss by taking $-\log(P(X \mid \boldsymbol{\theta}))$, which is the *negative log-likelihood*.
 
-To illustrate this, consider the coin flipping problem from before, and pretend that we do not know the closed form solution.  The we may compute that
+To illustrate this, consider the coin flipping problem from before, and pretend that we do not know the closed form solution.  We may compute that
 
 $$
 -\log(P(X \mid \boldsymbol{\theta})) = -\log(\theta^{n_H}(1-\theta)^{n_T}) = -(n_H\log(\theta) + n_T\log(1-\theta)).

--- a/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
+++ b/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
@@ -23,7 +23,7 @@ automatically retrieve the dataset from the Internet.
 Subsequently, Gluon will use the already-downloaded local copy.
 We specify whether we are requesting the training set or the test set
 by setting the value of the parameter `train` to `True` or `False`, respectively.
-Each image is a grayscale image with both width and height of $28$ with shape ($28$,$28$,$1$). We use a customized transformation to remove the last channel dimension. In addition, the dataset represents each pixel by a unsigned $8$-bit integer.  We quantize them into binary features to simplify the problem.
+Each image is a grayscale image with both width and height of $28$ with shape ($28$,$28$,$1$). We use a customized transformation to remove the last channel dimension. In addition, the dataset represents each pixel by an unsigned $8$-bit integer.  We quantize them into binary features to simplify the problem.
 
 ```{.python .input}
 def transform(data, label):

--- a/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
+++ b/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
@@ -19,7 +19,7 @@ d2l.use_svg_display()
 MNIST :cite:`LeCun.Bottou.Bengio.ea.1998` is one of widely used datasets. It contains 60,000 images for training and 10,000 images for validation. Each image contains a handwritten digit from 0 to 9. The task is classifying each image into the corresponding digit.
 
 Gluon provides a `MNIST` class in the `data.vision` module to
-automatically retrieve the dataset from the internet.
+automatically retrieve the dataset from the Internet.
 Subsequently, Gluon will use the already-downloaded local copy.
 We specify whether we are requesting the training set or the test set
 by setting the value of the parameter `train` to `True` or `False`, respectively.

--- a/chapter_appendix-mathematics-for-deep-learning/random-variables.md
+++ b/chapter_appendix-mathematics-for-deep-learning/random-variables.md
@@ -432,7 +432,7 @@ $$
 ![By summing along the columns of our array of probabilities, we are able to obtain the marginal distribution for just the random variable represented along the $x$-axis.](../img/Marginal.svg)
 :label:`fig_marginal`
 
-This tells us to add up the value of the density along a series of squares in a line as is show in in :numref:`fig_marginal`.  Indeed, after canceling one factor of epsilon from both sides, and recognizing the sum on the right is the integral over $y$, we can conclude that
+This tells us to add up the value of the density along a series of squares in a line as is shown in :numref:`fig_marginal`.  Indeed, after canceling one factor of epsilon from both sides, and recognizing the sum on the right is the integral over $y$, we can conclude that
 
 $$
 \begin{aligned}

--- a/chapter_appendix-mathematics-for-deep-learning/statistics.md
+++ b/chapter_appendix-mathematics-for-deep-learning/statistics.md
@@ -165,7 +165,7 @@ To complete the story of how to work with hypothesis testing, we need to now int
 
 ### Statistical Significance 
 
-The *statistical significance* measures the probability of erroneously reject the null hypothesis, $H_0$, when it should not be rejected, i.e.,
+The *statistical significance* measures the probability of erroneously rejecting the null hypothesis, $H_0$, when it should not be rejected, i.e.,
 
 $$ \text{statistical significance }= 1 - \alpha = P(\text{reject } H_0 \mid H_0 \text{ is true} ).$$
 

--- a/chapter_appendix-mathematics-for-deep-learning/statistics.md
+++ b/chapter_appendix-mathematics-for-deep-learning/statistics.md
@@ -156,7 +156,7 @@ First, you will need carefully random selected two groups of volunteers, so that
 
 Second, after a period of taking the medicine, you will need to measure the two groups' math understanding by the same metrics, such as letting the volunteers do the same tests after learning a new math formula. Then, you can collect their performance and compare the results.  In this case, our null hypothesis will be that there is no difference between the two groups, and our alternate will be that there is.  
 
-This is still not fully formal.  There are many details you have to think of carefully. For example, what is the suitable metrics to test their math understanding ability? How many volunteers for your test so you can be confident to claim the effectiveness of your medicine? How long should you run the test? How do you decided if there is a difference between the two groups?  Do you care about the average performance only, or do you also the range of variation of the scores. And so on.
+This is still not fully formal.  There are many details you have to think of carefully. For example, what is the suitable metrics to test their math understanding ability? How many volunteers for your test so you can be confident to claim the effectiveness of your medicine? How long should you run the test? How do you decide if there is a difference between the two groups?  Do you care about the average performance only, or do you also the range of variation of the scores. And so on.
 
 In this way, hypothesis testing provides framework for experimental design and reasoning about certainty in observed results.  If we can now show that the null hypothesis is very unlikely to be true, we may reject it with confidence.
 

--- a/chapter_appendix-mathematics-for-deep-learning/statistics.md
+++ b/chapter_appendix-mathematics-for-deep-learning/statistics.md
@@ -66,7 +66,7 @@ This allows us to quantify the average squared deviation from the true value.  M
 
 ### Statistical Bias
 
-The MSE provides a natural metric, but we can easily imagine multiple different phenomena that might make it large.  Two that we will see are fundamentally important are the fluctuation in the estimator due to randomness in the dataset, and systematic error in the estimator due to the estimation procedure.  
+The MSE provides a natural metric, but we can easily imagine multiple different phenomena that might make it large.  Two fundamentally important are fluctuation in the estimator due to randomness in the dataset, and systematic error in the estimator due to the estimation procedure.  
 
 
 First, let's measure the systematic error. For an estimator $\hat{\theta}_n$, the mathematical illustration of *statistical bias* can be defined as

--- a/chapter_multilayer-perceptrons/underfit-overfit.md
+++ b/chapter_multilayer-perceptrons/underfit-overfit.md
@@ -385,7 +385,7 @@ For many tasks, deep learning only outperforms linear models
 when many thousands of training examples are available.
 In part, the current success of deep learning
 owes to the current abundance of massive datasets
-due to internet companies, cheap storage, connected devices,
+due to Internet companies, cheap storage, connected devices,
 and the broad digitization of the economy.
 
 ## Polynomial Regression

--- a/chapter_preface/index.md
+++ b/chapter_preface/index.md
@@ -118,7 +118,7 @@ Code is best described in Python.
 And webpages are native in HTML and JavaScript.
 Furthermore, we want the content to be
 accessible both as executable code, as a physical book,
-as a downloadable PDF, and on the internet as a website.
+as a downloadable PDF, and on the Internet as a website.
 At present there exist no tools and no workflow
 perfectly suited to these demands, so we had to assemble our own.
 We describe our approach in detail in :numref:`sec_how_to_contribute`.


### PR DESCRIPTION
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
