### PR TITLE
[PyTorch] Add hybridize (torchscript)

### DIFF
--- a/chapter_computational-performance/hybridize.md
+++ b/chapter_computational-performance/hybridize.md
@@ -3,7 +3,8 @@
 
 So far, this book has focused on imperative programming, which makes use of statements such as `print`, `+` or `if` to change a program's state. Consider the following example of a simple imperative program.
 
-```{.python .input  n=1}
+```{.python .input}
+#@tab all
 def add(a, b):
     return a + b
 
@@ -33,7 +34,8 @@ Consider the alternative, symbolic programming where computation is usually perf
 
 This allows for a significant amount of optimization. First off, we can skip the Python interpreter in many cases, thus removing a performance bottleneck that can become significant on multiple fast GPUs paired with a single Python thread on a CPU. Secondly, a compiler might optimize and rewrite the above code into `print((1 + 2) + (3 + 4))` or even `print(10)`. This is possible since a compiler gets to see the full code before turning it into machine instructions. For instance, it can release memory (or never allocate it) whenever a variable is no longer needed. Or it can transform the code entirely into an equivalent piece. To get a better idea consider the following simulation of imperative programming (it is Python after all) below.
 
-```{.python .input  n=2}
+```{.python .input}
+#@tab all
 def add_():
     return '''
 def add(a, b):
@@ -65,15 +67,23 @@ The differences between imperative (interpreted) programming and symbolic progra
 
 ## Hybrid Programming
 
-Historically most deep learning frameworks choose between an imperative or a symbolic approach. For example, Theano, TensorFlow (inspired by the latter), Keras and CNTK formulate models symbolically. Conversely, Chainer and PyTorch take an imperative approach. An imperative mode was added to TensorFlow 2.0 (via Eager) and Keras in later revisions. When designing Gluon, developers considered whether it would be possible to combine the benefits of both programming models. This led to a hybrid model that lets users develop and debug using pure imperative programming, while having the ability to convert most programs into symbolic programs to be run when product-level computing performance and deployment are required.
+Historically most deep learning frameworks choose between an imperative or a symbolic approach. For example, Theano, TensorFlow (inspired by the latter), Keras and CNTK formulate models symbolically. Conversely, Chainer and PyTorch take an imperative approach. An imperative mode was added to TensorFlow 2.0 (via Eager) and Keras in later revisions.
+
+:begin_tab:`mxnet`
+When designing Gluon, developers considered whether it would be possible to combine the benefits of both programming models. This led to a hybrid model that lets users develop and debug using pure imperative programming, while having the ability to convert most programs into symbolic programs to be run when product-level computing performance and deployment are required.
 
 In practice this means that we build models using either the `HybridBlock` or the `HybridSequential` and `HybridConcurrent` classes. By default, they are executed in the same way `Block` or `Sequential` and `Concurrent` classes are executed in imperative programming. `HybridSequential` is a subclass of `HybridBlock` (just like `Sequential` subclasses `Block`). When the `hybridize` function is called, Gluon compiles the model into the form used in symbolic programming. This allows one to optimize the compute-intensive components without sacrifices in the way a model is implemented. We will illustrate the benefits below, focusing on sequential models and blocks only (the concurrent composition works analogously).
+:end_tab:
+
+:begin_tab:`pytorch`
+As mentioned above, pytorch is based on imperative programming and uses Dynamic Computation Graphs. In an effort to leverage the portability and efficiency of symbolic programming, developers considered whether it would be possible to combine the benefits of both programming models. This led to a torchscript that lets users develop and debug using pure imperative programming, while having the ability to convert most programs into symbolic programs to be run when product-level computing performance and deployment are required.
+:end_tab:
 
 ## HybridSequential
 
 The easiest way to get a feel for how hybridization works is to consider deep networks with multiple layers. Conventionally the Python interpreter will need to execute the code for all layers to generate an instruction that can then be forwarded to a CPU or a GPU. For a single (fast) compute device this does not cause any major issues. On the other hand, if we use an advanced 8-GPU server such as an AWS P3dn.24xlarge instance Python will struggle to keep all GPUs busy. The single-threaded Python interpreter becomes the bottleneck here. Let us see how we can address this for significant parts of the code by replacing `Sequential` by `HybridSequential`. We begin by defining a simple MLP.
 
-```{.python .input  n=3}
+```{.python .input}
 from d2l import mxnet as d2l
 from mxnet import np, npx
 from mxnet.gluon import nn
@@ -93,25 +103,64 @@ net = get_net()
 net(x)
 ```
 
-By calling the `hybridize` function, we are able to compile and optimize the computation in the MLP. The model's computation result remains unchanged.
+```{.python .input}
+#@tab pytorch
+from d2l import torch as d2l
+import torch
+from torch import nn
 
-```{.python .input  n=4}
+# factory for networks
+def get_net():
+    net = nn.Sequential(nn.Linear(512, 256),
+            nn.ReLU(),
+            nn.Linear(256, 128),
+            nn.ReLU(),
+            nn.Linear(128, 2))
+    return net
+
+x = torch.randn(size=(1, 512))
+net = get_net()
+net(x)
+```
+
+:begin_tab:`mxnet`
+By calling the `hybridize` function, we are able to compile and optimize the computation in the MLP. The model's computation result remains unchanged.
+:end_tab:
+
+:begin_tab:`pytorch`
+By converting the model using `torch.jit.script` function, we are able to compile and optimize the computation in the MLP. The model's computation result remains unchanged.
+:end_tab:
+
+```{.python .input}
 net.hybridize()
 net(x)
 ```
 
+```{.python .input}
+#@tab pytorch
+net = torch.jit.script(net)
+net(x)
+```
+
+:begin_tab:`mxnet`
 This seems almost too good to be true: simply designate a block to be `HybridSequential`, write the same code as before and invoke `hybridize`. Once this happens the network is optimized (we will benchmark the performance below). Unfortunately this does not work magically for every layer. That said, the blocks provided by Gluon are by default subclasses of `HybridBlock` and thus hybridizable. A layer will not be optimized if it inherits from the `Block` instead.
+:end_tab:
+
+:begin_tab:`pytorch`
+By converting the model using `torch.jit.script` This seems almost too good to be true: write the same code as before and simply convert the model using `torch.jit.script`. Once this happens the network is optimized (we will benchmark the performance below).
+:end_tab:
 
 ### Acceleration by Hybridization
 
 To demonstrate the performance improvement gained by compilation we compare the time needed to evaluate `net(x)` before and after hybridization. Let us define a function to measure this time first. It will come handy throughout the chapter as we set out to measure (and improve) performance.
 
 ```{.python .input}
+#@tab all
 #@save
-class Benchmark:    
+class Benchmark:
     def __init__(self, description='Done'):
         self.description = description
-        
+
     def __enter__(self):
         self.timer = d2l.Timer()
         return self
@@ -120,9 +169,15 @@ class Benchmark:
         print(f'{self.description}: {self.timer.stop():.4f} sec')
 ```
 
+:begin_tab:`mxnet`
 Now we can invoke the network twice, once with and once without hybridization.
+:end_tab:
 
-```{.python .input  n=5}
+:begin_tab:`pytorch`
+Now we can invoke the network twice, once with and once without torchscript.
+:end_tab:
+
+```{.python .input}
 net = get_net()
 with Benchmark('Without hybridization'):
     for i in range(1000): net(x)
@@ -134,31 +189,63 @@ with Benchmark('With hybridization'):
     npx.waitall()
 ```
 
-As is observed in the above results, after a HybridSequential instance calls the `hybridize` function, computing performance is improved through the use of symbolic programming.
+```{.python .input}
+#@tab pytorch
+net = get_net()
+with Benchmark('Without torchscript'):
+    for i in range(1000): net(x)
 
+net = torch.jit.script(net)
+with Benchmark('With torchscript'):
+    for i in range(1000): net(x)
+```
+
+:begin_tab:`mxnet`
+As is observed in the above results, after a HybridSequential instance calls the `hybridize` function, computing performance is improved through the use of symbolic programming.
+:end_tab:
+
+:begin_tab:`pytorch`
+As is observed in the above results, after a nn.Sequential instance is scripted using the `torch.jit.script` function, computing performance is improved through the use of symbolic programming.
+:end_tab:
 
 ### Serialization
 
+:begin_tab:`mxnet`
 One of the benefits of compiling the models is that we can serialize (save) the model and its parameters to disk. This allows us to store a model in a manner that is independent of the front-end language of choice. This allows us to deploy trained models to other devices and easily use other front-end programming languages. At the same time the code is often faster than what can be achieved in imperative programming. Let us see the `export` method in action.
+:end_tab:
 
-```{.python .input  n=13}
+:begin_tab:`pytorch`
+One of the benefits of compiling the models is that we can serialize (save) the model and its parameters to disk. This allows us to store a model in a manner that is independent of the front-end language of choice. This allows us to deploy trained models to other devices and easily use other front-end programming languages. At the same time the code is often faster than what can be achieved in imperative programming. Let us see the `save` method in action.
+:end_tab:
+
+```{.python .input}
 net.export('my_mlp')
 !ls -lh my_mlp*
 ```
 
-The model is decomposed into a (large binary) parameter file and a JSON description of the program required to execute to compute the model. The files can be read by other front-end languages supported by Python or MXNet, such as C++, R, Scala, and Perl. Let us have a look at the model description.
+```{.python .input}
+#@tab pytorch
+net.save('my_mlp')
+!ls -lh my_mlp*
+```
 
-```{.python .input  n=7}
+:begin_tab:`mxnet`
+The model is decomposed into a (large binary) parameter file and a JSON description of the program required to execute to compute the model. The files can be read by other front-end languages supported by Python or MXNet, such as C++, R, Scala, and Perl. Let us have a look at the model description.
+:end_tab:
+
+```{.python .input}
 !head my_mlp-symbol.json
 ```
 
+:begin_tab:`mxnet`
 Things are slightly more tricky when it comes to models that resemble code more closely. Basically hybridization needs to deal with control flow and Python overhead in a much more immediate manner. Moreover,
 
 Contrary to the Block instance, which needs to use the `forward` function, for a HybridBlock instance we need to use the `hybrid_forward` function.
 
 Earlier, we demonstrated that, after calling the `hybridize` method, the model is able to achieve superior computing performance and portability. Note, though that hybridization can affect model flexibility, in particular in terms of control flow. We will illustrate how to design more general models and also how compilation will remove spurious Python elements.
+:end_tab:
 
-```{.python .input  n=8}
+```{.python .input}
 class HybridNet(nn.HybridBlock):
     def __init__(self, **kwargs):
         super(HybridNet, self).__init__(**kwargs)
@@ -173,25 +260,31 @@ class HybridNet(nn.HybridBlock):
         return self.output(x)
 ```
 
+:begin_tab:`mxnet`
 The code above implements a simple network with 4 hidden units and 2 outputs. `hybrid_forward` takes an additional argument - the module `F`. This is needed since, depending on whether the code has been hybridized or not, it will use a slightly different library (`ndarray` or `symbol`) for processing. Both classes perform very similar functions and MXNet automatically determines the argument. To understand what is going on we print the arguments as part of the function invocation.
+:end_tab:
 
-```{.python .input  n=9}
+```{.python .input}
 net = HybridNet()
 net.initialize()
 x = np.random.normal(size=(1, 3))
 net(x)
 ```
 
+:begin_tab:`mxnet`
 Repeating the forward computation will lead to the same output (we omit details). Now let us see what happens if we invoke the `hybridize` method.
+:end_tab:
 
-```{.python .input  n=10}
+```{.python .input}
 net.hybridize()
 net(x)
 ```
 
+:begin_tab:`mxnet`
 Instead of using `ndarray` we now use the `symbol` module for `F`. Moreover, even though the input is of `ndarray` type, the data flowing through the network is now converted to `symbol` type as part of the compilation process. Repeating the function call leads to a surprising outcome:
+:end_tab:
 
-```{.python .input  n=11}
+```{.python .input}
 net(x)
 ```
 

--- a/d2l/mxnet.py
+++ b/d2l/mxnet.py
@@ -1289,10 +1289,10 @@ def train_concise_ch11(tr_name, hyperparams, data_iter, num_epochs=2):
 
 
 # Defined in file: ./chapter_computational-performance/hybridize.md
-class Benchmark:    
+class Benchmark:
     def __init__(self, description='Done'):
         self.description = description
-        
+
     def __enter__(self):
         self.timer = d2l.Timer()
         return self

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -1369,6 +1369,19 @@ def train_concise_ch11(trainer_fn, hyperparams, data_iter, num_epochs=4):
     print(f'loss: {animator.Y[0][-1]:.3f}, {timer.avg():.3f} sec/epoch')
 
 
+# Defined in file: ./chapter_computational-performance/hybridize.md
+class Benchmark:
+    def __init__(self, description='Done'):
+        self.description = description
+
+    def __enter__(self):
+        self.timer = d2l.Timer()
+        return self
+
+    def __exit__(self, *args):
+        print(f'{self.description}: {self.timer.stop():.4f} sec')
+
+
 # Defined in file: ./chapter_computational-performance/multiple-gpus-concise.md
 def resnet18(num_classes, in_channels=1):
     """A slightly modified ResNet-18 model."""


### PR DESCRIPTION
*Description of changes:*
There is no `npx.waitall` kind of functionality for torch. However it offers something similar (`torch.cuda.synchronize()`) for CUDA computations (by default, GPU operations are asynchronous.).

Also torchscript is not valid for the last few code blocks, hence there is no pytorch code or text.

The PR is still do not merge due to text modifications and feedback @astonzhang @mli 

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
