### PR TITLE
Update torch.eig method and add missing import in d2l/torch.py

### DIFF
--- a/chapter_appendix-mathematics-for-deep-learning/eigendecomposition.md
+++ b/chapter_appendix-mathematics-for-deep-learning/eigendecomposition.md
@@ -105,7 +105,7 @@ from d2l import torch as d2l
 from IPython import display
 import torch
 
-torch.eig(torch.tensor([[2, 1], [2, 3]], dtype=torch.float64))
+torch.eig(torch.tensor([[2, 1], [2, 3]], dtype=torch.float64), eigenvectors=True)
 ```
 
 Note that `numpy` normalizes the eigenvectors to be of length one,

--- a/chapter_appendix-mathematics-for-deep-learning/eigendecomposition.md
+++ b/chapter_appendix-mathematics-for-deep-learning/eigendecomposition.md
@@ -521,7 +521,7 @@ for i in range(1, 100):
 d2l.plot(torch.arange(0, 100), norm_list, 'Iteration', 'Value')
 ```
 
-We can also plot the ration between consecutive norms as before and see that indeed it stabilizes.
+We can also plot the ratio between consecutive norms as before and see that indeed it stabilizes.
 
 ```{.python .input}
 # Also plot the ratio

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -10,6 +10,7 @@ import math
 from matplotlib import pyplot as plt
 import os
 import pandas as pd
+import numpy as np
 import random
 import re
 import shutil


### PR DESCRIPTION
Add missing Numpy import in d2l/torch.py, remove an extra letter, and set a parameter in ```torch.eig``` to show corresponding eigenvectors.


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
