### PR TITLE
Revert "pytorch: add eigen decomposition"

### DIFF
--- a/chapter_appendix-mathematics-for-deep-learning/eigendecomposition.md
+++ b/chapter_appendix-mathematics-for-deep-learning/eigendecomposition.md
@@ -98,16 +98,6 @@ import numpy as np
 np.linalg.eig(np.array([[2, 1], [2, 3]]))
 ```
 
-```{.python .input}
-#@tab pytorch
-%matplotlib inline
-from d2l import torch as d2l
-from IPython import display
-import torch
-
-torch.eig(torch.tensor([[2, 1], [2, 3]], dtype=torch.float64))
-```
-
 Note that `numpy` normalizes the eigenvectors to be of length one,
 whereas we took ours to be of arbitrary length.
 Additionally, the choice of sign is arbitrary.
@@ -277,17 +267,6 @@ v, _ = np.linalg.eig(A)
 v
 ```
 
-```{.python .input}
-#@tab pytorch
-A = torch.tensor([[1.0, 0.1, 0.1, 0.1],
-              [0.1, 3.0, 0.2, 0.3],
-              [0.1, 0.2, 5.0, 0.5],
-              [0.1, 0.3, 0.5, 9.0]])
-
-v, _ = torch.eig(A)
-v
-```
-
 In this way, eigenvalues can be approximated, 
 and the approximations will be fairly accurate 
 in the case that the diagonal is 
@@ -331,15 +310,6 @@ A = np.random.randn(k, k)
 A
 ```
 
-```{.python .input}
-#@tab pytorch
-torch.manual_seed(42)
-
-k = 5
-A = torch.randn(k, k, dtype=torch.float64)
-A
-```
-
 ### Behavior on Random Data
 For simplicity in our toy model, 
 we will assume that the data vector we feed in $\mathbf{v}_{in}$ 
@@ -377,19 +347,6 @@ for i in range(1, 100):
 d2l.plot(np.arange(0, 100), norm_list, 'Iteration', 'Value')
 ```
 
-```{.python .input}
-#@tab pytorch
-# Calculate the sequence of norms after repeatedly applying A
-v_in = torch.randn(k, 1, dtype=torch.float64)
-
-norm_list = [torch.norm(v_in).item()]
-for i in range(1, 100):
-    v_in = A @ v_in
-    norm_list.append(torch.norm(v_in).item())
-
-d2l.plot(torch.arange(0, 100), norm_list, 'Iteration', 'Value')
-```
-
 The norm is growing uncontrollably! 
 Indeed if we take the list of quotients, we will see a pattern.
 
@@ -400,16 +357,6 @@ for i in range(1, 100):
     norm_ratio_list.append(norm_list[i]/norm_list[i - 1])
 
 d2l.plot(np.arange(1, 100), norm_ratio_list, 'Iteration', 'Ratio')
-```
-
-```{.python .input}
-#@tab pytroch
-# Compute the scaling factor of the norms
-norm_ratio_list = []
-for i in range(1, 100):
-    norm_ratio_list.append(norm_list[i]/norm_list[i - 1])
-
-d2l.plot(torch.arange(1, 100), norm_ratio_list, 'Iteration', 'Ratio')
 ```
 
 If we look at the last portion of the above computation, 
@@ -434,15 +381,6 @@ we can measure that stretching factor. Let us also sort them.
 # Compute the eigenvalues
 eigs = np.linalg.eigvals(A).tolist()
 norm_eigs = [np.absolute(x) for x in eigs]
-norm_eigs.sort()
-"Norms of eigenvalues: {}".format(norm_eigs)
-```
-
-```{.python .input}
-#@tab pytorch
-# Compute the eigenvalues
-eigs = torch.eig(A)[0][:,0].tolist()
-norm_eigs = [torch.abs(torch.tensor(x)) for x in eigs]
 norm_eigs.sort()
 "Norms of eigenvalues: {}".format(norm_eigs)
 ```
@@ -505,22 +443,6 @@ for i in range(1, 100):
 d2l.plot(np.arange(0, 100), norm_list, 'Iteration', 'Value')
 ```
 
-```{.python .input}
-#@tab pytorch
-# Rescale the matrix A
-A /= norm_eigs[-1]
-
-# Do the same experiment again
-v_in = torch.randn(k, 1, dtype=torch.float64)
-
-norm_list = [torch.norm(v_in).item()]
-for i in range(1, 100):
-    v_in = A @ v_in
-    norm_list.append(torch.norm(v_in).item())
-
-d2l.plot(torch.arange(0, 100), norm_list, 'Iteration', 'Value')
-```
-
 We can also plot the ration between consecutive norms as before and see that indeed it stabilizes.
 
 ```{.python .input}
@@ -530,16 +452,6 @@ for i in range(1, 100):
     norm_ratio_list.append(norm_list[i]/norm_list[i-1])
 
 d2l.plot(np.arange(1, 100), norm_ratio_list, 'Iteration', 'Ratio')
