### PR TITLE
Remove tf.cast & change torch.Tensor to torch.tensor  

### DIFF
--- a/chapter_convolutional-neural-networks/channels.md
+++ b/chapter_convolutional-neural-networks/channels.md
@@ -105,21 +105,47 @@ corr2d_multi_in(X, K)
 ```{.python .input}
 #@tab pytorch
 X = torch.tensor([[[0, 1, 2], [3, 4, 5], [6, 7, 8]],
-                  [[1, 2, 3], [4, 5, 6], [7, 8, 9]]])
+                  [[1, 2, 3], [4, 5, 6], [7, 8, 9]]], dtype=torch.float32)
 K = torch.tensor([[[0, 1], [2, 3]],
-                  [[1, 2], [3, 4]]])
+                  [[1, 2], [3, 4]]], dtype=torch.float32)
 
 corr2d_multi_in(X, K)
+```
+
+```{.json .output n=12}
+[
+ {
+  "data": {
+   "text/plain": "tensor([[ 56.,  72.],\n        [104., 120.]])"
+  },
+  "execution_count": 12,
+  "metadata": {},
+  "output_type": "execute_result"
+ }
+]
 ```
 
 ```{.python .input}
 #@tab tensorflow
 X = tf.constant([[[0, 1, 2], [3, 4, 5], [6, 7, 8]],
-                 [[1, 2, 3], [4, 5, 6], [7, 8, 9]]])
+                 [[1, 2, 3], [4, 5, 6], [7, 8, 9]]], dtype=tf.float32)
 K = tf.constant([[[0, 1], [2, 3]],
-                 [[1, 2], [3, 4]]])
+                 [[1, 2], [3, 4]]], dtype=tf.float32)
 
 corr2d_multi_in(X, K)
+```
+
+```{.json .output n=5}
+[
+ {
+  "data": {
+   "text/plain": "<tf.Tensor: shape=(2, 2), dtype=float32, numpy=\narray([[ 56.,  72.],\n       [104., 120.]], dtype=float32)>"
+  },
+  "execution_count": 5,
+  "metadata": {},
+  "output_type": "execute_result"
+ }
+]
 ```
 
 ## Multiple Output Channels
@@ -198,10 +224,36 @@ K = torch.stack([K, K + 1, K + 2], dim=0)
 K.shape
 ```
 
+```{.json .output n=14}
+[
+ {
+  "data": {
+   "text/plain": "torch.Size([3, 2, 2, 2])"
+  },
+  "execution_count": 14,
+  "metadata": {},
+  "output_type": "execute_result"
+ }
+]
+```
+
 ```{.python .input}
 #@tab tensorflow
 K = tf.stack([K, K + 1, K + 2], axis=0)
 K.shape
+```
+
+```{.json .output n=7}
+[
+ {
+  "data": {
+   "text/plain": "TensorShape([3, 2, 2, 2])"
+  },
+  "execution_count": 7,
+  "metadata": {},
+  "output_type": "execute_result"
+ }
+]
 ```
 
 Below, we perform cross-correlation operations
@@ -215,6 +267,19 @@ single-output channel kernel.
 ```{.python .input}
 #@tab all
 corr2d_multi_in_out(X, K)
+```
+
+```{.json .output n=15}
+[
+ {
+  "data": {
+   "text/plain": "tensor([[[ 56.,  72.],\n         [104., 120.]],\n\n        [[ 76., 100.],\n         [148., 172.]],\n\n        [[ 96., 128.],\n         [192., 224.]]])"
+  },
+  "execution_count": 15,
+  "metadata": {},
+  "output_type": "execute_result"
+ }
+]
 ```
 
 ## $1\times 1$ Convolutional Layer
@@ -317,6 +382,19 @@ Y2 = corr2d_multi_in_out(X, K)
 (Y1 - Y2).norm().item() < 1e-6
 ```
 
+```{.json .output n=17}
+[
+ {
+  "data": {
+   "text/plain": "True"
+  },
+  "execution_count": 17,
+  "metadata": {},
+  "output_type": "execute_result"
+ }
+]
+```
+
 ```{.python .input}
 #@tab tensorflow
 X = tf.random.uniform((3, 3, 3))
@@ -326,6 +404,19 @@ Y1 = corr2d_multi_in_out_1x1(X, K)
 Y2 = corr2d_multi_in_out(X, K)
 
 tf.norm(Y1 - Y2) < 1e-6
+```
+
+```{.json .output n=10}
+[
+ {
+  "data": {
+   "text/plain": "<tf.Tensor: shape=(), dtype=bool, numpy=True>"
+  },
+  "execution_count": 10,
+  "metadata": {},
+  "output_type": "execute_result"
+ }
+]
 ```
 
 ## Summary

