### PR TITLE
Fix attention query of seq2seq.

### DIFF
--- a/chapter_attention-mechanisms/seq2seq-attention.md
+++ b/chapter_attention-mechanisms/seq2seq-attention.md
@@ -38,7 +38,7 @@ Since the encoder of seq2seq with attention mechanisms is the same as `Seq2SeqEn
 
 - **the encoder valid length**: so the attention layer will not consider the padding tokens within the encoder outputs.
 
-At each timestep of the decoding, we use the output of the decoder's last RNN layer as the query for the attention layer. The attention model's output is then concatenated with the input embedding vector to feed into the RNN layer. Although the RNN layer hidden state also contains history information from decoder, the attention output explicitly selects the encoder outputs based on `enc_valid_len`, so that the attention output suspends other irrelevant information.
+At each timestep of the decoding, we use the hidden state of the decoder's last RNN layer as the query for the attention layer. The attention model's output is then concatenated with the input embedding vector to feed into the RNN layer. Although the RNN layer hidden state also contains history information from decoder, the attention output explicitly selects the encoder outputs based on `enc_valid_len`, so that the attention output suspends other irrelevant information.
 
 Let us implement the `Seq2SeqAttentionDecoder`, and see how it differs from the decoder in seq2seq from :numref:`sec_seq2seq_decoder`.
 


### PR DESCRIPTION
*Description of changes:* Wrong use of `output` instead of `hidden state` of decoder's RNN. The code and the figure both say `hidden state`.


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
