### PR TITLE
Fix potential error in Environment section

### DIFF
--- a/chapter_multilayer-perceptrons/environment.md
+++ b/chapter_multilayer-perceptrons/environment.md
@@ -346,7 +346,7 @@ using a minimum-norm or a maximum entropy principle.
 Note that for any such approach, we need samples
 drawn from both distributions---the "true" $p$, e.g.,
 by access to training data, and the one used
-for generating the training set $q$ (the latter is trivially available).
+for generating the test set $q$ (the latter is trivially available).
 Note however, that we only need samples $\mathbf{x} \sim q(\mathbf{x})$;
 we do not to access labels $y \sim q(y)$.
 


### PR DESCRIPTION
Hi, shouldn't `q(x)` be the distribution for the test set?


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