--- a/chapter_convolutional-neural-networks/channels.md
+++ b/chapter_convolutional-neural-networks/channels.md
@@ -112,19 +112,6 @@ K = torch.tensor([[[0, 1], [2, 3]],
 corr2d_multi_in(X, K)
 ```
 
-```{.json .output n=12}
-[
- {
-  "data": {
-   "text/plain": "tensor([[ 56.,  72.],\n        [104., 120.]])"
-  },
-  "execution_count": 12,
-  "metadata": {},
-  "output_type": "execute_result"
- }
-]
-```
-
 ```{.python .input}
 #@tab tensorflow
 X = tf.constant([[[0, 1, 2], [3, 4, 5], [6, 7, 8]],
@@ -133,19 +120,6 @@ K = tf.constant([[[0, 1], [2, 3]],
                  [[1, 2], [3, 4]]], dtype=tf.float32)
 
 corr2d_multi_in(X, K)
-```
-
-```{.json .output n=5}
-[
- {
-  "data": {
-   "text/plain": "<tf.Tensor: shape=(2, 2), dtype=float32, numpy=\narray([[ 56.,  72.],\n       [104., 120.]], dtype=float32)>"
-  },
-  "execution_count": 5,
-  "metadata": {},
-  "output_type": "execute_result"
- }
-]
 ```
 
 ## Multiple Output Channels
@@ -224,36 +198,10 @@ K = torch.stack([K, K + 1, K + 2], dim=0)
 K.shape
 ```
 
-```{.json .output n=14}
-[
- {
-  "data": {
-   "text/plain": "torch.Size([3, 2, 2, 2])"
-  },
-  "execution_count": 14,
-  "metadata": {},
-  "output_type": "execute_result"
- }
-]
-```
-
 ```{.python .input}
 #@tab tensorflow
 K = tf.stack([K, K + 1, K + 2], axis=0)
 K.shape
-```
-
-```{.json .output n=7}
-[
- {
-  "data": {
-   "text/plain": "TensorShape([3, 2, 2, 2])"
-  },
-  "execution_count": 7,
-  "metadata": {},
-  "output_type": "execute_result"
- }
-]
 ```
 
 Below, we perform cross-correlation operations
@@ -267,19 +215,6 @@ single-output channel kernel.
 ```{.python .input}
 #@tab all
 corr2d_multi_in_out(X, K)
-```
-
-```{.json .output n=15}
-[
- {
-  "data": {
-   "text/plain": "tensor([[[ 56.,  72.],\n         [104., 120.]],\n\n        [[ 76., 100.],\n         [148., 172.]],\n\n        [[ 96., 128.],\n         [192., 224.]]])"
-  },
-  "execution_count": 15,
-  "metadata": {},
-  "output_type": "execute_result"
- }
-]
 ```
 
 ## $1\times 1$ Convolutional Layer
@@ -382,19 +317,6 @@ Y2 = corr2d_multi_in_out(X, K)
 (Y1 - Y2).norm().item() < 1e-6
 ```
 
-```{.json .output n=17}
-[
- {
-  "data": {
-   "text/plain": "True"
-  },
-  "execution_count": 17,
-  "metadata": {},
-  "output_type": "execute_result"
- }
-]
-```
-
 ```{.python .input}
 #@tab tensorflow
 X = tf.random.uniform((3, 3, 3))
@@ -404,19 +326,6 @@ Y1 = corr2d_multi_in_out_1x1(X, K)
 Y2 = corr2d_multi_in_out(X, K)
 
 tf.norm(Y1 - Y2) < 1e-6
-```
-
-```{.json .output n=10}
-[
- {
-  "data": {
-   "text/plain": "<tf.Tensor: shape=(), dtype=bool, numpy=True>"
-  },
-  "execution_count": 10,
-  "metadata": {},
-  "output_type": "execute_result"
- }
-]
 ```
 
 ## Summary

--- a/chapter_convolutional-neural-networks/conv-layer.md
+++ b/chapter_convolutional-neural-networks/conv-layer.md
@@ -129,19 +129,6 @@ K = np.array([[0, 1], [2, 3]])
 corr2d(X, K)
 ```
 
-```{.json .output n=48}
-[
- {
-  "data": {
-   "text/plain": "array([[19., 25.],\n       [37., 43.]])"
-  },
-  "execution_count": 48,
-  "metadata": {},
-  "output_type": "execute_result"
- }
-]
-```
-
 ```{.python .input}
 #@tab pytorch
 X = torch.tensor([[0, 1, 2], [3, 4, 5], [6, 7, 8]], dtype=torch.float32)
@@ -149,37 +136,11 @@ K = torch.tensor([[0, 1], [2, 3]], dtype=torch.float32)
 corr2d(X, K)
 ```
 
-```{.json .output n=30}
-[
- {
-  "data": {
-   "text/plain": "tensor([[19., 25.],\n        [37., 43.]])"
-  },
-  "execution_count": 30,
-  "metadata": {},
-  "output_type": "execute_result"
- }
-]
-```
-
 ```{.python .input}
 #@tab tensorflow
 X = tf.constant([[0, 1, 2], [3, 4, 5], [6, 7, 8]], dtype=tf.float32)
 K = tf.constant([[0, 1], [2, 3]], dtype=tf.float32)
 corr2d(X, K)
-```
-
-```{.json .output n=39}
-[
- {
-  "data": {
-   "text/plain": "<tf.Variable 'Variable:0' shape=(2, 2) dtype=float32, numpy=\narray([[19., 25.],\n       [37., 43.]], dtype=float32)>"
-  },
-  "execution_count": 39,
-  "metadata": {},
-  "output_type": "execute_result"
- }
-]
 ```
 
 ## Convolutional Layers
@@ -254,19 +215,6 @@ X[:, 2:6] = 0
 X
 ```
 
-```{.json .output n=50}
-[
- {
-  "data": {
-   "text/plain": "array([[1., 1., 0., 0., 0., 0., 1., 1.],\n       [1., 1., 0., 0., 0., 0., 1., 1.],\n       [1., 1., 0., 0., 0., 0., 1., 1.],\n       [1., 1., 0., 0., 0., 0., 1., 1.],\n       [1., 1., 0., 0., 0., 0., 1., 1.],\n       [1., 1., 0., 0., 0., 0., 1., 1.]])"
-  },
-  "execution_count": 50,
-  "metadata": {},
-  "output_type": "execute_result"
- }
-]
-```
-
 ```{.python .input}
 #@tab pytorch
 X = torch.ones(6, 8)
@@ -274,37 +222,11 @@ X[:, 2:6] = 0
 X
 ```
 
-```{.json .output n=32}
-[
- {
-  "data": {
-   "text/plain": "tensor([[1., 1., 0., 0., 0., 0., 1., 1.],\n        [1., 1., 0., 0., 0., 0., 1., 1.],\n        [1., 1., 0., 0., 0., 0., 1., 1.],\n        [1., 1., 0., 0., 0., 0., 1., 1.],\n        [1., 1., 0., 0., 0., 0., 1., 1.],\n        [1., 1., 0., 0., 0., 0., 1., 1.]])"
-  },
-  "execution_count": 32,
-  "metadata": {},
-  "output_type": "execute_result"
- }
-]
-```
-
 ```{.python .input}
 #@tab tensorflow
 X = tf.Variable(tf.ones((6, 8)))
 X[:, 2:6].assign(tf.zeros(X[:, 2:6].shape))
 X
-```
-
-```{.json .output n=41}
-[
- {
-  "data": {
-   "text/plain": "<tf.Variable 'Variable:0' shape=(6, 8) dtype=float32, numpy=\narray([[1., 1., 0., 0., 0., 0., 1., 1.],\n       [1., 1., 0., 0., 0., 0., 1., 1.],\n       [1., 1., 0., 0., 0., 0., 1., 1.],\n       [1., 1., 0., 0., 0., 0., 1., 1.],\n       [1., 1., 0., 0., 0., 0., 1., 1.],\n       [1., 1., 0., 0., 0., 0., 1., 1.]], dtype=float32)>"
-  },
-  "execution_count": 41,
-  "metadata": {},
-  "output_type": "execute_result"
- }
-]
 ```
 
 Next, we construct a kernel `K` with a height of $1$ and width of $2$.
@@ -338,19 +260,6 @@ Y = corr2d(X, K)
 Y
 ```
 
-```{.json .output n=52}
-[
- {
-  "data": {
-   "text/plain": "array([[ 0.,  1.,  0.,  0.,  0., -1.,  0.],\n       [ 0.,  1.,  0.,  0.,  0., -1.,  0.],\n       [ 0.,  1.,  0.,  0.,  0., -1.,  0.],\n       [ 0.,  1.,  0.,  0.,  0., -1.,  0.],\n       [ 0.,  1.,  0.,  0.,  0., -1.,  0.],\n       [ 0.,  1.,  0.,  0.,  0., -1.,  0.]])"
-  },
-  "execution_count": 52,
-  "metadata": {},
-  "output_type": "execute_result"
- }
-]
-```
-
 We can now apply the kernel to the transposed image.
 As expected, it vanishes. The kernel `K` only detects vertical edges.
 
@@ -358,56 +267,14 @@ As expected, it vanishes. The kernel `K` only detects vertical edges.
 corr2d(X.T, K)
 ```
 
-```{.json .output n=53}
-[
- {
-  "data": {
-   "text/plain": "array([[0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.]])"
-  },
-  "execution_count": 53,
-  "metadata": {},
-  "output_type": "execute_result"
- }
-]
-```
-
 ```{.python .input}
 #@tab pytorch
 corr2d(X.t(), K)
 ```
 
-```{.json .output n=43}
-[
- {
-  "ename": "AttributeError",
-  "evalue": "'ResourceVariable' object has no attribute 't'",
-  "output_type": "error",
-  "traceback": [
-   "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-   "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-   "\u001b[0;32m<ipython-input-43-e776c5839792>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m#@tab pytorch\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mcorr2d\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mX\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mt\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mK\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-   "\u001b[0;31mAttributeError\u001b[0m: 'ResourceVariable' object has no attribute 't'"
-  ]
- }
-]
-```
-
 ```{.python .input}
 #@tab tensorflow
 corr2d(tf.transpose(X), K)
-```
-
-```{.json .output n=44}
-[
- {
-  "data": {
-   "text/plain": "<tf.Variable 'Variable:0' shape=(8, 5) dtype=float32, numpy=\narray([[0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.]], dtype=float32)>"
-  },
-  "execution_count": 44,
-  "metadata": {},
-  "output_type": "execute_result"
- }
-]
 ```
 
 ## Learning a Kernel
@@ -458,16 +325,6 @@ for i in range(10):
         print(f'batch {i+1}, loss {float(l.sum()):.3f}')
 ```
 
-```{.json .output n=54}
-[
- {
-  "name": "stdout",
-  "output_type": "stream",
-  "text": "batch 2, loss 4.949\nbatch 4, loss 0.831\nbatch 6, loss 0.140\nbatch 8, loss 0.024\nbatch 10, loss 0.004\n"
- }
-]
-```
-
 ```{.python .input}
 #@tab pytorch
 # Construct a convolutional layer with 1 input channel and 1 output channel
@@ -490,16 +347,6 @@ for i in range(10):
     conv2d.weight.data[:] -= 3e-2 * conv2d.weight.grad
     if (i + 1) % 2 == 0:
         print(f'batch {i+1}, loss {l.sum():.3f}')
-```
-
-```{.json .output n=36}
-[
- {
-  "name": "stdout",
-  "output_type": "stream",
-  "text": "batch 2, loss 9.349\nbatch 4, loss 1.570\nbatch 6, loss 0.264\nbatch 8, loss 0.044\nbatch 10, loss 0.008\n"
- }
-]
 ```
 
 ```{.python .input}
@@ -530,33 +377,10 @@ for i in range(10):
             print(f'batch {i+1}, loss {tf.reduce_sum(l):.3f}')
 ```
 
-```{.json .output n=45}
-[
- {
-  "name": "stdout",
-  "output_type": "stream",
-  "text": "batch 2, loss 1.837\nbatch 4, loss 0.663\nbatch 6, loss 0.257\nbatch 8, loss 0.103\nbatch 10, loss 0.042\n"
- }
-]
-```
-
 Note that the error has dropped to a small value after 10 iterations. Now we will take a look at the kernel array we learned.
 
 ```{.python .input}
 conv2d.weight.data().reshape(1, 2)
-```
-
-```{.json .output n=55}
-[
- {
-  "data": {
-   "text/plain": "array([[ 0.9895   , -0.9873705]])"
-  },
-  "execution_count": 55,
-  "metadata": {},
-  "output_type": "execute_result"
- }
-]
 ```
 
 ```{.python .input}
@@ -564,35 +388,9 @@ conv2d.weight.data().reshape(1, 2)
 conv2d.weight.data.reshape((1, 2))
 ```
 
-```{.json .output n=37}
-[
- {
-  "data": {
-   "text/plain": "tensor([[ 0.9830, -0.9853]])"
-  },
-  "execution_count": 37,
-  "metadata": {},
-  "output_type": "execute_result"
- }
-]
-```
-
 ```{.python .input}
 #@tab tensorflow
 tf.reshape(conv2d.get_weights()[0], (1, 2))
-```
-
-```{.json .output n=46}
-[
- {
-  "data": {
-   "text/plain": "<tf.Tensor: shape=(1, 2), dtype=float32, numpy=array([[ 0.9758461, -1.0178485]], dtype=float32)>"
-  },
-  "execution_count": 46,
-  "metadata": {},
-  "output_type": "execute_result"
- }
-]
 ```
 
 Indeed, the learned kernel array is remarkably close

--- a/chapter_convolutional-neural-networks/conv-layer.md
+++ b/chapter_convolutional-neural-networks/conv-layer.md
@@ -113,8 +113,8 @@ def corr2d(X, K):  #@save
     Y = tf.Variable(tf.zeros((X.shape[0] - h + 1, X.shape[1] - w + 1)))
     for i in range(Y.shape[0]):
         for j in range(Y.shape[1]):
-            Y[i, j].assign(tf.cast(tf.reduce_sum(
-                X[i: i + h, j: j + w] * K), dtype=tf.float32))
+            Y[i, j].assign(tf.reduce_sum(
+                X[i: i + h, j: j + w] * K))
     return Y
 ```
 
@@ -129,18 +129,57 @@ K = np.array([[0, 1], [2, 3]])
 corr2d(X, K)
 ```
 
+```{.json .output n=48}
+[
+ {
+  "data": {
+   "text/plain": "array([[19., 25.],\n       [37., 43.]])"
+  },
+  "execution_count": 48,
+  "metadata": {},
+  "output_type": "execute_result"
+ }
+]
+```
+
 ```{.python .input}
 #@tab pytorch
-X = torch.Tensor([[0, 1, 2], [3, 4, 5], [6, 7, 8]])
-K = torch.Tensor([[0, 1], [2, 3]])
+X = torch.tensor([[0, 1, 2], [3, 4, 5], [6, 7, 8]], dtype=torch.float32)
+K = torch.tensor([[0, 1], [2, 3]], dtype=torch.float32)
 corr2d(X, K)
+```
+
+```{.json .output n=30}
+[
+ {
+  "data": {
+   "text/plain": "tensor([[19., 25.],\n        [37., 43.]])"
+  },
+  "execution_count": 30,
+  "metadata": {},
+  "output_type": "execute_result"
+ }
+]
 ```
 
 ```{.python .input}
 #@tab tensorflow
-X = tf.constant([[0.0, 1, 2], [3, 4, 5], [6, 7, 8]])
-K = tf.constant([[0.0, 1], [2, 3]])
+X = tf.constant([[0, 1, 2], [3, 4, 5], [6, 7, 8]], dtype=tf.float32)
+K = tf.constant([[0, 1], [2, 3]], dtype=tf.float32)
 corr2d(X, K)
+```
+
+```{.json .output n=39}
+[
+ {
+  "data": {
+   "text/plain": "<tf.Variable 'Variable:0' shape=(2, 2) dtype=float32, numpy=\narray([[19., 25.],\n       [37., 43.]], dtype=float32)>"
+  },
+  "execution_count": 39,
+  "metadata": {},
+  "output_type": "execute_result"
+ }
+]
 ```
 
 ## Convolutional Layers
@@ -215,6 +254,19 @@ X[:, 2:6] = 0
 X
 ```
 
+```{.json .output n=50}
+[
+ {
+  "data": {
+   "text/plain": "array([[1., 1., 0., 0., 0., 0., 1., 1.],\n       [1., 1., 0., 0., 0., 0., 1., 1.],\n       [1., 1., 0., 0., 0., 0., 1., 1.],\n       [1., 1., 0., 0., 0., 0., 1., 1.],\n       [1., 1., 0., 0., 0., 0., 1., 1.],\n       [1., 1., 0., 0., 0., 0., 1., 1.]])"
+  },
+  "execution_count": 50,
+  "metadata": {},
+  "output_type": "execute_result"
+ }
+]
+```
+
 ```{.python .input}
 #@tab pytorch
 X = torch.ones(6, 8)
@@ -222,11 +274,37 @@ X[:, 2:6] = 0
 X
 ```
 
+```{.json .output n=32}
+[
+ {
+  "data": {
+   "text/plain": "tensor([[1., 1., 0., 0., 0., 0., 1., 1.],\n        [1., 1., 0., 0., 0., 0., 1., 1.],\n        [1., 1., 0., 0., 0., 0., 1., 1.],\n        [1., 1., 0., 0., 0., 0., 1., 1.],\n        [1., 1., 0., 0., 0., 0., 1., 1.],\n        [1., 1., 0., 0., 0., 0., 1., 1.]])"
+  },
+  "execution_count": 32,
+  "metadata": {},
+  "output_type": "execute_result"
+ }
+]
+```
+
 ```{.python .input}
 #@tab tensorflow
 X = tf.Variable(tf.ones((6, 8)))
 X[:, 2:6].assign(tf.zeros(X[:, 2:6].shape))
 X
+```
+
+```{.json .output n=41}
+[
+ {
+  "data": {
+   "text/plain": "<tf.Variable 'Variable:0' shape=(6, 8) dtype=float32, numpy=\narray([[1., 1., 0., 0., 0., 0., 1., 1.],\n       [1., 1., 0., 0., 0., 0., 1., 1.],\n       [1., 1., 0., 0., 0., 0., 1., 1.],\n       [1., 1., 0., 0., 0., 0., 1., 1.],\n       [1., 1., 0., 0., 0., 0., 1., 1.],\n       [1., 1., 0., 0., 0., 0., 1., 1.]], dtype=float32)>"
+  },
+  "execution_count": 41,
+  "metadata": {},
+  "output_type": "execute_result"
+ }
+]
 ```
 
 Next, we construct a kernel `K` with a height of $1$ and width of $2$.
@@ -240,12 +318,12 @@ K = np.array([[1, -1]])
 
 ```{.python .input}
 #@tab pytorch
-K = torch.Tensor([[1, -1]])
+K = torch.tensor([[1, -1]], dtype=torch.float32)
 ```
 
 ```{.python .input}
 #@tab tensorflow
-K = tf.constant([[1., -1.]])
+K = tf.constant([[1, -1]], dtype=tf.float32)
 ```
 
 We are ready to perform the cross-correlation operation
@@ -260,6 +338,19 @@ Y = corr2d(X, K)
 Y
 ```
 
+```{.json .output n=52}
+[
+ {
+  "data": {
+   "text/plain": "array([[ 0.,  1.,  0.,  0.,  0., -1.,  0.],\n       [ 0.,  1.,  0.,  0.,  0., -1.,  0.],\n       [ 0.,  1.,  0.,  0.,  0., -1.,  0.],\n       [ 0.,  1.,  0.,  0.,  0., -1.,  0.],\n       [ 0.,  1.,  0.,  0.,  0., -1.,  0.],\n       [ 0.,  1.,  0.,  0.,  0., -1.,  0.]])"
+  },
+  "execution_count": 52,
+  "metadata": {},
+  "output_type": "execute_result"
+ }
+]
+```
+
 We can now apply the kernel to the transposed image.
 As expected, it vanishes. The kernel `K` only detects vertical edges.
 
@@ -267,14 +358,56 @@ As expected, it vanishes. The kernel `K` only detects vertical edges.
 corr2d(X.T, K)
 ```
 
+```{.json .output n=53}
+[
+ {
+  "data": {
+   "text/plain": "array([[0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.]])"
+  },
+  "execution_count": 53,
+  "metadata": {},
+  "output_type": "execute_result"
+ }
+]
+```
+
 ```{.python .input}
 #@tab pytorch
 corr2d(X.t(), K)
 ```
 
+```{.json .output n=43}
+[
+ {
+  "ename": "AttributeError",
+  "evalue": "'ResourceVariable' object has no attribute 't'",
+  "output_type": "error",
+  "traceback": [
+   "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+   "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+   "\u001b[0;32m<ipython-input-43-e776c5839792>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m#@tab pytorch\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mcorr2d\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mX\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mt\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mK\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+   "\u001b[0;31mAttributeError\u001b[0m: 'ResourceVariable' object has no attribute 't'"
+  ]
+ }
+]
+```
+
 ```{.python .input}
 #@tab tensorflow
 corr2d(tf.transpose(X), K)
+```
+
+```{.json .output n=44}
+[
+ {
+  "data": {
+   "text/plain": "<tf.Variable 'Variable:0' shape=(8, 5) dtype=float32, numpy=\narray([[0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.],\n       [0., 0., 0., 0., 0.]], dtype=float32)>"
+  },
+  "execution_count": 44,
+  "metadata": {},
+  "output_type": "execute_result"
+ }
+]
 ```
 
 ## Learning a Kernel
@@ -325,6 +458,16 @@ for i in range(10):
         print(f'batch {i+1}, loss {float(l.sum()):.3f}')
 ```
 
+```{.json .output n=54}
+[
+ {
+  "name": "stdout",
+  "output_type": "stream",
+  "text": "batch 2, loss 4.949\nbatch 4, loss 0.831\nbatch 6, loss 0.140\nbatch 8, loss 0.024\nbatch 10, loss 0.004\n"
+ }
+]
+```
+
 ```{.python .input}
 #@tab pytorch
 # Construct a convolutional layer with 1 input channel and 1 output channel
@@ -347,6 +490,16 @@ for i in range(10):
     conv2d.weight.data[:] -= 3e-2 * conv2d.weight.grad
     if (i + 1) % 2 == 0:
         print(f'batch {i+1}, loss {l.sum():.3f}')
+```
+
+```{.json .output n=36}
+[
+ {
+  "name": "stdout",
+  "output_type": "stream",
+  "text": "batch 2, loss 9.349\nbatch 4, loss 1.570\nbatch 6, loss 0.264\nbatch 8, loss 0.044\nbatch 10, loss 0.008\n"
+ }
+]
 ```
 
 ```{.python .input}
@@ -377,10 +530,33 @@ for i in range(10):
             print(f'batch {i+1}, loss {tf.reduce_sum(l):.3f}')
 ```
 
+```{.json .output n=45}
+[
+ {
+  "name": "stdout",
+  "output_type": "stream",
+  "text": "batch 2, loss 1.837\nbatch 4, loss 0.663\nbatch 6, loss 0.257\nbatch 8, loss 0.103\nbatch 10, loss 0.042\n"
+ }
+]
+```
+
 Note that the error has dropped to a small value after 10 iterations. Now we will take a look at the kernel array we learned.
 
 ```{.python .input}
 conv2d.weight.data().reshape(1, 2)
+```
+
+```{.json .output n=55}
+[
+ {
+  "data": {
+   "text/plain": "array([[ 0.9895   , -0.9873705]])"
+  },
+  "execution_count": 55,
+  "metadata": {},
+  "output_type": "execute_result"
+ }
+]
 ```
 
 ```{.python .input}
@@ -388,9 +564,35 @@ conv2d.weight.data().reshape(1, 2)
 conv2d.weight.data.reshape((1, 2))
 ```
 
+```{.json .output n=37}
+[
+ {
+  "data": {
+   "text/plain": "tensor([[ 0.9830, -0.9853]])"
+  },
+  "execution_count": 37,
+  "metadata": {},
+  "output_type": "execute_result"
+ }
+]
+```
+
 ```{.python .input}
 #@tab tensorflow
 tf.reshape(conv2d.get_weights()[0], (1, 2))
+```
+
+```{.json .output n=46}
+[
+ {
+  "data": {
+   "text/plain": "<tf.Tensor: shape=(1, 2), dtype=float32, numpy=array([[ 0.9758461, -1.0178485]], dtype=float32)>"
+  },
+  "execution_count": 46,
+  "metadata": {},
+  "output_type": "execute_result"
+ }
+]
 ```
 
 Indeed, the learned kernel array is remarkably close

--- a/chapter_convolutional-neural-networks/conv-layer.md
+++ b/chapter_convolutional-neural-networks/conv-layer.md
@@ -73,7 +73,7 @@ Next, we implement this process in the `corr2d` function,
 which accepts the input array `X` and kernel array `K`
 and returns the output array `Y`.
 
-```{.python .input  n=47}
+```{.python .input}
 from mxnet import autograd, np, npx
 from mxnet.gluon import nn
 npx.set_np()
@@ -88,7 +88,7 @@ def corr2d(X, K):  #@save
     return Y
 ```
 
-```{.python .input  n=29}
+```{.python .input}
 #@tab pytorch
 import torch
 from torch import nn
@@ -103,7 +103,7 @@ def corr2d(X, K):  #@save
     return Y
 ```
 
-```{.python .input  n=38}
+```{.python .input}
 #@tab tensorflow
 import tensorflow as tf
 
@@ -123,7 +123,7 @@ from the figure above
 to validate the output of the above implementation
 of the two-dimensional cross-correlation operation.
 
-```{.python .input  n=48}
+```{.python .input}
 X = np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]])
 K = np.array([[0, 1], [2, 3]])
 corr2d(X, K)
@@ -142,7 +142,7 @@ corr2d(X, K)
 ]
 ```
 
-```{.python .input  n=30}
+```{.python .input}
 #@tab pytorch
 X = torch.tensor([[0, 1, 2], [3, 4, 5], [6, 7, 8]], dtype=torch.float32)
 K = torch.tensor([[0, 1], [2, 3]], dtype=torch.float32)
@@ -162,7 +162,7 @@ corr2d(X, K)
 ]
 ```
 
-```{.python .input  n=39}
+```{.python .input}
 #@tab tensorflow
 X = tf.constant([[0, 1, 2], [3, 4, 5], [6, 7, 8]], dtype=tf.float32)
 K = tf.constant([[0, 1], [2, 3]], dtype=tf.float32)
@@ -202,7 +202,7 @@ As with $h \times w$ cross-correlation
 we also refer to convolutional layers
 as $h \times w$ convolutions.
 
-```{.python .input  n=49}
+```{.python .input}
 class Conv2D(nn.Block):
     def __init__(self, kernel_size, **kwargs):
         super().__init__(**kwargs)
@@ -213,7 +213,7 @@ class Conv2D(nn.Block):
         return corr2d(x, self.weight.data()) + self.bias.data()
 ```
 
-```{.python .input  n=31}
+```{.python .input}
 #@tab pytorch
 class Conv2D(nn.Module):
     def __init__(self, kernel_size):
@@ -225,7 +225,7 @@ class Conv2D(nn.Module):
         return corr2d(x, self.weight) + self.bias
 ```
 
-```{.python .input  n=40}
+```{.python .input}
 #@tab tensorflow
 class Conv2D(tf.keras.layers.Layer):
     def __init__(self):
@@ -248,7 +248,7 @@ by finding the location of the pixel change.
 First, we construct an 'image' of $6\times 8$ pixels.
 The middle four columns are black (0) and the rest are white (1).
 
-```{.python .input  n=50}
+```{.python .input}
 X = np.ones((6, 8))
 X[:, 2:6] = 0
 X
@@ -267,7 +267,7 @@ X
 ]
 ```
 
-```{.python .input  n=32}
+```{.python .input}
 #@tab pytorch
 X = torch.ones(6, 8)
 X[:, 2:6] = 0
@@ -287,7 +287,7 @@ X
 ]
 ```
 
-```{.python .input  n=41}
+```{.python .input}
 #@tab tensorflow
 X = tf.Variable(tf.ones((6, 8)))
 X[:, 2:6].assign(tf.zeros(X[:, 2:6].shape))
@@ -312,16 +312,16 @@ When we perform the cross-correlation operation with the input,
 if the horizontally adjacent elements are the same,
 the output is 0. Otherwise, the output is non-zero.
 
-```{.python .input  n=51}
+```{.python .input}
 K = np.array([[1, -1]])
 ```
 
-```{.python .input  n=33}
+```{.python .input}
 #@tab pytorch
 K = torch.tensor([[1, -1]], dtype=torch.float32)
 ```
 
-```{.python .input  n=42}
+```{.python .input}
 #@tab tensorflow
 K = tf.constant([[1, -1]], dtype=tf.float32)
 ```
@@ -332,7 +332,7 @@ As you can see, we detect 1 for the edge from white to black
 and -1 for the edge from black to white.
 All other outputs take value $0$.
 
-```{.python .input  n=52}
+```{.python .input}
 #@tab all
 Y = corr2d(X, K)
 Y
@@ -354,7 +354,7 @@ Y
 We can now apply the kernel to the transposed image.
 As expected, it vanishes. The kernel `K` only detects vertical edges.
 
-```{.python .input  n=53}
+```{.python .input}
 corr2d(X.T, K)
 ```
 
@@ -371,7 +371,7 @@ corr2d(X.T, K)
 ]
 ```
 
-```{.python .input  n=43}
+```{.python .input}
 #@tab pytorch
 corr2d(X.t(), K)
 ```
@@ -392,7 +392,7 @@ corr2d(X.t(), K)
 ]
 ```
 
-```{.python .input  n=44}
+```{.python .input}
 #@tab tensorflow
 corr2d(tf.transpose(X), K)
 ```
@@ -434,7 +434,7 @@ However, since we used single-element assignments,
 `autograd` has some trouble finding the gradient.
 Instead, we use the built-in `Conv2D` class.
 
-```{.python .input  n=54}
+```{.python .input}
 # Construct a convolutional layer with 1 output channel
 # (channels will be introduced in the following section)
 # and a kernel array shape of (1, 2)
@@ -468,7 +468,7 @@ for i in range(10):
 ]
 ```
 
-```{.python .input  n=36}
+```{.python .input}
 #@tab pytorch
 # Construct a convolutional layer with 1 input channel and 1 output channel
 # (channels will be introduced in the following section)
@@ -502,7 +502,7 @@ for i in range(10):
 ]
 ```
 
