### PR TITLE
[PyTorch] fix(Batch Normalization): memory leaky

### DIFF
--- a/chapter_convolutional-modern/batch-norm.md
+++ b/chapter_convolutional-modern/batch-norm.md
@@ -246,7 +246,7 @@ def batch_norm(X, gamma, beta, moving_mean, moving_var, eps, momentum):
         moving_mean = momentum * moving_mean + (1.0 - momentum) * mean
         moving_var = momentum * moving_var + (1.0 - momentum) * var
     Y = gamma * X_hat + beta  # Scale and shift
-    return Y, moving_mean.data, moving_var.data
+    return Y, moving_mean, moving_var
 ```
 
 ```{.python .input}

--- a/chapter_convolutional-modern/batch-norm.md
+++ b/chapter_convolutional-modern/batch-norm.md
@@ -246,7 +246,7 @@ def batch_norm(X, gamma, beta, moving_mean, moving_var, eps, momentum):
         moving_mean = momentum * moving_mean + (1.0 - momentum) * mean
         moving_var = momentum * moving_var + (1.0 - momentum) * var
     Y = gamma * X_hat + beta  # Scale and shift
-    return Y, moving_mean, moving_var
+    return Y, moving_mean.data, moving_var.data
 ```
 
 ```{.python .input}
@@ -283,7 +283,7 @@ def batch_norm(X, gamma, beta, moving_mean, moving_var, eps, momentum):
         moving_mean = momentum * moving_mean + (1.0 - momentum) * mean
         moving_var = momentum * moving_var + (1.0 - momentum) * var
     Y = gamma * X_hat + beta  # Scale and shift
-    return Y, moving_mean, moving_var
+    return Y, moving_mean.data, moving_var.data
 ```
 
 ```{.python .input}


### PR DESCRIPTION
The memory would not be freed and accumulate every epochs to explode finally.

X is associated with *moving_mean* and *moving_var* via gradient computation.

As the result, **X will not be freed** due to the resident of *self.moving_mean* and *self.moving_var* in memory.

Thus the returning values here should be modified to *moving_mean.data* and *moving_var.data* to remove the gradient property, which will not impact our model.