### PR TITLE
Fix accuracy function on chapter 3.6

### DIFF
--- a/d2l/d2l.py
+++ b/d2l/d2l.py
@@ -199,7 +199,7 @@ def load_data_fashion_mnist(batch_size, resize=None):
 # Defined in file: ./chapter_linear-networks/softmax-regression-scratch.md
 def accuracy(y_hat, y):
     if y_hat.shape[1] > 1:
-        return float((y_hat.argmax(axis=1) == y.astype('float32')).sum())
+        return float((y_hat.argmax(axis=1).astype('float32') == y.astype('float32')).sum())
     else:
         return float((y_hat.astype('int32') == y.astype('int32')).sum())
 


### PR DESCRIPTION
Hello there,

I got an error while running the code `d2l.train_ch3(net, train_iter, test_iter, loss, num_epochs, trainer).` Further examination showed to me that the error was caused by the `accuracy` function trying to compare a int64 with a float32.

Below is my change to fix this issue:
(added a `.astype('float32')`)

```python
def accuracy(y_hat, y):
    if y_hat.shape[1] > 1:
        return float((y_hat.argmax(axis=1).astype('float32') == y.astype('float32')).sum())
    else:
        return float((y_hat.astype('int32') == y.astype('int32')).sum())
```