### PR TITLE
Removed reference to NDarray

### DIFF
--- a/chapter_multilayer-perceptrons/mlp.md
+++ b/chapter_multilayer-perceptrons/mlp.md
@@ -297,8 +297,6 @@ Informally, the ReLU function retains only positive
 elements and discards all negative elements 
 (setting the corresponding activations to 0).
 To gain some intuition, we can plot the function.
-Because it is used so commonly, NDarray 
-supports the `relu` function as a native operator.
 As you can see, the activation function is piecewise linear.
 
 ```{.python .input  n=2}


### PR DESCRIPTION
Are you wanting ND Array references still now that numpy is being used?




By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
