### PR TITLE
Update PyTorch example to illustrate calling .backward() on a non-scalar

### DIFF
--- a/chapter_preliminaries/autograd.md
+++ b/chapter_preliminaries/autograd.md
@@ -211,9 +211,14 @@ x.grad  # Equals to y = sum(x * x)
 
 ```{.python .input}
 #@tab pytorch
+# Invoking `backward` on a non-scalar requires passing in a `gradient` argument
+# which specifies the gradient of the differentiated function w.r.t `self`.
+# In our case, we simple want to sum the partial derivatives, so passing
+# in a gradient of ones is appropriate.
 x.grad.zero_()
 y = x * x
-y.sum().backward()  # `backward` only supports for scalars
+# y.sum().backward() equivalent to the below
+y.backward(torch.ones(len(x)))
 x.grad
 ```
 

--- a/chapter_preliminaries/autograd.md
+++ b/chapter_preliminaries/autograd.md
@@ -214,7 +214,7 @@ x.grad  # Equals to y = sum(x * x)
 # Invoking `backward` on a non-scalar requires passing in a `gradient` argument
 # which specifies the gradient of the differentiated function w.r.t `self`.
 # In our case, we simply want to sum the partial derivatives, so passing
-# in a gradient of ones is appropriate.
+# in a gradient of ones is appropriate
 x.grad.zero_()
 y = x * x
 # y.backward(torch.ones(len(x))) equivalent to the below

--- a/chapter_preliminaries/autograd.md
+++ b/chapter_preliminaries/autograd.md
@@ -217,8 +217,8 @@ x.grad  # Equals to y = sum(x * x)
 # in a gradient of ones is appropriate.
 x.grad.zero_()
 y = x * x
-# y.sum().backward() equivalent to the below
-y.backward(torch.ones(len(x)))
+# y.backward(torch.ones(len(x))) equivalent to the below
+y.sum().backward()
 x.grad
 ```
 

--- a/chapter_preliminaries/autograd.md
+++ b/chapter_preliminaries/autograd.md
@@ -213,7 +213,7 @@ x.grad  # Equals to y = sum(x * x)
 #@tab pytorch
 # Invoking `backward` on a non-scalar requires passing in a `gradient` argument
 # which specifies the gradient of the differentiated function w.r.t `self`.
-# In our case, we simple want to sum the partial derivatives, so passing
+# In our case, we simply want to sum the partial derivatives, so passing
 # in a gradient of ones is appropriate.
 x.grad.zero_()
 y = x * x


### PR DESCRIPTION
I thought it would be useful to illustrate how calling .backward() on a non-scalar is also possible, as long as you pass in an appropriate `gradient` argument, which is simply all ones in our case.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
