### PR TITLE
Remove the pinned cloudpickle version

### DIFF
--- a/static/build.yml
+++ b/static/build.yml
@@ -10,4 +10,3 @@ dependencies:
     - torch==1.6.0+cu101
     - tensorflow==2.2.0
     - tensorflow-probability==0.10.1
-    - cloudpickle==1.4.1  # due to https://github.com/tensorflow/probability/issues/991


### PR DESCRIPTION
*Description of changes:*

Now that https://github.com/tensorflow/probability/issues/991 has been fixed so things should work as expected.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
