### PR TITLE
Update linear-regression-concise.md

### DIFF
--- a/chapter_linear-networks/linear-regression-concise.md
+++ b/chapter_linear-networks/linear-regression-concise.md
@@ -220,7 +220,7 @@ Bias parameters are initialized to zero by default.
 :end_tab:
 
 :begin_tab:`pytorch`
-As we have specified the input and output dimensions when constructing `nn.Linear`. Now we access the parameters directly to specify there initial values. We first locate the layer by `net[0]`, which is the first layer in the network, and then use the `weight.data` and `bias.data` methods to access the parameters. Next we use the replace methods `normal_` and `fill_` to overwrite parameter values.
+As we have specified the input and output dimensions when constructing `nn.Linear`. Now we access the parameters directly to specify their initial values. We first locate the layer by `net[0]`, which is the first layer in the network, and then use the `weight.data` and `bias.data` methods to access the parameters. Next we use the replace methods `normal_` and `fill_` to overwrite parameter values.
 :end_tab:
 
 :begin_tab:`tensorflow`


### PR DESCRIPTION
Typo in 'pytorch' tab of "initializing model parameters" section -- changed "...directly to specify *there* initial values" to "...directly to specify *their* initial values."

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