-```{.python .input  n=45}
+```{.python .input}
 #@tab tensorflow
 # Construct a convolutional layer with 1 input channel and 1 output channel
 # (channels will be introduced in the following section)
@@ -542,7 +542,7 @@ for i in range(10):
 
 Note that the error has dropped to a small value after 10 iterations. Now we will take a look at the kernel array we learned.
 
-```{.python .input  n=55}
+```{.python .input}
 conv2d.weight.data().reshape(1, 2)
 ```
 
@@ -559,7 +559,7 @@ conv2d.weight.data().reshape(1, 2)
 ]
 ```
 
-```{.python .input  n=37}
+```{.python .input}
 #@tab pytorch
 conv2d.weight.data.reshape((1, 2))
 ```
@@ -577,7 +577,7 @@ conv2d.weight.data.reshape((1, 2))
 ]
 ```
 
-```{.python .input  n=46}
+```{.python .input}
 #@tab tensorflow
 tf.reshape(conv2d.get_weights()[0], (1, 2))
 ```

--- a/chapter_convolutional-neural-networks/conv-layer.md
+++ b/chapter_convolutional-neural-networks/conv-layer.md
@@ -73,7 +73,7 @@ Next, we implement this process in the `corr2d` function,
 which accepts the input array `X` and kernel array `K`
 and returns the output array `Y`.
 
-```{.python .input}
+```{.python .input  n=47}
 from mxnet import autograd, np, npx
 from mxnet.gluon import nn
 npx.set_np()
@@ -88,7 +88,7 @@ def corr2d(X, K):  #@save
     return Y
 ```
 
