### PR TITLE
revert all d2l alias before evaluation

### DIFF
--- a/chapter_preface/index.md
+++ b/chapter_preface/index.md
@@ -361,6 +361,14 @@ import numpy as np
 import tensorflow as tf
 ```
 
+Note that the comment `#@save` is a special mark where the following function,
+class, or statements are saved in the `d2l` package.
+In the rest of the book,
+we often define more complicated functions or classes.
+For those that can be used later,
+we will also save them in the `d2l` package
+so later they can be directly invoked without being redefined.
+
 ### Target Audience
 
 This book is for students (undergraduate or graduate),

--- a/chapter_preliminaries/ndarray.md
+++ b/chapter_preliminaries/ndarray.md
@@ -667,59 +667,6 @@ a = tf.constant([3.5]).numpy()
 a, a.item(), float(a), int(a)
 ```
 
-## The `d2l` Package
-
-Throughout the online version of this book,
-we will provide implementations of multiple frameworks.
-However, different frameworks may be different in their API names or usage.
-To better reuse the same code block across multiple frameworks,
-we unify a few commonly-used functions in the `d2l` package.
-The comment `#@save` is a special mark where the following function,
-class, or statements are saved in the `d2l` package.
-For instance, later we can directly invoke
-`d2l.numpy(a)` to convert a tensor `a`,
-which can be defined in any supported framework,
-into a NumPy tensor.
-
-```{.python .input}
-#@save
-numpy = lambda a: a.asnumpy()
-size = lambda a: a.size
-reshape = lambda a, *args: a.reshape(*args)
-ones = np.ones
-zeros = np.zeros
-tensor = np.array
-```
-
-```{.python .input}
-#@tab pytorch
-#@save
-numpy = lambda a: a.detach().numpy()
-size = lambda a: a.numel()
-reshape = lambda a, *args: a.reshape(*args)
-ones = torch.ones
-zeros = torch.zeros
-tensor = torch.Tensor
-```
-
-```{.python .input}
-#@tab tensorflow
-#@save
-numpy = lambda a: a.numpy()
-size = lambda a: tf.size(a).numpy()
-reshape = tf.reshape
-ones = tf.ones
-zeros = tf.zeros
-tensor = tf.constant
-```
-
-In the rest of the book,
-we often define more complicated functions or classes.
-For those that can be used later,
-we will also save them in the `d2l` package
-so later they can be directly invoked without being redefined.
-
-
 ## Summary
 
 * The main interface to store and manipulate data for deep learning is the tensor ($n$-dimensional array). It provides a variety of functionalities including basic mathematics operations, broadcasting, indexing, slicing, memory saving, and conversion to other Python objects.

--- a/config.ini
+++ b/config.ini
@@ -63,13 +63,67 @@ mono_font = Inconsolata
 
 [library]
 
-# A list of filename and pattern pairs.
-save_patterns = d2l/mxnet.py, mxnet
-                d2l/torch.py, pytorch
-                d2l/tensorflow.py, tensorflow
-
 version_file = d2l/__init__.py
 
