### PR TITLE
Grammar, typos, etc in index.md and model-construction.md.

### DIFF
--- a/chapter_deep-learning-computation/custom-layer.md
+++ b/chapter_deep-learning-computation/custom-layer.md
@@ -1,6 +1,6 @@
 # Custom Layers
 
-One of factors behind deep learnings success
+One factor behind deep learning's success
 is the availability of a wide range of layers
 that can be composed in creative ways
 to design architectures suitable
@@ -10,7 +10,7 @@ specifically for handling images, text,
 looping over sequential data,
 performing dynamic programming, etc.
 Sooner or later you will encounter (or invent)
-a layer that does not exist yet in Gluon,
+a layer that does not exist yet in Gluon.
 In these cases, you must build a custom layer.
 In this section, we show you how.
 
@@ -67,14 +67,14 @@ y.mean()
 
 ## Layers with Parameters
 
-Now that we know how to define simple layers
+Now that we know how to define simple layers,
 let us move on to defining layers with parameters
 that can be adjusted through training. 
-To automate some of the routine work
+To automate some of the routine work,
 the `Parameter` class and the `ParameterDict` dictionary 
 provide some basic housekeeping functionality.
 In particular, they govern access, initialization, 
-sharing, saving and loading model parameters. 
+sharing, saving, and loading model parameters. 
 This way, among other benefits, we will not need to write
 custom serialization routines for every custom layer.
 
@@ -82,7 +82,7 @@ The `Block` class contains a `params` variable
 of the `ParameterDict` type. 
 This dictionary maps strings representing parameter names
 to model parameters (of the `Parameter` type). 
-The `ParameterDict` also supplied a `get` function
+The `ParameterDict` also supplies a `get` function
 that makes it easy to generate a new parameter
 with a specified name and shape.
 
@@ -139,7 +139,7 @@ We can also construct models using custom layers.
 Once we have that we can use it just like the built-in dense layer.
 The only exception is that in our case,
 shape inference is not automatic. 