-```{.python .input}
+```{.python .input  n=29}
 #@tab pytorch
 import torch
 from torch import nn
@@ -103,7 +103,7 @@ def corr2d(X, K):  #@save
     return Y
 ```
 
-```{.python .input}
+```{.python .input  n=38}
 #@tab tensorflow
 import tensorflow as tf
 
@@ -123,7 +123,7 @@ from the figure above
 to validate the output of the above implementation
 of the two-dimensional cross-correlation operation.
 
-```{.python .input}
+```{.python .input  n=48}
 X = np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]])
 K = np.array([[0, 1], [2, 3]])
 corr2d(X, K)
@@ -142,7 +142,7 @@ corr2d(X, K)
 ]
 ```
 
-```{.python .input}
+```{.python .input  n=30}
 #@tab pytorch
 X = torch.tensor([[0, 1, 2], [3, 4, 5], [6, 7, 8]], dtype=torch.float32)
 K = torch.tensor([[0, 1], [2, 3]], dtype=torch.float32)
@@ -162,7 +162,7 @@ corr2d(X, K)
 ]
 ```
 
-```{.python .input}
+```{.python .input  n=39}
 #@tab tensorflow
 X = tf.constant([[0, 1, 2], [3, 4, 5], [6, 7, 8]], dtype=tf.float32)
 K = tf.constant([[0, 1], [2, 3]], dtype=tf.float32)
@@ -202,7 +202,7 @@ As with $h \times w$ cross-correlation
 we also refer to convolutional layers
 as $h \times w$ convolutions.
 
-```{.python .input}
+```{.python .input  n=49}
 class Conv2D(nn.Block):
     def __init__(self, kernel_size, **kwargs):
         super().__init__(**kwargs)
@@ -213,7 +213,7 @@ class Conv2D(nn.Block):
         return corr2d(x, self.weight.data()) + self.bias.data()
 ```
 
