### PR TITLE
Update transformer.md

### DIFF
--- a/chapter_attention-mechanisms/transformer.md
+++ b/chapter_attention-mechanisms/transformer.md
@@ -284,7 +284,13 @@ ffn(d2l.ones((2, 3, 4)))[0]
 
 Besides the above two components in the Transformer block, the "add and norm" within the block also plays a key role to connect the inputs and outputs of other layers smoothly. To explain, we add a layer that contains a residual structure and a *layer normalization* after both the multi-head attention layer and the position-wise FFN network. *Layer normalization* is similar to batch normalization in :numref:`sec_batch_norm`. One difference is that the mean and variances for the layer normalization are calculated along the last dimension, e.g `X.mean(axis=-1)` instead of the first batch dimension, e.g., `X.mean(axis=0)`. Layer normalization prevents the range of values in the layers from changing too much, which allows faster training and better generalization ability.
 
-MXNet has both `LayerNorm` and `BatchNorm` implemented within the `nn` block. Let us call both of them and see the difference in the  example below.
+:begin_tab:`mxnet`
+MXNet has both `LayerNorm` and `BatchNorm` implemented within the `nn` block. Let us call both of them and see the difference in the example below.
+:end_tab:
+
+:begin_tab:`pytorch`
+PyTorch has both `LayerNorm` and `BatchNorm1d` implemented within the `nn` module. Let us call both of them and see the difference in the example below.
+:end_tab:
 
 ```{.python .input}
 layer = nn.LayerNorm()
@@ -299,10 +305,8 @@ with autograd.record():
 
 ```{.python .input}
 #@tab pytorch
-layer = nn.LayerNorm([2])
-layer.eval()
+layer = nn.LayerNorm(2)
 batch = nn.BatchNorm1d(2)
-batch.eval()
 X = d2l.tensor([[1, 2], [2, 3]], dtype=torch.float32)
 # Compute mean and variance from `X` in the training mode
 print('layer norm:', layer(X), '\nbatch norm:', batch(X))
@@ -354,7 +358,7 @@ add_norm(d2l.ones((2, 3, 4)), d2l.ones((2, 3, 4))).shape
 
 Unlike the recurrent layer, both the multi-head attention layer and the position-wise feed-forward network compute the output of each item in the sequence independently. This feature enables us to parallelize the computation, but it fails to model the sequential information for a given sequence. To better capture the sequential information, the Transformer model uses the *positional encoding* to maintain the positional information of the input sequence.
 
-To explain, assume that $X\in\mathbb R^{l\times d}$ is the embedding of an example, where $l$ is the sequence length and $d$ is the embedding size. This positional encoding layer encodes X's position $P\in\mathbb R^{l\times d}$ and outputs $P+X$.
+To explain, assume that $X\in\mathbb R^{l\times d}$ is the embedding of an example, where $l$ is the sequence length and $d$ is the embedding size. This positional encoding layer encodes $X$'s position $P\in\mathbb R^{l\times d}$ and outputs $P+X$.
 
 The position $P$ is a 2-D matrix, where $i$ refers to the order in the sentence, and $j$ refers to the position along the embedding vector dimension. In this way, each value in the origin sequence is then maintained using the equations below:
 


### PR DESCRIPTION
- Fixed minor inconsistency in the example between the mxnet and the PyTorch version. (Alternatively to removing the *eval* statements, the evaluation mode could remain and the argument *track_running_stats* in *nn.BatchNorm1d* could be set to *False*)
- Added a tab for the PyTorch version in "Add and Norm".

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
