### PR TITLE
Update convexity.md

### DIFF
--- a/chapter_optimization/convexity.md
+++ b/chapter_optimization/convexity.md
@@ -109,7 +109,7 @@ Convex functions have a few useful properties. We describe them as follows.
 
 ### No Local Minima
 
-In particular, convex functions do not have local minima. Let us assume the contrary and prove it wrong. If $x \in X$ is a local minimum there exists some neighborhood of $x$ for which $f(x)$ is the smallest value. Since $x$ is only a local minimum there has to be another $x' \in X$ for which $f(x') < f(x)$. However, by convexity the function values on the entire *line* $\lambda x + (1-\lambda) x'$ have to be less than $f(x')$ since for $\lambda \in [0, 1)$
+In particular, convex functions do not have local minima. Let us assume the contrary and prove it wrong. If $x \in X$ is a local minimum there exists some neighborhood of $x$ for which $f(x)$ is the smallest value. Since $x$ is only a local minimum there has to be another $x' \in X$ for which $f(x') < f(x)$. However, by convexity the function values on the entire *line* $\lambda x + (1-\lambda) x'$ have to be less than $f(x)$ since for $\lambda \in [0, 1)$
 
 $$f(x) > \lambda f(x) + (1-\lambda) f(x') \geq f(\lambda x + (1-\lambda) x').$$
 


### PR DESCRIPTION
There's a typo in the sentence just before the formula (11.2.5): “However, by convexity the function values on the entire line λx+(1−λ)x have to be less than f(x')”, instead of “less than f(x')”, goldpiggy just confirmed that it should be “less than f(x)” here.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
