### PR TITLE
remove scipy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,6 @@ stage("Build and Publish") {
       # pytorch
       pip install torch==1.5.0+cu101 -f https://download.pytorch.org/whl/torch_stable.html
       pip install torchvision
-      pip install scipy
       cd d2l_pytorch; python setup.py develop
       pip list
       nvidia-smi


### PR DESCRIPTION
gamma function was implemented using math.gamma.
So there is no need for scipy now.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
