### PR TITLE
Missing $..$ in Classification Accuracy

### DIFF
--- a/chapter_linear-networks/softmax-regression-scratch.md
+++ b/chapter_linear-networks/softmax-regression-scratch.md
@@ -211,7 +211,7 @@ We will continue to use the variables `y_hat` and `y`
 defined in the `pick` function,
 as the predicted probability distribution and label, respectively.
 We can see that the first example's prediction category is $2$
-(the largest element of the row is 0.6 with an index of $2$),
+(the largest element of the row is $0.6$ with an index of $2$),
 which is inconsistent with the actual label, $0$.
 The second example's prediction category is $2$
 (the largest element of the row is $0.5$ with an index of $2$),

--- a/chapter_linear-networks/softmax-regression-scratch.md
+++ b/chapter_linear-networks/softmax-regression-scratch.md
@@ -70,7 +70,7 @@ along specific dimensions in an `ndarray`.
 Given a matrix `X` we can sum over all elements (default) or only
 over elements in the same axis, *i.e.*, the column (`axis=0`) or the same row (`axis=1`).
 Note that if `X` is an array with shape `(2, 3)`
-and we sum over the columns (`X.sum(axis=0`),
+and we sum over the columns (`X.sum(axis=0)`),
 the result will be a (1D) vector with shape `(3,)`.
 If we want to keep the number of axes in the original array
 (resulting in a 2D array with shape `(1, 3)`),


### PR DESCRIPTION
*Description of changes:*
I take a look at the content of section 3.6.5. Classification Accuracy. I realized there was a point I believed was a lack of latex format, so I created PR to add more.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
