### PR TITLE
Change name of function to match equation

### DIFF
--- a/chapter_recurrent-modern/seq2seq.md
+++ b/chapter_recurrent-modern/seq2seq.md
@@ -268,7 +268,7 @@ them and
 the previous hidden state $\mathbf{s}_{t^\prime-1}$
 into the
 hidden state $\mathbf{s}_{t^\prime}$ at the current time step.
-As a result, we can use a function $f$ to express the transformation of the decoder's hidden layer:
+As a result, we can use a function $g$ to express the transformation of the decoder's hidden layer:
 
 $$\mathbf{s}_{t^\prime} = g(y_{t^\prime-1}, \mathbf{c}, \mathbf{s}_{t^\prime-1}).$$
 


### PR DESCRIPTION
The text says we can use a function *f*, but the function label in the equation is *g*.
This commit changes the text label to *g* so it matches the equation.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
