### PR TITLE
[PyTorch] NiN AdaptiveMaxPool2d->AdaptiveAvgPool2d

### DIFF
--- a/chapter_convolutional-modern/nin.md
+++ b/chapter_convolutional-modern/nin.md
@@ -138,7 +138,7 @@ net = nn.Sequential(
     nn.Dropout(0.5),
     # There are 10 label classes
     nin_block(384, 10, kernel_size=3, strides=1, padding=1),
-    nn.AdaptiveMaxPool2d((1, 1)),
+    nn.AdaptiveAvgPool2d((1, 1)),
     # Transform the four-dimensional output into two-dimensional output with a
     # shape of (batch size, 10)
     nn.Flatten())


### PR DESCRIPTION
Make PyTorch code consistent with MXNet/TF

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
