### PR TITLE
Fix typo, grammar in batch-norm.md

### DIFF
--- a/chapter_convolutional-modern/batch-norm.md
+++ b/chapter_convolutional-modern/batch-norm.md
@@ -271,7 +271,7 @@ keeping track of running averages (here for mean and variance), etc.
 This pattern enables a clean separation of math from boilerplate code.
 Also note that for the sake of convenience
 we did not worry about automatically inferring the input shape here,
-thus our need to specify the number of features throughout.
+thus we need to specify the number of features throughout.
 Do not worry, the Gluon `BatchNorm` layer will care of this for us.
 
 ```{.python .input  n=73}

--- a/chapter_convolutional-modern/batch-norm.md
+++ b/chapter_convolutional-modern/batch-norm.md
@@ -379,7 +379,7 @@ net.add(nn.Conv2D(6, kernel_size=5),
         nn.Dense(10))
 ```
 
-Below, we use the same hyper-parameters to train out model.
+Below, we use the same hyper-parameters to train our model.
 Note that as usual, the Gluon variant runs much faster
 because its code has been compiled to C++/CUDA
 while our custom implementation must be interpreted by Python.


### PR DESCRIPTION
*Description of changes:*

Fix a small grammatical error and typo.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
