### PR TITLE
add scipy to jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,7 @@ stage("Build and Publish") {
       # pytorch
       pip install torch==1.5.0+cu101 -f https://download.pytorch.org/whl/torch_stable.html
       pip install torchvision
+      pip install scipy
       cd d2l_pytorch; python setup.py develop
       pip list
       nvidia-smi


### PR DESCRIPTION
**Description of changes:**
Add `pip install scipy` to configure jenkins.
*This is required for gamma function (`from scipy.special import gamma`) which is used in `chapter_multilayer-perceptrons/underfit-overfit.md`*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.

