### PR TITLE
Update seqrec.md - The text doesn't match illustration

### DIFF
--- a/chapter_recommender-systems/seqrec.md
+++ b/chapter_recommender-systems/seqrec.md
@@ -104,7 +104,7 @@ class Caser(nn.Block):
 ```
 
 ## Sequential Dataset with Negative Sampling
-To process the sequential interaction data, we need to reimplement the Dataset class. The following code creates a new dataset class named `SeqDataset`. In each sample, it outputs the user identity, his previous $L$ interacted items as a sequence and the next item he interacts as the target. The following figure demonstrates the data loading process for one user. Suppose that this user liked 8 movies, we organize these eight movies in chronological order. The latest movie is left out as the test item. For the remaining seven movies, we can get three training samples, with each sample containing a sequence of five ($L=5$) movies and its subsequent item as the target item. Negative samples are also included in the Customized dataset.
+To process the sequential interaction data, we need to reimplement the Dataset class. The following code creates a new dataset class named `SeqDataset`. In each sample, it outputs the user identity, his previous $L$ interacted items as a sequence and the next item he interacts as the target. The following figure demonstrates the data loading process for one user. Suppose that this user liked 9 movies, we organize these nine movies in chronological order. The latest movie is left out as the test item. For the remaining eight movies, we can get three training samples, with each sample containing a sequence of five ($L=5$) movies and its subsequent item as the target item. Negative samples are also included in the Customized dataset.
 
 ![Illustration of the data generation process](../img/rec-seq-data.svg)
 


### PR DESCRIPTION
*Description of changes:*
In the image, there are nine samples. But in the text, there are only eight. Hence, it does not make sense how can we get 3 training samples just from a sequence of 7 movies with L=5

![image](https://user-images.githubusercontent.com/23548268/93017244-60e89480-f5f1-11ea-85bf-808cf0c829ae.png)


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