-```{.python .input}
+```{.python .input  n=31}
 #@tab pytorch
 class Conv2D(nn.Module):
     def __init__(self, kernel_size):
@@ -225,7 +225,7 @@ class Conv2D(nn.Module):
         return corr2d(x, self.weight) + self.bias
 ```
 
-```{.python .input}
+```{.python .input  n=40}
 #@tab tensorflow
 class Conv2D(tf.keras.layers.Layer):
     def __init__(self):
@@ -248,7 +248,7 @@ by finding the location of the pixel change.
 First, we construct an 'image' of $6\times 8$ pixels.
 The middle four columns are black (0) and the rest are white (1).
 
-```{.python .input}
+```{.python .input  n=50}
 X = np.ones((6, 8))
 X[:, 2:6] = 0
 X
@@ -267,7 +267,7 @@ X
 ]
 ```
 
-```{.python .input}
+```{.python .input  n=32}
 #@tab pytorch
 X = torch.ones(6, 8)
 X[:, 2:6] = 0
@@ -287,7 +287,7 @@ X
 ]
 ```
 
-```{.python .input}
+```{.python .input  n=41}
 #@tab tensorflow
 X = tf.Variable(tf.ones((6, 8)))
 X[:, 2:6].assign(tf.zeros(X[:, 2:6].shape))
@@ -312,16 +312,16 @@ When we perform the cross-correlation operation with the input,
 if the horizontally adjacent elements are the same,
 the output is 0. Otherwise, the output is non-zero.
 
-```{.python .input}
+```{.python .input  n=51}
 K = np.array([[1, -1]])
 ```
 
