### PR TITLE
fix typo

### DIFF
--- a/chapter_convolutional-neural-networks/why-conv.md
+++ b/chapter_convolutional-neural-networks/why-conv.md
@@ -261,7 +261,7 @@ We could think of the hidden representation as comprising
 a number of 2D grids stacked on top of each other.
 As in the inputs, these are sometimes called *channels*.
 They are also sometimes called *feature maps*,
-as each provides a set of spatialized set
+as each provides a spatialized set
 of learned features to the subsequent layer.
 Intuitively, you might imagine that at lower layers,
 some channels could become specialized to recognize edges,


### PR DESCRIPTION
"a set of spatialized set of learned features" looks like a typo.
My guess is that the intention was: "a spatialized set of learned features"
However, other possibilities would be:
"a set of spatialized learned features"
"a set of spatialized sets of learned features"

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
