### PR TITLE
tf pytorch add missing numpy import

### DIFF
--- a/chapter_preface/index.md
+++ b/chapter_preface/index.md
@@ -342,10 +342,10 @@ from mxnet import autograd, context, gluon, image, init, np, npx
 from mxnet.gluon import nn, rnn
 ```
 
-
 ```{.python .input  n=1}
 #@tab pytorch
 #@save
+import numpy as np
 import torch
 import torchvision
 from torch import nn
@@ -357,6 +357,7 @@ from torchvision import transforms
 ```{.python .input  n=1}
 #@tab tensorflow
 #@save
+import numpy as np
 import tensorflow as tf
 ```
 

--- a/d2l/tensorflow.py
+++ b/d2l/tensorflow.py
@@ -23,6 +23,7 @@ d2l = sys.modules[__name__]
 
 
 # Defined in file: ./chapter_preface/index.md
+import numpy as np
 import tensorflow as tf
 
 

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -10,7 +10,6 @@ import math
 from matplotlib import pyplot as plt
 import os
 import pandas as pd
-import numpy as np
 import random
 import re
 import shutil
@@ -24,6 +23,7 @@ d2l = sys.modules[__name__]
 
 
 # Defined in file: ./chapter_preface/index.md
+import numpy as np
 import torch
 import torchvision
 from torch import nn


### PR DESCRIPTION
*Description of changes:*
numpy import is needed in pytorch and tensorflow d2l libraries as well specifically for the `Timer` class which is used later in the book. It was probably removed in [this commit](https://github.com/d2l-ai/d2l-en/commit/91072b379ebb9fdea1faf64339334f07a6a2738e#diff-7199ea3162d85ba4377898f52160727b) because mxnet uses its own version of numpy array but other libraries don't have that. Thus it is required.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
