### PR TITLE
Rename Ant Financial to Ant Group

### DIFF
--- a/static/frontpage/frontpage.html
+++ b/static/frontpage/frontpage.html
@@ -313,7 +313,7 @@ a {
     <div class="author-item">
       <img src="https://terrytangyuan.github.io/img/avatar.jpg"/>
       <h3><a href="https://terrytangyuan.github.io/about/">Yuan Tang</a></h3>
-      <p>Ant Financial Senior Engineer<br><i>TensorFlow Adaptation</i></p>
+      <p>Ant Group Senior Engineer<br><i>TensorFlow Adaptation</i></p>
     </div>
   </div>
 


### PR DESCRIPTION
*Description of changes:* It's now renamed to be Ant Group (short for Ant Financial Services Group).


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
