### PR TITLE
[TF] Add missing TensorFlow tab in API document page

### DIFF
--- a/chapter_appendix-tools-for-deep-learning/d2l.md
+++ b/chapter_appendix-tools-for-deep-learning/d2l.md
@@ -27,3 +27,16 @@ The implementations of the following members of the `d2l` package and sections w
 ```
 
 :end_tab:
+
+
+:begin_tab:`tensorflow`
+
+```eval_rst
+
+.. automodule:: d2l.tensorflow
+   :members:
+   :imported-members:
+
+```
+
+:end_tab:


### PR DESCRIPTION
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
