### PR TITLE
Update ndarray.md

### DIFF
--- a/chapter_preliminaries/ndarray.md
+++ b/chapter_preliminaries/ndarray.md
@@ -295,7 +295,7 @@ x + y, x - y, x * y, x / y, x ** y  # The ** operator is exponentiation
 #@tab pytorch
 x = torch.tensor([1.0, 2, 4, 8])
 y = torch.tensor([2, 2, 2, 2])
-x + y, x - y, x * y, x / y, x ** y  # The ** operator is exponentiation
+x + y, x - y, x * y, x // y, x ** y  # The ** operator is exponentiation
 ```
 
 ```{.python .input}


### PR DESCRIPTION
Integer division gives the error as listed below:
-- RuntimeError: Integer division of tensors using div or / is no longer supported, and in a future release div will perform true division as in Python 3. Use true_divide or floor_divide (// in Python) instead.
Pytorch documentation : https://pytorch.org/docs/stable/generated/torch.div.html

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
