### PR TITLE
Tensorflow not available yet for Python 3.9

### DIFF
--- a/chapter_installation/index.md
+++ b/chapter_installation/index.md
@@ -40,7 +40,7 @@ Now close and re-open your current shell. You should be able to create a new
 environment as following:
 
 ```bash
-conda create --name d2l -y
+conda create --name d2l python=3.8 -y
 ```
 
 
@@ -57,12 +57,10 @@ unzip d2l-en.zip && rm d2l-en.zip
 ```
 
 
-Now we will want to activate the `d2l` environment and install `pip`.
-Enter `y` for the queries that follow this command.
+Now we will want to activate the `d2l` environment.
 
 ```bash
 conda activate d2l
-conda install pip -y
 ```
 
 


### PR DESCRIPTION
When creating conda env, it is important to enforce Python 3.8 as Tensorflow packages are not available yet for Python 3.9.

In addition, it is important to always specify `python`. Otherwise, miniconda will create an empty environment without pip and python. There is no need to upgrade pip afterwards as it will be latest version already.