### PR TITLE
bptt typos

### DIFF
--- a/chapter_recurrent-neural-networks/bptt.md
+++ b/chapter_recurrent-neural-networks/bptt.md
@@ -75,7 +75,7 @@ $$
 \partial_{w_h}h_{t}=\partial_{w_h}f(x_{t},h_{t-1},w)+\partial_{h_{t-1}}f(x_{t},h_{t-1},w_h)\partial_{w_h}h_{t-1}.
 $$
 
-By :eqref:`eq_bptt_at`, the third part will be
+By :eqref:`eq_bptt_at`, the right side can be represented by
 
 $$
 \partial_{w_h}h_{t}=\partial_{w_h}f(x_{t},h_{t-1},w_h)+\sum_{i=1}^{t-1}\left(\prod_{j=i+1}^{t}\partial_{h_{j-1}}f(x_{j},h_{j-1},w_h)\right)\partial_{w_h}f(x_{i},h_{i-1},w_h).
@@ -85,7 +85,7 @@ While we can use the chain rule to compute $\partial_{w_h} h_t$ recursively, thi
 
 * **Compute the full sum.** This is very slow and gradients can blow up, since subtle changes in the initial conditions can potentially affect the outcome a lot. That is, we could see things similar to the butterfly effect where minimal changes in the initial conditions lead to disproportionate changes in the outcome. This is actually quite undesirable in terms of the model that we want to estimate. After all, we are looking for robust estimators that generalize well. Hence this strategy is almost never used in practice.
 
-* **Truncate the sum after** $\tau$ **steps.** This is what we have been discussing so far. This leads to an *approximation* of the true gradient, simply by terminating the sum above at $\partial_{w_h} h_{t-\tau}$. The approximation error is thus given by $\partial_{h_{t-1}} f(x_t, h_{t-1}, w) \partial_{w_h} h_{t-1}$ (multiplied by a product of  gradients involving $\partial_h f$). In practice this works quite well. It is what is commonly referred to as truncated BPTT (backpropgation through time). One of the consequences of this is that the model focuses primarily on short-term influence rather than long-term consequences. This is actually *desirable*, since it biases the estimate towards simpler and more stable models.
+* **Truncate the sum after** $\tau$ **steps.** This is what we have been discussing so far. This leads to an *approximation* of the true gradient, simply by terminating the sum above at $\partial_{w_h} h_{t-\tau}$. The approximation error is thus given by $\partial_{h_{t-\tau-1}} f(x_{t-\tau}, h_{t-\tau-1}, w_h) \partial_{w_h} h_{t-\tau-1}$ (multiplied by a product of  gradients involving $\partial_h f$). In practice this works quite well. It is what is commonly referred to as truncated BPTT (backpropgation through time). One of the consequences of this is that the model focuses primarily on short-term influence rather than long-term consequences. This is actually *desirable*, since it biases the estimate towards simpler and more stable models.
 
 * **Randomized Truncation.** Last we can replace $\partial_{w_h} h_t$ by a random variable which is correct in expectation but which truncates the sequence. This is achieved by using a sequence of $\xi_t$ where $E[\xi_t] = 1$ and $P(\xi_t = 0) = 1-\pi$ and furthermore $P(\xi_t = \pi^{-1}) = \pi$. We use this to replace the gradient:
 


### PR DESCRIPTION
Truncate the sum after  𝜏  steps.... The approximation error is thus given by

![image](https://user-images.githubusercontent.com/37914843/91518436-1bb02d00-e8a5-11ea-9ce6-cde37091bdb2.png)
