### PR TITLE
[PyTorch] Fix #1361: Slow Train Time

### DIFF
--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -973,10 +973,11 @@ class Seq2SeqDecoder(d2l.Decoder):
 
 # Defined in file: ./chapter_recurrent-modern/seq2seq.md
 def sequence_mask(X, valid_len, value=0):
-    output = X.clone()
-    for count, matrix in enumerate(output):
-        matrix[int(valid_len[count]):]=value
-    return output
+    maxlen = X.size(1)
+    mask = torch.arange((maxlen), dtype=torch.float32,
+                        device=X.device)[None, :] < valid_len[:, None]    
+    X[~mask] = value
+    return X
 
 
 # Defined in file: ./chapter_recurrent-modern/seq2seq.md


### PR DESCRIPTION
*Description of changes:*
This PR highly optimizes the `sequence_mask` function leading to a significant boost in training time for PyTorch section on the transformer (#1361). 

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
