### PR TITLE
[PyTorch] Add MultiGPU Concise

### DIFF
--- a/chapter_computational-performance/multiple-gpus-concise.md
+++ b/chapter_computational-performance/multiple-gpus-concise.md
@@ -3,18 +3,25 @@
 
 Implementing parallelism from scratch for every new model is no fun. Moreover, there is significant benefit in optimizing synchronization tools for high performance. In the following we will show how to do this using Gluon. The math and the algorithms are the same as in :numref:`sec_multi_gpu`. As before we begin by importing the required modules (quite unsurprisingly you will need at least two GPUs to run this notebook).
 
-```{.python .input  n=1}
+```{.python .input}
 from d2l import mxnet as d2l
 from mxnet import autograd, gluon, init, np, npx
 from mxnet.gluon import nn
 npx.set_np()
 ```
 
+```{.python .input}
+#@tab pytorch
+from d2l import torch as d2l
+import torch
+from torch import nn
+```
+
 ## A Toy Network
 
 Let us use a slightly more meaningful network than LeNet from the previous section that's still sufficiently easy and quick to train. We pick a ResNet-18 variant :cite:`He.Zhang.Ren.ea.2016`. Since the input images are tiny we modify it slightly. In particular, the difference to :numref:`sec_resnet` is that we use a smaller convolution kernel, stride, and padding at the beginning. Moreover, we remove the max-pooling layer.
 
-```{.python .input  n=2}
+```{.python .input}
 #@save
 def resnet18(num_classes):
     """A slightly modified ResNet-18 model."""
@@ -41,11 +48,43 @@ def resnet18(num_classes):
     return net
 ```
 
+```{.python .input}
+#@tab pytorch
+#@save
+def resnet18(num_classes, in_channels=1):
+    """A slightly modified ResNet-18 model."""
+    def resnet_block(in_channels, out_channels, num_residuals,
+                     first_block=False):
+        blk = []
+        for i in range(num_residuals):
+            if i == 0 and not first_block:
+                blk.append(d2l.Residual(in_channels, out_channels,
+                                        use_1x1conv=True, strides=2))
+            else:
+                blk.append(d2l.Residual(out_channels, out_channels))
+        return nn.Sequential(*blk)
+
+    # This model uses a smaller convolution kernel, stride, and padding and
+    # removes the maximum pooling layer
+    net = nn.Sequential(
+        nn.Conv2d(in_channels, 64, kernel_size=3, stride=1, padding=1),
+        nn.BatchNorm2d(64),
+        nn.ReLU())
+    net.add_module("resnet_block1", resnet_block(64, 64, 2, first_block=True))
+    net.add_module("resnet_block2", resnet_block(64, 128, 2))
+    net.add_module("resnet_block3", resnet_block(128, 256, 2))
+    net.add_module("resnet_block4", resnet_block(256, 512, 2))
+    net.add_module("global_avg_pool", nn.AdaptiveAvgPool2d((1,1)))
+    net.add_module("fc", nn.Sequential(nn.Flatten(),
+                                       nn.Linear(512, num_classes)))
+    return net
+```
+
 ## Parameter Initialization and Logistics
 
 The `initialize` method allows us to set initial defaults for parameters on a device of our choice. For a refresher see :numref:`sec_numerical_stability`. What is particularly convenient is that it also lets us initialize the network on *multiple* devices simultaneously. Let us try how this works in practice.
 
-```{.python .input  n=3}
+```{.python .input}
 net = resnet18(10)
 # get a list of GPUs
 devices = d2l.try_all_gpus()
