### PR TITLE
fix inconsistency in init

### DIFF
--- a/chapter_linear-networks/linear-regression-concise.md
+++ b/chapter_linear-networks/linear-regression-concise.md
@@ -230,7 +230,7 @@ Bias parameters are initialized to zero by default.
 :end_tab:
 
 :begin_tab:`pytorch`
-As we have specified the input and output dimensions when constructing `nn.Linear`. Now we access the parameters directly to specify there initial values. We first locate the layer by `net[0]`, which is the first layer in the network, and then use the `weight.data` and `bias.data` methods to access the parameters. Next we use the replace methods `uniform_` and `fill_` to overwrite parameter values.
+As we have specified the input and output dimensions when constructing `nn.Linear`. Now we access the parameters directly to specify there initial values. We first locate the layer by `net[0]`, which is the first layer in the network, and then use the `weight.data` and `bias.data` methods to access the parameters. Next we use the replace methods `normal_` and `fill_` to overwrite parameter values.
 :end_tab:
 
 :begin_tab:`tensorflow`
@@ -244,7 +244,7 @@ net.initialize(init.Normal(sigma=0.01))
 
 ```{.python .input}
 #@tab pytorch
-net[0].weight.data.uniform_(0.0, 0.01)
+net[0].weight.data.normal_(0, 0.01)
 net[0].bias.data.fill_(0)
 ```
 


### PR DESCRIPTION
In 3.3.4 (PyTorch) you describe using the normal distribution, however, the initialization is based on the uniform distribution.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
