### PR TITLE
[PyTorch] Use PIL

### DIFF
--- a/chapter_computer-vision/fine-tuning.md
+++ b/chapter_computer-vision/fine-tuning.md
@@ -72,24 +72,16 @@ test_imgs = gluon.data.vision.ImageFolderDataset(
 
 ```{.python .input}
 #@tab pytorch
-train_imgs = torchvision.datasets.ImageFolder(os.path.join(data_dir, 'train'),
-                                transform=torchvision.transforms.ToTensor())
-test_imgs = torchvision.datasets.ImageFolder(os.path.join(data_dir, 'test'),
-                                transform=torchvision.transforms.ToTensor())
+train_imgs = torchvision.datasets.ImageFolder(os.path.join(data_dir, 'train'))
+test_imgs = torchvision.datasets.ImageFolder(os.path.join(data_dir, 'test'))
 ```
 
 The first 8 positive examples and the last 8 negative images are shown below. As you can see, the images vary in size and aspect ratio.
 
 ```{.python .input}
+#@tab all
 hotdogs = [train_imgs[i][0] for i in range(8)]
 not_hotdogs = [train_imgs[-i - 1][0] for i in range(8)]
-d2l.show_images(hotdogs + not_hotdogs, 2, 8, scale=1.4);
-```
-
-```{.python .input}
-#@tab pytorch
-hotdogs = [train_imgs[i][0].permute(1,2,0) for i in range(8)]
-not_hotdogs = [train_imgs[-i - 1][0].permute(1,2,0) for i in range(8)]
 d2l.show_images(hotdogs + not_hotdogs, 2, 8, scale=1.4);
 ```
 

--- a/chapter_computer-vision/image-augmentation.md
+++ b/chapter_computer-vision/image-augmentation.md
@@ -50,24 +50,16 @@ d2l.plt.imshow(img.asnumpy());
 ```{.python .input}
 #@tab pytorch
 d2l.set_figsize()
-img = d2l.plt.imread('../img/cat1.jpg')
+img = d2l.Image.open('../img/cat1.jpg')
 d2l.plt.imshow(img);
 ```
 
 Most image augmentation methods have a certain degree of randomness. To make it easier for us to observe the effect of image augmentation, we next define the auxiliary function `apply`. This function runs the image augmentation method `aug` multiple times on the input image `img` and shows all results.
 
 ```{.python .input}
+#@tab all
 def apply(img, aug, num_rows=2, num_cols=4, scale=1.5):
     Y = [aug(img) for _ in range(num_rows * num_cols)]
-    d2l.show_images(Y, num_rows, num_cols, scale=scale)
-```
-
-```{.python .input}
-#@tab pytorch
-def apply(img, aug, num_rows=2, num_cols=4, scale=1.5):
-    img = torchvision.transforms.ToPILImage()(img)
-    Y = [torchvision.transforms.ToTensor()(aug(img)).permute(1,2,0)
-         for _ in range(num_rows * num_cols)]
     d2l.show_images(Y, num_rows, num_cols, scale=scale)
 ```
 
@@ -188,9 +180,9 @@ d2l.show_images(gluon.data.vision.CIFAR10(
 
 ```{.python .input}
 #@tab pytorch
-all_images = torchvision.datasets.CIFAR10(train=True, root="../temp", download=True)
-d2l.show_images([torchvision.transforms.ToTensor()(all_images[i][0]).permute(1,2,0)
-                 for i in range(32)], 4, 8, scale=0.8);
+all_images = torchvision.datasets.CIFAR10(train=True, root="../temp",
+                                          download=True)
+d2l.show_images([all_images[i][0] for i in range(32)], 4, 8, scale=0.8);
 ```
 
 In order to obtain definitive results during prediction, we usually only apply image augmentation to the training example, and do not use image augmentation with random operations during prediction. Here, we only use the simplest random left-right flipping method. In addition, we use a `ToTensor` instance to convert minibatch images into the format required by MXNet, i.e., 32-bit floating point numbers with the shape of (batch size, number of channels, height, width) and value range between 0 and 1.

--- a/chapter_linear-networks/image-classification-dataset.md
+++ b/chapter_linear-networks/image-classification-dataset.md
@@ -108,7 +108,7 @@ def get_fashion_mnist_labels(labels):  #@save
 We can now create a function to visualize these examples.
 
 ```{.python .input}
-#@tab all
+#@tab mxnet, tensorflow
 def show_images(imgs, num_rows, num_cols, titles=None, scale=1.5):  #@save
     """Plot a list of images."""
     figsize = (num_cols * scale, num_rows * scale)
@@ -116,6 +116,27 @@ def show_images(imgs, num_rows, num_cols, titles=None, scale=1.5):  #@save
     axes = axes.flatten()
     for i, (ax, img) in enumerate(zip(axes, imgs)):
         ax.imshow(d2l.numpy(img))
+        ax.axes.get_xaxis().set_visible(False)
+        ax.axes.get_yaxis().set_visible(False)
+        if titles:
+            ax.set_title(titles[i])
+    return axes
+```
+
+```{.python .input}
+#@tab pytorch
+def show_images(imgs, num_rows, num_cols, titles=None, scale=1.5):  #@save
+    """Plot a list of images."""
+    figsize = (num_cols * scale, num_rows * scale)
+    _, axes = d2l.plt.subplots(num_rows, num_cols, figsize=figsize)
+    axes = axes.flatten()
+    for i, (ax, img) in enumerate(zip(axes, imgs)):
+        if torch.is_tensor(img):
+            # Tensor Image
+            ax.imshow(img.numpy())
+        else:
+            # PIL Image
+            ax.imshow(img)
         ax.axes.get_xaxis().set_visible(False)
         ax.axes.get_yaxis().set_visible(False)
         if titles:

--- a/chapter_preface/index.md
+++ b/chapter_preface/index.md
@@ -425,7 +425,7 @@ StevenJokes, Tomer Kaftan, liweiwp, netyster, ypandya, NishantTharani, heiligerl
 Hoa Nguyen, manuel-arno-korfmann-webentwicklung, aterzis-personal, nxby, Xiaoting He, Josiah Yoder,
 mathresearch, mzz2017, jroberayalas, iluu, ghejc, BSharmi, vkramdev, simonwardjones, LakshKD,
 TalNeoran, djliden, Nikhil95, Oren Barkan, guoweis, haozhu233, pratikhack, 315930399, tayfununal,
-steinsag, charleybeller.
+steinsag, charleybeller, Andrew Lumsdaine.
 
 We thank Amazon Web Services, especially Swami Sivasubramanian,
 Raju Gulabani, Charlie Bell, and Andrew Jassy for their generous support in writing this book. Without the available time, resources, discussions with colleagues, and continuous encouragement this book would not have happened.

--- a/chapter_preface/index.md
+++ b/chapter_preface/index.md
@@ -265,7 +265,7 @@ to be saved in the package, we will mark it with
 The `d2l` package is light-weight and only requires
 the following packages and modules as dependencies:
 
-```{.python .input  n=1}
+```{.python .input}
 #@tab all
 #@save
 import collections
@@ -288,7 +288,6 @@ d2l = sys.modules[__name__]
 ```
 
 :begin_tab:`mxnet`
-
 Most of the code in this book is based on Apache MXNet.
 MXNet is an open-source framework for deep learning
 and the preferred choice of AWS (Amazon Web Services),
@@ -305,7 +304,6 @@ Here is how we import modules from MXNet.
 :end_tab:
 
 :begin_tab:`pytorch`
-
 Most of the code in this book is based on PyTorch.
 PyTorch is an open-source framework for deep learning, which is extremely
 popular in the research community.
@@ -321,7 +319,6 @@ Here is how we import modules from PyTorch.
 :end_tab:
 
 :begin_tab:`tensorflow`
-
 Most of the code in this book is based on TensorFlow.
 TensorFlow is an open-source framework for deep learning, which is extremely
 popular in both the research community and industrial.
@@ -336,13 +333,13 @@ to update your code and runtime environment.
 Here is how we import modules from TensorFlow.
 :end_tab:
 
-```{.python .input  n=1}
+```{.python .input}
 #@save
 from mxnet import autograd, context, gluon, image, init, np, npx
 from mxnet.gluon import nn, rnn
 ```
 
-```{.python .input  n=1}
+```{.python .input}
 #@tab pytorch
 #@save
 import numpy as np
@@ -352,9 +349,10 @@ from torch import nn
 from torch.nn import functional as F
 from torch.utils import data
 from torchvision import transforms
+from PIL import Image
 ```
 
-```{.python .input  n=1}
+```{.python .input}
 #@tab tensorflow
 #@save
 import numpy as np
@@ -427,7 +425,7 @@ StevenJokes, Tomer Kaftan, liweiwp, netyster, ypandya, NishantTharani, heiligerl
 Hoa Nguyen, manuel-arno-korfmann-webentwicklung, aterzis-personal, nxby, Xiaoting He, Josiah Yoder,
 mathresearch, mzz2017, jroberayalas, iluu, ghejc, BSharmi, vkramdev, simonwardjones, LakshKD,
 TalNeoran, djliden, Nikhil95, Oren Barkan, guoweis, haozhu233, pratikhack, 315930399, tayfununal,
-steinsag, charleybeller, Andrew Lumsdaine.
+steinsag, charleybeller.
 
 We thank Amazon Web Services, especially Swami Sivasubramanian,
 Raju Gulabani, Charlie Bell, and Andrew Jassy for their generous support in writing this book. Without the available time, resources, discussions with colleagues, and continuous encouragement this book would not have happened.

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -30,6 +30,7 @@ from torch import nn
 from torch.nn import functional as F
 from torch.utils import data
 from torchvision import transforms
+from PIL import Image
 
 
 # Defined in file: ./chapter_preliminaries/calculus.md
@@ -172,7 +173,12 @@ def show_images(imgs, num_rows, num_cols, titles=None, scale=1.5):
     _, axes = d2l.plt.subplots(num_rows, num_cols, figsize=figsize)
     axes = axes.flatten()
     for i, (ax, img) in enumerate(zip(axes, imgs)):
-        ax.imshow(d2l.numpy(img))
+        if torch.is_tensor(img):
+            # Tensor Image
+            ax.imshow(img.numpy())
+        else:
+            # PIL Image
+            ax.imshow(img)
         ax.axes.get_xaxis().set_visible(False)
         ax.axes.get_yaxis().set_visible(False)
         if titles:
@@ -1161,6 +1167,7 @@ class MultiHeadAttention(nn.Module):
         value = transpose_qkv(self.W_v(value), self.num_heads)
 
         if valid_len is not None:
+            # Copy `valid_len` by `num_heads` times
             if valid_len.ndim == 1:
               valid_len = valid_len.repeat(self.num_heads)
             else:


### PR DESCRIPTION
*Description of changes:*
This PR helps transition to `PIL.Image` for opening and rendering images since `torchvision` supports `torch.tensor` and `PIL` by default. Also helps to remove redundant and unnecessary transforms.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
