### PR TITLE
Small edits to tensorflow examples in the earlier chapters.

### DIFF
--- a/chapter_convolutional-neural-networks/pooling.md
+++ b/chapter_convolutional-neural-networks/pooling.md
@@ -202,7 +202,7 @@ print(X)
 # Note that TensorFlow has default data format "channels_last" which corresponds to inputs
 # with shape " so here the shape (batch_size, height, width, channels) so here the shape
 # should be (1, 4, 4, 1) instead of (1, 1, 4, 4).
-X = tf.reshape(tf.constant(range(16), dtype=tf.float32), (1, 4, 4, 1))
+X = tf.reshape(tf.range(16, dtype=tf.float32), (1, 4, 4, 1))
 X
 ```
 

--- a/chapter_deep-learning-computation/read-write.md
+++ b/chapter_deep-learning-computation/read-write.md
@@ -46,7 +46,7 @@ torch.save(x,"x-file")
 import tensorflow as tf
 import numpy as np
 
-x = tf.constant(range(4))
+x = tf.range(4)
 np.save("x-file.npy", x)
 ```
 

--- a/chapter_linear-networks/linear-regression-concise.md
+++ b/chapter_linear-networks/linear-regression-concise.md
@@ -432,7 +432,7 @@ for epoch in range(num_epochs):
 num_epochs = 3
 for epoch in range(num_epochs):
     for X, y in data_iter:
-        with tf.GradientTape(persistent=True) as tape:
+        with tf.GradientTape() as tape:
             l = loss(net(X, training=True), y)
         grads = tape.gradient(l, net.trainable_variables)
         trainer.apply_gradients(zip(grads, net.trainable_variables))

--- a/chapter_multilayer-perceptrons/dropout.md
+++ b/chapter_multilayer-perceptrons/dropout.md
@@ -317,7 +317,7 @@ print(dropout_layer(X, 1.))
 
 ```{.python .input}
 #@tab tensorflow
-X = tf.reshape(tf.constant(range(16), dtype=tf.float32), (2, 8))
+X = tf.reshape(tf.range(16, dtype=tf.float32), (2, 8))
 print(X)
 print(dropout_layer(X, 0.))
 print(dropout_layer(X, 0.5))

--- a/chapter_multilayer-perceptrons/weight-decay.md
+++ b/chapter_multilayer-perceptrons/weight-decay.md
@@ -357,7 +357,7 @@ def train(lambd):
                             xlim=[1, num_epochs], legend=['train', 'test'])
     for epoch in range(1, num_epochs + 1):
         for X, y in train_iter:
-            with tf.GradientTape(persistent=True) as tape:
+            with tf.GradientTape() as tape:
                 # The L2 norm penalty term has been added, and broadcasting
                 # makes l2_penalty(w) a vector whose length is batch_size
                 l = loss(net(X), y) + lambd * l2_penalty(w)

--- a/chapter_preliminaries/autograd.md
+++ b/chapter_preliminaries/autograd.md
@@ -55,7 +55,7 @@ x
 
 ```{.python .input}
 #@tab tensorflow
-x = tf.constant(range(4), dtype=tf.float32)
+x = tf.range(4, dtype=tf.float32)
 x
 ```
 
@@ -180,7 +180,7 @@ x.grad
 #@tab tensorflow
 with tf.GradientTape() as t:
     y = tf.reduce_sum(x)
-t.gradient(y, x)  # Overwritten by the newly calculated gradient.
+t.gradient(y, x)
 ```
 
 ## Backward for Non-Scalar Variables

--- a/chapter_preliminaries/linear-algebra.md
+++ b/chapter_preliminaries/linear-algebra.md
@@ -114,7 +114,7 @@ x
 
 ```{.python .input}
 #@tab tensorflow
-x = tf.constant(range(4))
+x = tf.range(4)
 x
 ```
 
@@ -171,7 +171,7 @@ len(x)
 
 ```{.python .input}
 #@tab tensorflow
-tf.size(x)  # TensorFlow doesn't have a len function.
+len(x)
 ```
 
 When a tensor represents a vector (with precisely one axis),
@@ -243,7 +243,7 @@ A
 
 ```{.python .input}
 #@tab tensorflow
-A = tf.reshape(tf.constant(range(20)), (5, 4))
+A = tf.reshape(tf.range(20), (5, 4))
 A
 ```
 
@@ -367,7 +367,7 @@ X
 
 ```{.python .input}
 #@tab tensorflow
-X = tf.reshape(tf.constant(range(24)), (2, 3, 4))
+X = tf.reshape(tf.range(24), (2, 3, 4))
 X
 ```
 
@@ -400,8 +400,8 @@ A, A + B
 
 ```{.python .input}
 #@tab tensorflow
-A = tf.reshape(tf.constant(range(20), dtype=tf.float32), (5, 4))
-B = tf.identity(A)  # Assign a copy of `A` to `B` by allocating new memory
+A = tf.reshape(tf.range(20, dtype=tf.float32), (5, 4))
+B = A  # No cloning of `A` to `B` by allocating new memory
 A, A + B
 ```
 
@@ -451,7 +451,7 @@ a + X, (a * X).shape
 ```{.python .input}
 #@tab tensorflow
 a = 2
-X = tf.reshape(tf.constant(range(24)), (2, 3, 4))
+X = tf.reshape(tf.range(24), (2, 3, 4))
 a + X, (a * X).shape
 ```
 
@@ -478,7 +478,7 @@ x, x.sum()
 
 ```{.python .input}
 #@tab tensorflow
-x = tf.constant(range(4), dtype=tf.float32)
+x = tf.range(4, dtype=tf.float32)
 x, tf.reduce_sum(x)
 ```
 
@@ -951,7 +951,7 @@ torch.abs(u).sum()
 
 ```{.python .input}
 #@tab tensorflow
-sum(tf.abs(u))
+tf.reduce_sum(tf.abs(u))
 ```
 
 Both the $\ell_2$ norm and the $\ell_1$ norm

--- a/chapter_preliminaries/ndarray.md
+++ b/chapter_preliminaries/ndarray.md
@@ -97,7 +97,7 @@ x
 
 ```{.python .input}
 #@tab tensorflow
-x = tf.constant(range(12))
+x = tf.range(12)
 x
 ```
 
@@ -355,7 +355,7 @@ torch.cat((x, y), dim=0), torch.cat((x, y), dim=1)
 
 ```{.python .input}
 #@tab tensorflow
-x = tf.constant(range(12), dtype=tf.float32, shape=(3, 4))
+x = tf.reshape(tf.range(12, dtype=tf.float32), (3, 4))
 y = tf.constant([[2.0, 1, 4, 3], [1, 2, 3, 4], [4, 3, 2, 1]])
 tf.concat([x, y], axis=0), tf.concat([x, y], axis=1)
 ```
@@ -417,8 +417,8 @@ a, b
 
 ```{.python .input}
 #@tab tensorflow
-a = tf.constant(range(3), shape=(3, 1))
-b = tf.constant(range(2), shape=(1, 2))
+a = tf.reshape(tf.range(3), (3, 1))
+b = tf.reshape(tf.range(2), (1, 2))
 a, b
 ```
 


### PR DESCRIPTION
These include:
* Switching tf.constant(range()) to tf.range
* Changing an incorrect note that tensorflow doesn't support `len`
* removing unnecessary `persistent=True` in gradienttapes that don't compute a gradient more than once.
* replacing a `sum` with a `tf.reduce_sum` for consistency (and more performant)


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
