### PR TITLE
[TF] Remove warnings and training progress in kaggle-house-price.md

### DIFF
--- a/chapter_multilayer-perceptrons/kaggle-house-price.md
+++ b/chapter_multilayer-perceptrons/kaggle-house-price.md
@@ -351,10 +351,10 @@ train_labels = torch.tensor(train_data.SalePrice.values,
 ```{.python .input}
 #@tab tensorflow
 n_train = train_data.shape[0]
-train_features = np.array(all_features[:n_train].values, dtype=np.float)
-test_features = np.array(all_features[n_train:].values, dtype=np.float)
+train_features = np.array(all_features[:n_train].values, dtype=np.float32)
+test_features = np.array(all_features[n_train:].values, dtype=np.float32)
 train_labels = np.array(train_data.SalePrice.values.reshape(-1, 1), 
-                        dtype=np.float)
+                        dtype=np.float32)
 ```
 
 ## Training
@@ -525,7 +525,8 @@ def train(net, train_features, train_labels, test_features, test_labels,
     optimizer = tf.keras.optimizers.Adam(learning_rate)
     net.compile(loss=log_rmse, optimizer=optimizer)
     history = net.fit(train_iter, validation_data=test_iter,
-        epochs=num_epochs, batch_size=batch_size, validation_freq=1)
+        epochs=num_epochs, batch_size=batch_size,
+        validation_freq=1, verbose=0)
     train_ls = history.history['loss']
     if test_features is not None:
         test_ls = history.history['val_loss']


### PR DESCRIPTION
Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

*Description of changes:*

This PR removes the following logs:
```
Epoch 1/100
WARNING:tensorflow:Layer dense is casting an input tensor from dtype float64 to the layer's dtype of float32, which is new behavior in TensorFlow 2.  The layer has dtype float32 because it's dtype defaults to floatx.

If you intended to run this layer in float32, you can safely ignore this warning. If in doubt, this warning is likely only an issue if you are porting a TensorFlow 1.X model to TensorFlow 2.

To change all layers to have dtype float64 by default, call tf.keras.backend.set_floatx('float64'). To change just this layer, pass dtype='float64' to the layer constructor. If you are the author of this layer, you can disable autocasting by passing autocast=False to the base Layer constructor.

19/19 [==============================] - 0s 9ms/step - loss: 0.7085 - val_loss: 0.5878
Epoch 2/100
19/19 [==============================] - 0s 2ms/step - loss: 0.5661 - val_loss: 0.5495
Epoch 3/100
```


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
