### PR TITLE
fix discussions tab

### DIFF
--- a/chapter_convolutional-neural-networks/lenet.md
+++ b/chapter_convolutional-neural-networks/lenet.md
@@ -437,6 +437,6 @@ train_ch6(build_model, train_iter, test_iter, num_epochs, lr)
 [Discussions](https://discuss.d2l.ai/t/74)
 :end_tab:
 
-:begin_tab:`pytorch`
+:begin_tab:`tensorflow`
 [Discussions](https://discuss.d2l.ai/t/275)
 :end_tab:

--- a/chapter_convolutional-neural-networks/padding-and-strides.md
+++ b/chapter_convolutional-neural-networks/padding-and-strides.md
@@ -313,6 +313,6 @@ i.e., we usually have $p_h = p_w$ and $s_h = s_w$.
 [Discussions](https://discuss.d2l.ai/t/68)
 :end_tab:
 
-:begin_tab:`pytorch`
+:begin_tab:`tensorflow`
 [Discussions](https://discuss.d2l.ai/t/272)
 :end_tab:

--- a/chapter_convolutional-neural-networks/pooling.md
+++ b/chapter_convolutional-neural-networks/pooling.md
@@ -342,6 +342,6 @@ pool2d(X)
 [Discussions](https://discuss.d2l.ai/t/72)
 :end_tab:
 
-:begin_tab:`pytorch`
+:begin_tab:`tensorflow`
 [Discussions](https://discuss.d2l.ai/t/274)
 :end_tab:


### PR DESCRIPTION
*Description of changes:*
This PR fixes the discussions tab link for TensorFlow in Chapter LeNet 

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
