### PR TITLE
Handles an edge case in 3.6.5 Accuracy

### DIFF
--- a/chapter_linear-networks/softmax-regression-scratch.md
+++ b/chapter_linear-networks/softmax-regression-scratch.md
@@ -270,7 +270,7 @@ Taking the sum yields the number of correct predictions.
 #@tab all
 def accuracy(y_hat, y):  #@save
     """Compute the number of correct predictions."""
-    if len(y_hat.shape) > 1 and y_hat.shape[1] > 1:
+    if y_hat.shape[0] >= 1:
         y_hat = d2l.argmax(y_hat, axis=1)        
     cmp = d2l.astype(y_hat, y.dtype) == y
     return float(d2l.reduce_sum(d2l.astype(cmp, y.dtype)))


### PR DESCRIPTION
In the definition of `accuracy`, `if len(y_hat.shape) >= 1:` would handle the case of `y_hat` containing prediction for only one example. Checking the second dimension of `y_hat.shape[1] > 1` is also redundant since `tf.argmax` would handle the case of tensor having only one element by returning the index `0`.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
