### PR TITLE
pytorch: add import requests to index

### DIFF
--- a/chapter_preface/index.md
+++ b/chapter_preface/index.md
@@ -351,6 +351,7 @@ import sys
 import tarfile
 import time
 import zipfile
+import requests
 
 d2l = sys.modules[__name__]
 ```

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -25,6 +25,7 @@ import sys
 import tarfile
 import time
 import zipfile
+import requests
 
 d2l = sys.modules[__name__]
 


### PR DESCRIPTION
*Description of changes:*
This is required by the d2l torch function saved as `util_download`. This was defined earlier in replacement for `gluon.utils.download` as PyTorch doesn't offer such a utility function.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.