### PR TITLE
modified class Timer  to be more pythonable 3

### DIFF
--- a/chapter_linear-networks/linear-regression.md
+++ b/chapter_linear-networks/linear-regression.md
@@ -361,7 +361,7 @@ to track the running time.
 
 ```{.python .input  n=1}
 # Saved in the d2l package for later use
-class Timer(object):
+class Timer:
     """Record multiple running times."""
     def __init__(self):
         self.times = []


### PR DESCRIPTION
Hello,

all classes in Python3 inherits from object() class by design. Thus I removed unnecessary inheritance.
Ref doc: https://docs.python.org/3/library/functions.html?highlight=object%20class#object