-```{.python .input}
+```{.python .input  n=33}
 #@tab pytorch
 K = torch.tensor([[1, -1]], dtype=torch.float32)
 ```
 
-```{.python .input}
+```{.python .input  n=42}
 #@tab tensorflow
 K = tf.constant([[1, -1]], dtype=tf.float32)
 ```
@@ -332,7 +332,7 @@ As you can see, we detect 1 for the edge from white to black
 and -1 for the edge from black to white.
 All other outputs take value $0$.
 
-```{.python .input}
+```{.python .input  n=52}
 #@tab all
 Y = corr2d(X, K)
 Y
@@ -354,7 +354,7 @@ Y
 We can now apply the kernel to the transposed image.
 As expected, it vanishes. The kernel `K` only detects vertical edges.
 
-```{.python .input}
+```{.python .input  n=53}
 corr2d(X.T, K)
 ```
 
@@ -371,7 +371,7 @@ corr2d(X.T, K)
 ]
 ```
 
-```{.python .input}
+```{.python .input  n=43}
 #@tab pytorch
 corr2d(X.t(), K)
 ```
@@ -392,7 +392,7 @@ corr2d(X.t(), K)
 ]
 ```
 
-```{.python .input}
+```{.python .input  n=44}
 #@tab tensorflow
 corr2d(tf.transpose(X), K)
 ```
@@ -434,7 +434,7 @@ However, since we used single-element assignments,
 `autograd` has some trouble finding the gradient.
 Instead, we use the built-in `Conv2D` class.
 
-```{.python .input}
+```{.python .input  n=54}
 # Construct a convolutional layer with 1 output channel
 # (channels will be introduced in the following section)
 # and a kernel array shape of (1, 2)
@@ -468,7 +468,7 @@ for i in range(10):
 ]
 ```
 
