### PR TITLE
Update information-theory.md

### DIFF
--- a/chapter_appendix-mathematics-for-deep-learning/information-theory.md
+++ b/chapter_appendix-mathematics-for-deep-learning/information-theory.md
@@ -435,7 +435,7 @@ def kl_divergence(p, q):
 
 Let us take a look at some properties of the KL divergence :eqref:`eq_kl_def`.
 
-* KL divergence is non-symmetric, i.e., $$D_{\mathrm{KL}}(P\|Q) \neq D_{\mathrm{KL}}(Q\|P), \text{ if } P \neq Q.$$
+* KL divergence is non-symmetric, i.e., there are $P,Q$ such that $$D_{\mathrm{KL}}(P\|Q) \neq D_{\mathrm{KL}}(Q\|P).$$
 * KL divergence is non-negative, i.e., $$D_{\mathrm{KL}}(P\|Q) \geq 0.$$ Note that the equality holds only when $P = Q$.
 * If there exists an $x$ such that $p(x) > 0$ and $q(x) = 0$, then $D_{\mathrm{KL}}(P\|Q) = \infty$.
 * There is a close relationship between KL divergence and mutual information. Besides the relationship shown in :numref:`fig_mutual_information`, $I(X, Y)$ is also numerically equivalent with the following terms:


### PR DESCRIPTION
The Kullback Leibler divergence is not symmetric but  one can easily construct $P, Q, P \neq Q$ such that $D_{\mathrm{KL}}(P\|Q) = D_{\mathrm{KL}}(Q\|P)$.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