-```
-
-```{.python .input}
-#@tab pytorch
-# Also plot the ratio
-norm_ratio_list = []
-for i in range(1, 100):
-    norm_ratio_list.append(norm_list[i]/norm_list[i-1])
-
-d2l.plot(torch.arange(1, 100), norm_ratio_list, 'Iteration', 'Ratio')
 ```
 
 ## Conclusions


### PR DESCRIPTION
Reverts d2l-ai/d2l-en#954

I am reverting this due to the following error: @AnirudhDagar can you fix it in your next PR:

[d2lbook:build.py:L208] INFO   merge ['_build/eval/chapter_appendix-mathematics-for-deep-learning/eigendecomposition.ipynb', '_build/eval_pytorch/chapter_appendix-mathematics-for-deep-learning/eigendecomposition.ipynb'] into _build/eval_all/chapter_appendix-mathematics-for-deep-learning/eigendecomposition.ipynb
Traceback (most recent call last):
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/bin/d2lbook", line 8, in <module>
    sys.exit(main())
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/lib/python3.7/site-packages/d2lbook/main.py", line 22, in main
    commands[args.command[0]]()
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/lib/python3.7/site-packages/d2lbook/build.py", line 35, in build
    getattr(builder, cmd)()
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/lib/python3.7/site-packages/d2lbook/build.py", line 47, in warp
    func(self)
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/lib/python3.7/site-packages/d2lbook/build.py", line 224, in rst
    self.merge()
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/lib/python3.7/site-packages/d2lbook/build.py", line 47, in warp
    func(self)
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/lib/python3.7/site-packages/d2lbook/build.py", line 213, in merge
    dst_nb = notebook.add_html_tab(dst_nb, self.config.default_tab)
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/lib/python3.7/site-packages/d2lbook/notebook.py", line 177, in add_html_tab
    cell_groups = _merge_tabs(nb)
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/lib/python3.7/site-packages/d2lbook/notebook.py", line 153, in _merge_tabs
    cell_groups = common.group_list(nb.cells, _tab_status)
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/lib/python3.7/site-packages/d2lbook/common.py", line 21, in group_list
    cur_status = status_fn(item, prev_status)
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/lib/python3.7/site-packages/d2lbook/notebook.py", line 145, in _tab_status
    tab = _get_cell_tab(cell)
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/lib/python3.7/site-packages/d2lbook/notebook.py", line 66, in _get_cell_tab
    if 'tab' in cell.metadata:
AttributeError: 'NoneType' object has no attribute 'metadata'
[d2lbook:config.py:L12] INFO   Load configure from config.ini
[d2lbook:build.py:L208] INFO   merge ['_build/eval/chapter_appendix-mathematics-for-deep-learning/eigendecomposition.ipynb', '_build/eval_pytorch/chapter_appendix-mathematics-for-deep-learning/eigendecomposition.ipynb'] into _build/eval_all/chapter_appendix-mathematics-for-deep-learning/eigendecomposition.ipynb
Traceback (most recent call last):
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/bin/d2lbook", line 8, in <module>
    sys.exit(main())
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/lib/python3.7/site-packages/d2lbook/main.py", line 22, in main
    commands[args.command[0]]()
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/lib/python3.7/site-packages/d2lbook/build.py", line 35, in build
    getattr(builder, cmd)()
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/lib/python3.7/site-packages/d2lbook/build.py", line 47, in warp
    func(self)
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/lib/python3.7/site-packages/d2lbook/build.py", line 247, in html
    self.rst()
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/lib/python3.7/site-packages/d2lbook/build.py", line 47, in warp
    func(self)
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/lib/python3.7/site-packages/d2lbook/build.py", line 224, in rst
    self.merge()
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/lib/python3.7/site-packages/d2lbook/build.py", line 47, in warp
    func(self)
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/lib/python3.7/site-packages/d2lbook/build.py", line 213, in merge
    dst_nb = notebook.add_html_tab(dst_nb, self.config.default_tab)
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/lib/python3.7/site-packages/d2lbook/notebook.py", line 177, in add_html_tab
    cell_groups = _merge_tabs(nb)
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/lib/python3.7/site-packages/d2lbook/notebook.py", line 153, in _merge_tabs
    cell_groups = common.group_list(nb.cells, _tab_status)
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/lib/python3.7/site-packages/d2lbook/common.py", line 21, in group_list
    cur_status = status_fn(item, prev_status)
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/lib/python3.7/site-packages/d2lbook/notebook.py", line 145, in _tab_status
    tab = _get_cell_tab(cell)
  File "/var/lib/jenkins/miniconda3/envs/d2l-en-0/lib/python3.7/site-packages/d2lbook/notebook.py", line 66, in _get_cell_tab
    if 'tab' in cell.metadata:
AttributeError: 'NoneType' object has no attribute 'metadata'