+[library-mxnet]
+
+lib_file = d2l/mxnet.py
+
+alias =
+       numpy = lambda a: a.asnumpy()
+       size = lambda a: a.size
+       reshape = lambda a, *args: a.reshape(*args)
+       ones = np.ones
+       zeros = np.zeros
+       tensor = np.array
+
+reverse_alias =
+       d2l.numpy\(([\w\_\d]+)\) -> \1.asnumpy()
+       d2l.size\(([\w\_\d]+)\) -> \1.size
+       d2l.reshape\(([\w\_\d]+)\,\ * -> \1.reshape(
+       d2l.ones -> np.ones
+       d2l.zeros -> np.zeros
+       d2l.tensor -> np.array
+
+[library-pytorch]
+
+lib_file = d2l/torch.py
+
+alias =
+       numpy = lambda a: a.detach().numpy()
+       size = lambda a: a.numel()
+       reshape = lambda a, *args: a.reshape(*args)
+       ones = torch.ones
+       zeros = torch.zeros
+       tensor = torch.tensor
+
+reverse_alias =
+       d2l.numpy\(([\w\_\d]+)\) -> \1.detach().numpy()
+       d2l.size\(([\w\_\d]+)\) -> \1.numel()
+       d2l.reshape\(([\w\_\d]+)\,\ * -> \1.reshape(
+       d2l.ones -> torch.ones
+       d2l.zeros -> torch.zeros
+       d2l.tensor -> torch.tensor
+
+[library-tensorflow]
+
+lib_file = d2l/tensorflow.py
+
+alias =
+       numpy = lambda a: a.numpy()
+       size = lambda a: tf.size(a).numpy()
+       reshape = tf.reshape
+       ones = tf.ones
+       zeros = tf.zeros
+       tensor = tf.constant
+
+reverse_alias =
+       d2l.numpy\(([\w\_\d]+)\) -> \1.numpy()
+       d2l.size\(([\w\_\d]+)\) -> tf.size(\1).numpy()
+       d2l.reshape -> tf.reshape
+       d2l.ones -> tf.ones
+       d2l.zeros -> tf.zeros
+       d2l.tensor -> tf.constant
 
 [deploy]
 

--- a/d2l/mxnet.py
+++ b/d2l/mxnet.py
@@ -27,15 +27,6 @@ from mxnet import autograd, context, gluon, image, init, np, npx
 from mxnet.gluon import nn, rnn
 
 
-# Defined in file: ./chapter_preliminaries/ndarray.md
-numpy = lambda a: a.asnumpy()
-size = lambda a: a.size
-reshape = lambda a, *args: a.reshape(*args)
-ones = np.ones
-zeros = np.zeros
-tensor = np.array
-
-
 # Defined in file: ./chapter_preliminaries/pandas.md
 def mkdir_if_not_exist(path):  #@save
     """Make a directory if it does not exist."""
@@ -2568,4 +2559,12 @@ def update_G(Z, net_D, net_G, loss, trainer_G):  #@save
 d2l.DATA_HUB['pokemon'] = (d2l.DATA_URL + 'pokemon.zip',
                            'c065c0e2593b8b161a2d7873e42418bf6a21106c')
 
+
+# Alias defined in config.ini
+numpy = lambda a: a.asnumpy()
+size = lambda a: a.size
+reshape = lambda a, *args: a.reshape(*args)
+ones = np.ones
+zeros = np.zeros
+tensor = np.array
 

--- a/d2l/tensorflow.py
+++ b/d2l/tensorflow.py
@@ -27,15 +27,6 @@ import numpy as np
 import tensorflow as tf
 
 
-# Defined in file: ./chapter_preliminaries/ndarray.md
-numpy = lambda a: a.numpy()
-size = lambda a: tf.size(a).numpy()
-reshape = tf.reshape
-ones = tf.ones
-zeros = tf.zeros
-tensor = tf.constant
-
-
 # Defined in file: ./chapter_preliminaries/pandas.md
 def mkdir_if_not_exist(path):  #@save
     """Make a directory if it does not exist."""
@@ -532,4 +523,12 @@ class Residual(tf.keras.Model):  #@save
         Y += X
         return tf.keras.activations.relu(Y)
 
+
+# Alias defined in config.ini
+numpy = lambda a: a.numpy()
+size = lambda a: tf.size(a).numpy()
+reshape = tf.reshape
+ones = tf.ones
+zeros = tf.zeros
+tensor = tf.constant
 

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -32,15 +32,6 @@ from torch.utils import data
 from torchvision import transforms
 
 
-# Defined in file: ./chapter_preliminaries/ndarray.md
-numpy = lambda a: a.detach().numpy()
-size = lambda a: a.numel()
-reshape = lambda a, *args: a.reshape(*args)
-ones = torch.ones
-zeros = torch.zeros
-tensor = torch.Tensor
-
-
 # Defined in file: ./chapter_preliminaries/pandas.md
 def mkdir_if_not_exist(path):  #@save
     """Make a directory if it does not exist."""
@@ -1092,4 +1083,12 @@ def show_trace_2d(f, results):
     d2l.plt.xlabel('x1')
     d2l.plt.ylabel('x2')
 
+
+# Alias defined in config.ini
+numpy = lambda a: a.detach().numpy()
+size = lambda a: a.numel()
+reshape = lambda a, *args: a.reshape(*args)
+ones = torch.ones
+zeros = torch.zeros
+tensor = torch.tensor
 


### PR DESCRIPTION
*Description of changes:*

For all alias such as `d2l.ones`, `d2l.reshape`, we will convert them to the framework native operators before evaluation. 

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
