### PR TITLE
backprop.md: Ex2: Don't require bias in the regularization term

### DIFF
--- a/chapter_multilayer-perceptrons/backprop.md
+++ b/chapter_multilayer-perceptrons/backprop.md
@@ -285,7 +285,7 @@ more easily leads to *out of memory* errors.
 
 1. Assume that the inputs $\mathbf{X}$ to some scalar function $f$ are $n \times m$ matrices. What is the dimensionality of the gradient of $f$ with respect to $\mathbf{X}$?
 1. Add a bias to the hidden layer of the model described in this section.
-    * Draw the corresponding computational graph.
+    * Draw the corresponding computational graph.  You do not need to include bias in the regularization term.
     * Derive the forward and backward propagation equations.
 1. Compute the memory footprint for training and prediction in the model described in this section.
 1. Assume that you want to compute second derivatives. What happens to the computational graph? How long do you expect the calculation to take?


### PR DESCRIPTION
Given the ambiguity of whether biases are included[1], I think it is good to specify whether they are needed not. I chose not in this suggested edit to keep the problem simpler.  Choosing to explicitly require it might give students practice in thinking about variables that depend on multiple paths, but my guess is they'll get that from reworking the weights anyway.

[1] "Whether we include a corresponding bias penalty  b2  can vary across implementations, and may vary across layers of a neural network. Often, we do not regularize the bias term of a network’s output layer." in section [4.5.1](https://d2l.ai/chapter_multilayer-perceptrons/weight-decay.html#norms-and-weight-decay)

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
