### PR TITLE
Fixed missing parenthesis in mlp-scratch.md

### DIFF
--- a/chapter_multilayer-perceptrons/mlp-scratch.md
+++ b/chapter_multilayer-perceptrons/mlp-scratch.md
@@ -92,7 +92,7 @@ def net(X):
 To ensure numerical stability
 (and because we already implemented
 the softmax function from scratch
-(:numref:`sec_softmax_scratch`),
+(:numref:`sec_softmax_scratch`)),
 we leverage Gluon's integrated function
 for calculating the softmax and cross-entropy loss.
 Recall our earlier discussion of these intricacies 


### PR DESCRIPTION
In line 92; 

> To ensure numerical stability
> (and because we already implemented
> the softmax function from scratch
> (:numref:`sec_softmax_scratch`)

 was there, but the opening parenthesis (before _and_) was not closed, so closed it.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
