### PR TITLE
Demonstrate the use of MySequential in PyTorch example

### DIFF
--- a/chapter_deep-learning-computation/model-construction.md
+++ b/chapter_deep-learning-computation/model-construction.md
@@ -462,7 +462,7 @@ net(x)
 
 ```{.python .input}
 #@tab pytorch
-net = nn.Sequential(nn.Linear(20, 256), nn.ReLU(), nn.Linear(256, 10))
+net = MySequential(nn.Linear(20, 256), nn.ReLU(), nn.Linear(256, 10))
 net(x)
 ```
 


### PR DESCRIPTION
*Description of changes:* This section is for demonstrating the self-defined sequential class instead of using the built-in sequential class.


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
