### PR TITLE
Correct Function for Eigenvalue Decomposition

### DIFF
--- a/chapter_appendix-mathematics-for-deep-learning/eigendecomposition.md
+++ b/chapter_appendix-mathematics-for-deep-learning/eigendecomposition.md
@@ -115,7 +115,7 @@ from d2l import tensorflow as d2l
 from IPython import display
 import tensorflow as tf
 
-tf.linalg.eigh(tf.constant([[2, 1], [2, 3]], dtype=tf.float64))
+tf.linalg.eig(tf.constant([[2, 1], [2, 3]], dtype=tf.float64))
 ```
 
 Note that `numpy` normalizes the eigenvectors to be of length one,


### PR DESCRIPTION
Correct Function for Eigenvalue Decomposition by TensorFlow

*Description of changes:*

The tensor flow function used for eigenvalue calculation  is given as tf.linalg.eigh(tf.constant([[2, 1], [2, 3]], dtype=tf.float64)).
The change incorporates the correct function for Eigen value calculation as tf.linalg.eig.
