### PR TITLE
Fixed mixed QR code

### DIFF
--- a/chapter_recurrent-modern/encoder-decoder.md
+++ b/chapter_recurrent-modern/encoder-decoder.md
@@ -76,6 +76,6 @@ class EncoderDecoder(nn.Block):
 
 
 
-## [Discussions](https://discuss.mxnet.io/t/2396)
+## [Discussions](https://discuss.mxnet.io/t/2393)
 
 ![](../img/qr_encoder-decoder.svg)


### PR DESCRIPTION
The old version will point to machine translation but not encoder decoder.