-```{.python .input}
+```{.python .input  n=36}
 #@tab pytorch
 # Construct a convolutional layer with 1 input channel and 1 output channel
 # (channels will be introduced in the following section)
@@ -502,7 +502,7 @@ for i in range(10):
 ]
 ```
 
-```{.python .input}
+```{.python .input  n=45}
 #@tab tensorflow
 # Construct a convolutional layer with 1 input channel and 1 output channel
 # (channels will be introduced in the following section)
@@ -542,7 +542,7 @@ for i in range(10):
 
 Note that the error has dropped to a small value after 10 iterations. Now we will take a look at the kernel array we learned.
 
-```{.python .input}
+```{.python .input  n=55}
 conv2d.weight.data().reshape(1, 2)
 ```
 
@@ -559,7 +559,7 @@ conv2d.weight.data().reshape(1, 2)
 ]
 ```
 
-```{.python .input}
+```{.python .input  n=37}
 #@tab pytorch
 conv2d.weight.data.reshape((1, 2))
 ```
@@ -577,7 +577,7 @@ conv2d.weight.data.reshape((1, 2))
 ]
 ```
 
-```{.python .input}
+```{.python .input  n=46}
 #@tab tensorflow
 tf.reshape(conv2d.get_weights()[0], (1, 2))
 ```

