### PR TITLE
remove duplicated mean for pytorch

### DIFF
--- a/chapter_multilayer-perceptrons/kaggle-house-price.md
+++ b/chapter_multilayer-perceptrons/kaggle-house-price.md
@@ -430,8 +430,8 @@ def log_rmse(net, features, labels):
     # To further stabilize the value when the logarithm is taken, set the
     # value less than 1 as 1
     clipped_preds = torch.clamp(net(features), 1, float('inf'))
-    rmse = torch.sqrt(torch.mean(loss(torch.log(clipped_preds),
-                                       torch.log(labels))))
+    rmse = torch.sqrt(loss(torch.log(clipped_preds),
+                           torch.log(labels)))
     return rmse.item()
 ```
 


### PR DESCRIPTION
MSELoss has the "mean" built-in already

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