-If you are interested in these bells and whisteles,
+If you are interested in these bells and whistles,
 please consult the [MXNet documentation](http://www.mxnet.io)
 for details on how to implement shape inference in custom layers.
 
@@ -155,7 +155,7 @@ net(np.random.uniform(size=(2, 64)))
 
 * We can design custom layers via the Block class. This allows us to define flexible new layers that behave differently from any existing layers in the library.
 * Once defined, custom layers can be invoked in arbitrary contexts and architectures.
-* Blocks can have local parameters, which are stored as a `ParameterDict` object in each Blovk's `params` attribute.
+* Blocks can have local parameters, which are stored in a `ParameterDict` object in each Block's `params` attribute.
 
 
 ## Exercises

--- a/chapter_deep-learning-computation/deferred-init.md
+++ b/chapter_deep-learning-computation/deferred-init.md
@@ -4,7 +4,7 @@
 So far, it might seem that we got away
 with being sloppy in setting up our networks.
 Specifically, we did the following unintuitive things,
-which not might seem like they should work:
+which might not seem like they should work:
 
 * We defined the network architectures 
   without specifying the input dimensionality.
@@ -22,8 +22,8 @@ waiting until the first time we pass data through the model,
 to infer the sizes of each layer *on the fly*.
 
 
-Later on, when working with convolutional neural networks
-this technique will become even more convenient,
+Later on, when working with convolutional neural networks,
+this technique will become even more convenient
 since the input dimensionality 
 (i.e., the resolution of an image) 
 will affect the dimensionality 
@@ -39,7 +39,7 @@ Next, we go deeper into the mechanics of initialization.
 
 ## Instantiating a Network
 
-To begin, let us instantiate an MLP. 
+To begin, let us instantiate an MLP.
 
 ```{.python .input}
 from mxnet import init, np, npx
@@ -67,10 +67,10 @@ print(net.collect_params())
 ```
 
 Note that while the Parameter objects exist,
-the input dimension to each layer to listed as `-1`.
+the input dimension to each layer is listed as `-1`.
 MXNet uses the special value `-1` to indicate
 that the parameters dimension remains unknown.
-At this point attempts to access `net[0].weight.data()`
+At this point, attempts to access `net[0].weight.data()`
 would trigger a runtime error stating that the network
 must be initialized before the parameters can be accessed.
 Now let us see what happens when we attempt to initialze
@@ -89,7 +89,7 @@ Instead, this call registers to MXNet that we wish
 to initialize the parameters. 
 Only once we pass data through the network
 will MXNet finally initialize parameters 
-and we will see a difference.
+and will we see a difference.
 
 ```{.python .input}
 x = np.random.uniform(size=(2, 20))
@@ -99,13 +99,13 @@ net.collect_params()
 ```
 
 As soon as we knew the input dimensionality, 
-$\mathbf{x} \in \mathbb{R}^{20}$ 
-MXNet can identify the shape of the first layer's weight matrix, 
+$\mathbf{x} \in \mathbb{R}^{20}$, 
+MXNet could identify the shape of the first layer's weight matrix, 
 i.e., $\mathbf{W}_1 \in \mathbb{R}^{256 \times 20}$.
-Having recognized the first layer shape, MXNet proceeds
+Having recognized the first layer shape, MXNet proceeded
 to the second layer, whose dimensionality is $10 \times 256$
 and so on through the computational graph
-until all shapes are known.
+until all shapes were known.
 Note that in this case, 
 only the first layer required deferred initialization,
 but MXNet initializes sequentially. 
@@ -163,10 +163,10 @@ y = net(x)
 ```
 
 As mentioned at the beginning of this section,
-deferred initialization can be source of confusion.
+deferred initialization can be a source of confusion.
 Before the first forward calculation,
-we were unable to directly manipulate the model parameters,
-for example, we could not use
+we were unable to directly manipulate the model parameters.
+For example, we could not use
 the `data` and `set_data` functions
 to get and modify the parameters.
 Therefore, we often force initialization

--- a/chapter_deep-learning-computation/index.md
+++ b/chapter_deep-learning-computation/index.md
@@ -6,7 +6,7 @@ great software tools have played an indispensable role
 in the rapid progress of deep learning.
 Starting with the pathbreaking Theano library released in 2007,
 flexible open-source tools have enabled researchers
-to rapidly prototype models avoiding repetitive work
+to rapidly prototype models, avoiding repetitive work
 when recycling standard components
 while still maintaining the ability to make low-level modifications.
 Over time, deep learning's libraries have evolved
@@ -31,8 +31,8 @@ namely model construction, parameter access and initialization,
 designing custom layers and blocks, reading and writing models to disk,
 and leveraging GPUs to achieve dramatic speedups.
 These insights will move you from *end user* to *power user*,
-giving you the tools needed to combine the reap the benefits
-of a mature deep learning library, while retaining the flexibility
+giving you the tools needed to reap the benefits
+of a mature deep learning library while retaining the flexibility
 to implement more complex models, including those you invent yourself!
 While this chapter does not introduce any new models or datasets,
 the advanced modeling chapters that follow rely heavily on these techniques.
@@ -47,3 +47,4 @@ custom-layer
 read-write
 use-gpu
 ```
+

--- a/chapter_deep-learning-computation/model-construction.md
+++ b/chapter_deep-learning-computation/model-construction.md
@@ -54,7 +54,7 @@ The ResNet architecture mentioned above
 won the 2015 ImageNet and COCO computer vision competitions
 for both recognition and detection :cite:`He.Zhang.Ren.ea.2016`
 and remains a go-to architecture for many vision tasks.
-Similar patterns are in which layers are arranged 
+Similar architectures in which layers are arranged 
 in various repeating patterns 
 are now ubiquitous in other domains,
 including natural language processing and speech.
@@ -123,7 +123,7 @@ In short, `nn.Sequential` defines a special kind of `Block`
 that mantains an ordered list of constituent `Blocks`.
 The `add` method simply facilitates
 the addition of each successive `Block` to the list.
-Note that each our layer is an instance of the `Dense` class
+Note that each layer is an instance of the `Dense` class
 which is itself a subclass of `Block`.
 The `forward` function is also remarkably simple:
 it chains each Block in the list together,
@@ -203,7 +203,7 @@ on each call to the `forward` method.
 Note a few key details.
 First, our customized `__init__` method 
 invokes the parent class's `__init__` method
-via `super(MLP, self).__init__(**kwargs)`
+via `super(MLP, self).__init__(**kwargs)`,
 sparing us the pain of restating
 boilerplate code applicable to most Blocks.
 We then instantiate our two `Dense` layers,
@@ -300,11 +300,11 @@ for the Gluon `Sequential` class
 
 The `nn.Sequential` class makes model construction easy,
 allowing us to assemble new architectures
-without having to defined our own class.
+without having to define our own class.
 However, not all architectures are simple daisy chains.
 When greater flexibility is required,
 we will want to define our own `Block`s.
-For example, we might want to exectute 
+For example, we might want to execute 
 Python's control flow within the forward method.
 Moreover we might want to perform
 arbitrary mathematical operations,
@@ -315,8 +315,8 @@ all of the operations in our networks
 have acted upon our network's activations
 and its parameters. 
 Sometimes, however, we might want to 
-incorporate terms constant terms 
-which are neither the result of previous layers
+incorporate terms 
+that are neither the result of previous layers
 nor updatable parameters. 
 In Gluon, we call these *constant* parameters. 
 Say for example that we want a layer
@@ -327,7 +327,7 @@ and $c$ is some specified constant
 that is not updated during optimization.
 
 Declaring constants explicitly (via `get_constant`)
-makes this clear helps Gluon to speed up execution.
+makes this clear and helps Gluon to speed up execution.
 In the following code, we will implement a model
 that could not easily be assembled
 using only predefined layers and `Sequential`.
@@ -372,7 +372,7 @@ We ran a `while` loop, testing
 on the condition `np.abs(x).sum() > 1`,
 and dividing our output vector by $2$ 
 until it satisfied the condition.
-Finally, we outputed the sum of the entries in `x`.
+Finally, we returned the sum of the entries in `x`.
 To our knowledge, no standard neural network
 performs this operation.
 Note that this particular operation may not be useful
@@ -432,7 +432,7 @@ The Gluon runtime records what is happening
 and the next time around it short-circuits calls to Python.
 This can accelerate things considerably in some cases
 but care needs to be taken when control flow (as above)
-lead down different branches on different passes through the net.
+leads down different branches on different passes through the net.
 We recommend that the interested reader check out 
 the hybridization section (:numref:`sec_hybridize`)
 to learn about compilation after finishing the current chapter.
@@ -441,8 +441,8 @@ to learn about compilation after finishing the current chapter.
 ## Summary
 
 * Layers are Blocks.
-* Many layers can comprise a Block.
-* Many Blocks can comprise a Block.
+* A Block can contain many layers.
+* A Block can contain many Blocks.
 * A Block can contain code.
 * Blocks take care of lots of housekeeping, including parameter initialization and backpropagation.
 * Sequential concatenations of layers and blocks are handled by the `Sequential` Block.

--- a/chapter_deep-learning-computation/parameters.md
+++ b/chapter_deep-learning-computation/parameters.md
@@ -23,7 +23,7 @@ to do the heavy lifting.
 However, when we move away from 
 stacked architectures with standard layers, 
 we will sometimes need to get into the weeds
-of declaring and manipulate parameters. 
+of declaring and manipulating parameters. 
 In this section, we cover the following:
 
 * Accessing parameters for debugging, diagnostics, and visualiziations.
@@ -70,14 +70,14 @@ corresponding to that layer's
 weights and biases, respectively.
 Both are stored as single precision floats.
 Note that the names of the parameters
-are allow us to *uniquely* identify
+allow us to *uniquely* identify
 each layer's parameters,
-even in a network contains hundreds of layers.
+even in a network containing hundreds of layers.
 
 
 ### Targeted Parameters
 
-Note that each parameters is represented
+Note that each parameter is represented
 as an instance of the `Parameter` class.
 To do anything useful with the parameters,
 we first need to access the underlying numerical values. 
@@ -106,7 +106,7 @@ since it was initialized.
 We can also access each parameter by name,
 e.g., `dense0_weight` as follows. 
 Under the hood this is possible because
-each layer contains a parameter dictionary. 
+each layer contains a parameter dictionary.
 
 ```{.python .input  n=4}
 print(net[0].params['dense0_weight'])
@@ -134,7 +134,7 @@ accessing them one-by-one can grow tedious.
 The situation can grow especially unwieldy
 when we work with more complex Blocks, (e.g., nested Blocks),
 since we would need to recurse 
-through the entire tree in to extact
+through the entire tree in order to extract
 each sub-Block's parameters.
 To avoid this, each Block comes 
 with a `collect_params`  method 
@@ -258,7 +258,7 @@ net.initialize(init=init.Constant(1), force_reinit=True)
 net[0].weight.data()[0]
 ```
 
-We can also apply different initialziers for certain Blocks.
+We can also apply different initializers for certain Blocks.
 For example, below we initialize the first layer
 with the `Xavier` initializer
 and initialize the second layer 
@@ -276,7 +276,7 @@ print(net[1].weight.data()[0, 0])
 Sometimes, the initialization methods we need 
 are not provided in the `init` module. 
 In these cases, we can define a subclass of `Initializer`. 
-Usually, we only need to implement the `_init_weight` function
+Usually, we only need to implement the `_init_weight` function,
 which takes an `ndarray` argument (`data`) 
 and assigns to it the desired initialized values. 
 In the example below, we define an initializer

--- a/chapter_deep-learning-computation/read-write.md
+++ b/chapter_deep-learning-computation/read-write.md
@@ -61,16 +61,16 @@ mydict2
 
 ## Gluon Model Parameters
 
-Saving individual weight vectors (or other `ndarray` tensors) is useful 
+Saving individual weight vectors (or other `ndarray` tensors) is useful, 
 but it gets very tedious if we want to save 
 (and later load) an entire model.
 After all, we might have hundreds of 
 parameter groups sprinkled throughout. 
-For this reason Gluon provides built-in functionality 
+For this reason, Gluon provides built-in functionality 
 to load and save entire networks.
 An important detail to note is that this 
 saves model *parameters* and not the entire model. 
-For example, if we have a 3 layer MLP,
+For example, if we have a 3-layer MLP,
 we need to specify the *architecture* separately. 
 The reason for this is that the models themselves can contain arbitrary code, 
 hence they cannot be serialized as naturally 
@@ -104,7 +104,7 @@ y = net(x)
 Next, we store the parameters of the model as a file with the name `mlp.params`.
 Gluon Blocks support a `save_parameters` method 
 that writes all parameters to disk given 
-a string for the file name. 
+a string for the file name.
 
 ```{.python .input}
 net.save_parameters('mlp.params')
@@ -115,7 +115,7 @@ of the original MLP model.
 Instead of randomly initializing the model parameters, 
 we read the parameters stored in the file directly.
 Conveniently we can load parameters into Blocks
-via their `load_parameters` method. 
+via their `load_parameters` method.
 
 ```{.python .input  n=8}
 clone = MLP()

--- a/chapter_deep-learning-computation/use-gpu.md
+++ b/chapter_deep-learning-computation/use-gpu.md
@@ -18,8 +18,8 @@ a significant need to provide such performance.
 |2020|1 T (social network)|100 GB|1 PF (NVIDIA DGX-2)|
 
 In this section, we begin to discuss how to harness 
-this compute performance for your research. 
-First by using single GPUs and at a later point,
+this compute performance for your research 
+by using single GPUs.   At a later point, we show
 how to use multiple GPUs and multiple servers (with multiple GPUs). 
 You might have noticed that MXNet `ndarray` 
 looks almost identical to NumPy. 
@@ -157,7 +157,6 @@ We can use the `nvidia-smi` command to view GPU memory usage.
 In general, we need to make sure we do not 
 create data that exceeds the GPU memory limit.
 
-
 ```{.python .input  n=5}
 x = np.ones((2, 3), ctx=try_gpu())
 x
@@ -210,12 +209,12 @@ Imagine that your variable z already lives on your second GPU (gpu(1)).
 What happens if we call z.copyto(gpu(1))? 
 It will make a copy and allocate new memory,
 even though that variable already lives on the desired device!
-There are times where depending on the environment our code is running in,
+There are times where, depending on the environment our code is running in,
 two variables may already live on the same device.
 So we only want to make a copy if the variables 
-currently lives on different contexts.
+currently live on different contexts.
 In these cases, we can call `as_in_ctx()`.
-If the variable already live in the specified context
+If the variables already live in the specified context
 then this is a no-op. 
 Unless you specifically want to make a copy, 
 `as_in_ctx()` is the method of choice.


### PR DESCRIPTION
*Description of changes:*

Grammar and typos in beginning of chapter 5.
Also fixed misuse of "comprise".  The whole comprises all the parts; all the parts compose the whole.  Never say "is comprised of" or use comprise when something is missing (all parts must be involved) or as a synonym for "compose."  Use "comprises" as a replacement for "is composed of".

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
