### PR TITLE
[TF] Fix incorrect argument name for in get_params() in RNN scratch

### DIFF
--- a/chapter_recurrent-neural-networks/rnn-scratch.md
+++ b/chapter_recurrent-neural-networks/rnn-scratch.md
@@ -160,7 +160,7 @@ def get_params(vocab_size, num_hiddens, device):
 
 ```{.python .input}
 #@tab tensorflow
-def get_params(vocab_size, num_hidden):
+def get_params(vocab_size, num_hiddens):
     num_inputs = num_outputs = vocab_size
     
     def normal(shape):


### PR DESCRIPTION
*Description of changes:*

Fix incorrect argument name for in get_params() in RNN scratch. 


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