@@ -53,9 +92,17 @@ devices = d2l.try_all_gpus()
 net.initialize(init=init.Normal(sigma=0.01), ctx=devices)
 ```
 
+```{.python .input}
+#@tab pytorch
+net = resnet18(10)
+# get a list of GPUs
+devices = d2l.try_all_gpus()
+# we'll initialize the network inside the training loop
+```
+
 Using the `split_and_load` function introduced in the previous section we can divide a minibatch of data and copy portions to the list of devices provided by the context variable. The network object *automatically* uses the appropriate GPU to compute the value of the forward propagation. As before we generate 4 observations and split them over the GPUs.
 
-```{.python .input  n=4}
+```{.python .input}
 x = np.random.uniform(size=(4, 1, 28, 28))
 x_shards = gluon.utils.split_and_load(x, devices)
 net(x_shards[0]), net(x_shards[1])
@@ -63,7 +110,7 @@ net(x_shards[0]), net(x_shards[1])
 
 Once data passes through the network, the corresponding parameters are initialized *on the device the data passed through*. This means that initialization happens on a per-device basis. Since we picked GPU 0 and GPU 1 for initialization, the network is initialized only there, and not on the CPU. In fact, the parameters do not even exist on the device. We can verify this by printing out the parameters and observing any errors that might arise.
 
-```{.python .input  n=5}
+```{.python .input}
 weight = net[0].params.get('weight')
 
 try:
@@ -75,7 +122,7 @@ weight.data(devices[0])[0], weight.data(devices[1])[0]
 
 Lastly let us replace the code to evaluate the accuracy by one that works in parallel across multiple devices. This serves as a replacement of the `evaluate_accuracy_gpu` function from :numref:`sec_lenet`. The main difference is that we split a batch before invoking the network. All else is essentially identical.
 
-```{.python .input  n=6}
+```{.python .input}
 #@save
 def evaluate_accuracy_gpus(net, data_iter, split_f=d2l.split_batch):
     # Query the list of devices
@@ -102,7 +149,7 @@ As before, the training code needs to perform a number of basic functions for ef
 
 In the end we compute the accuracy (again in parallel) to report the final value of the network. The training routine is quite similar to implementations in previous chapters, except that we need to split and aggregate data.
 
-```{.python .input  n=7}
+```{.python .input}
 def train(num_gpus, batch_size, lr):
     train_iter, test_iter = d2l.load_data_fashion_mnist(batch_size)
     ctx = [d2l.try_gpu(i) for i in range(num_gpus)]
@@ -129,18 +176,58 @@ def train(num_gpus, batch_size, lr):
           f'on {str(ctx)}')
 ```
 
+```{.python .input}
+#@tab pytorch
+def train(net, num_gpus, batch_size, lr):
+    train_iter, test_iter = d2l.load_data_fashion_mnist(batch_size)
+    devices = [d2l.try_gpu(i) for i in range(num_gpus)]
+    def init_weights(m):
+        if type(m) in [nn.Linear, nn.Conv2d]:
+            nn.init.normal_(m.weight, std=0.01)
+    net.apply(init_weights)
+    # Set model on multiple gpus
+    net = nn.DataParallel(net, device_ids=devices)
+    trainer = torch.optim.SGD(net.parameters(), lr)
+    loss = nn.CrossEntropyLoss()
+    timer, num_epochs = d2l.Timer(), 10
+    animator = d2l.Animator('epoch', 'test acc', xlim=[1, num_epochs])
+    for epoch in range(num_epochs):
+        net.train()
+        timer.start()
+        for X, y in train_iter:
+            trainer.zero_grad()
+            X, y = X.to(devices[0]), y.to(devices[0])
+            l = loss(net(X), y)
+            l.backward()
+            trainer.step()
+        timer.stop()
+        animator.add(epoch + 1, (d2l.evaluate_accuracy_gpu(net, test_iter),))
+    print(f'test acc: {animator.Y[0][-1]:.2f}, {timer.avg():.1f} sec/epoch '
+          f'on {str(devices)}')
+```
+
 ## Experiments
 
 Let us see how this works in practice. As a warmup we train the network on a single GPU.
 
-```{.python .input  n=8}
+```{.python .input}
 train(num_gpus=1, batch_size=256, lr=0.1)
+```
+
+```{.python .input}
+#@tab pytorch
+train(net, num_gpus=1, batch_size=256, lr=0.1)
 ```
 
 Next we use 2 GPUs for training. Compared to LeNet the model for ResNet-18 is considerably more complex. This is where parallelization shows its advantage. The time for computation is meaningfully larger than the time for synchronizing parameters. This improves scalability since the overhead for parallelization is less relevant.
 
-```{.python .input  n=9}
+```{.python .input}
 train(num_gpus=2, batch_size=512, lr=0.2)
+```
+
+```{.python .input}
+#@tab pytorch
+train(net, num_gpus=2, batch_size=512, lr=0.2)
 ```
 
 ## Summary


### PR DESCRIPTION
*Description of changes:*

This PR utilizes PyTorch's `nn.DataParallel` module for multi-gpu parallelization.
@astonzhang note that `evaluate_accuracy_gpu` and `evaluate_accuracy_gpus` are essentially the same functions for PyTorch hence we utilize the former which was saved earlier.  

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
