### PR TITLE
[PyTorch] Fix Transformers, Seq2Seq Predictions

### DIFF
--- a/chapter_recurrent-modern/seq2seq.md
+++ b/chapter_recurrent-modern/seq2seq.md
@@ -675,6 +675,8 @@ def predict_s2s_ch9(model, src_sentence, src_vocab, tgt_vocab, num_steps,
 def predict_s2s_ch9(model, src_sentence, src_vocab, tgt_vocab, num_steps,
                     device):
     """Predict sequences (defined in Chapter 9)."""
+    # Set model to eval mode for inference
+    model.eval()
     src_tokens = src_vocab[src_sentence.lower().split(' ')] + [
         src_vocab['<eos>']]
     enc_valid_len = torch.tensor([len(src_tokens)], device=device)
@@ -824,4 +826,3 @@ translate(engs, fras, model, src_vocab, tgt_vocab, num_steps, device)
 :begin_tab:`pytorch`
 [Discussions](https://discuss.d2l.ai/t/1062)
 :end_tab:
-

--- a/d2l/mxnet.py
+++ b/d2l/mxnet.py
@@ -991,7 +991,7 @@ def translate(engs, fras, model, src_vocab, tgt_vocab, num_steps, device):
             f'{eng} => {translation}, bleu {bleu(translation, fra, k=2):.3f}')
 
 
-# Defined in file: ./chapter_attention-mechanisms/attention.md
+# Defined in file: ./chapter_attention-mechanisms/attention-functions.md
 def masked_softmax(X, valid_len):
     """Perform softmax by filtering out some elements."""
     # X: 3-D tensor, valid_len: 1-D or 2-D tensor
@@ -1009,7 +1009,7 @@ def masked_softmax(X, valid_len):
         return npx.softmax(X).reshape(shape)
 
 
-# Defined in file: ./chapter_attention-mechanisms/attention.md
+# Defined in file: ./chapter_attention-mechanisms/attention-functions.md
 class DotProductAttention(nn.Block):
     def __init__(self, dropout, **kwargs):
         super(DotProductAttention, self).__init__(**kwargs)
@@ -1027,7 +1027,7 @@ class DotProductAttention(nn.Block):
         return npx.batch_dot(attention_weights, value)
 
 
-# Defined in file: ./chapter_attention-mechanisms/attention.md
+# Defined in file: ./chapter_attention-mechanisms/attention-functions.md
 class MLPAttention(nn.Block):
     def __init__(self, units, dropout, **kwargs):
         super(MLPAttention, self).__init__(**kwargs)

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -1022,6 +1022,8 @@ def train_s2s_ch9(model, data_iter, lr, num_epochs, tgt_vocab, device):
 def predict_s2s_ch9(model, src_sentence, src_vocab, tgt_vocab, num_steps,
                     device):
     """Predict sequences (defined in Chapter 9)."""
+    # Set model to eval mode for inference
+    model.eval()
     src_tokens = src_vocab[src_sentence.lower().split(' ')] + [
         src_vocab['<eos>']]
     enc_valid_len = torch.tensor([len(src_tokens)], device=device)
@@ -1077,7 +1079,7 @@ def translate(engs, fras, model, src_vocab, tgt_vocab, num_steps, device):
             f'{eng} => {translation}, bleu {bleu(translation, fra, k=2):.3f}')
 
 
-# Defined in file: ./chapter_attention-mechanisms/attention.md
+# Defined in file: ./chapter_attention-mechanisms/attention-functions.md
 def masked_softmax(X, valid_len):
     """Perform softmax by filtering out some elements."""
     # X: 3-D tensor, valid_len: 1-D or 2-D tensor
@@ -1095,7 +1097,7 @@ def masked_softmax(X, valid_len):
         return nn.functional.softmax(X.reshape(shape), dim=-1)
 
 
-# Defined in file: ./chapter_attention-mechanisms/attention.md
+# Defined in file: ./chapter_attention-mechanisms/attention-functions.md
 class DotProductAttention(nn.Module):
     def __init__(self, dropout, **kwargs):
         super(DotProductAttention, self).__init__(**kwargs)
@@ -1113,7 +1115,7 @@ class DotProductAttention(nn.Module):
         return torch.bmm(attention_weights, value)
 
 
-# Defined in file: ./chapter_attention-mechanisms/attention.md
+# Defined in file: ./chapter_attention-mechanisms/attention-functions.md
 class MLPAttention(nn.Module):
     def __init__(self, key_size, query_size, units, dropout, **kwargs):
         super(MLPAttention, self).__init__(**kwargs)


### PR DESCRIPTION
*Description of changes:*
This PR addresses and fixes the bug mentioned in #1484 .
Since earlier the model was still in `train` mode, the randomness due to dropout kicked in. Now the model is set to `eval` mode for inference in the function `predict_s2s_ch9`. This should fix the transformers as well as seq2seq(which apparently also had the bug but was not clearly visible) sections.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
