### PR TITLE
Undefined name: import warnings for line 372

### DIFF
--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -24,6 +24,7 @@ import shutil
 import sys
 import tarfile
 import time
+import warnings
 import zipfile
 import requests
 


### PR DESCRIPTION
`warnings.warn()` is called on line 372 but `warnings` is neither imported nor defined so NameError will probably be raised instead of a warning.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