--- a/d2l/tensorflow.py
+++ b/d2l/tensorflow.py
@@ -428,8 +428,8 @@ def corr2d(X, K):  #@save
     Y = tf.Variable(tf.zeros((X.shape[0] - h + 1, X.shape[1] - w + 1)))
     for i in range(Y.shape[0]):
         for j in range(Y.shape[1]):
-            Y[i, j].assign(tf.cast(tf.reduce_sum(
-                X[i: i + h, j: j + w] * K), dtype=tf.float32))
+            Y[i, j].assign(tf.reduce_sum(
+                X[i: i + h, j: j + w] * K))
     return Y
 
 
@@ -479,7 +479,7 @@ class Residual(tf.keras.Model):  #@save
         self.conv1 = tf.keras.layers.Conv2D(
             num_channels, padding='same', kernel_size=3, strides=strides)
         self.conv2 = tf.keras.layers.Conv2D(
-            num_channels, kernel_size=3,padding='same')
+            num_channels, kernel_size=3, padding='same')
         self.conv3 = None
         if use_1x1conv:
             self.conv3 = tf.keras.layers.Conv2D(
@@ -493,6 +493,6 @@ class Residual(tf.keras.Model):  #@save
         if self.conv3 is not None:
             X = self.conv3(X)
         Y += X
-        return tf.keras.activations.relu(Y + X)
+        return tf.keras.activations.relu(Y)
 
 


### PR DESCRIPTION
*Description of changes:*
This PR removes the use of tf.cast in the function corr2d.
Also changes the `torch.Tensor` to `torch.tensor` which is standard across the book.
Adds explicitly the dtypes in tf and torch to make more interpretable and to remove `tf.cast` extra step in `corr2d`.

This also fixes Resnet class in tensorflow. 

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
