### PR TITLE
fix a possible typo

### DIFF
--- a/chapter_linear-networks/image-classification-dataset.md
+++ b/chapter_linear-networks/image-classification-dataset.md
@@ -156,7 +156,7 @@ We also randomly shuffle the examples for the training data iterator.
 batch_size = 256
 
 def get_dataloader_workers():  #@save
-    """Use 4 processes to read the data expect for Windows."""
+    """Use 4 processes to read the data except for Windows."""
     return 0 if sys.platform.startswith('win') else 4
 
 # `ToTensor` converts the image data from uint8 to 32-bit floating point. It


### PR DESCRIPTION
Propose a change in doc string for function `get_dataloader_workers`.




*Description of changes:*

  In  `"""Use 4 processes to read the data expect for Windows."""`, change from **'expect for'** to **'except for'**.

Thank you!

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
