### PR TITLE
[PyTorch] Detection Scratch

### DIFF
--- a/chapter_computer-vision/anchor.md
+++ b/chapter_computer-vision/anchor.md
@@ -5,13 +5,23 @@ Object detection algorithms usually sample a large number of regions in the inpu
 
 First, import the packages or modules required for this section. Here, we have modified the printing accuracy of NumPy. Because printing tensors actually calls the print function of NumPy, the floating-point numbers in tensors printed in this section are more concise.
 
-```{.python .input  n=1}
+```{.python .input}
 %matplotlib inline
 from d2l import mxnet as d2l
 from mxnet import gluon, image, np, npx
 
 np.set_printoptions(2)
 npx.set_np()
+```
+
+```{.python .input}
+#@tab pytorch
+%matplotlib inline
+from d2l import torch as d2l
+import torch
+from math import sqrt
+
+torch.set_printoptions(2)
 ```
 
 ## Generating Multiple Anchor Boxes
@@ -26,7 +36,43 @@ That is, the number of anchor boxes centered on the same pixel is $n+m-1$. For t
 
 The above method of generating anchor boxes has been implemented in the `multibox_prior` function. We specify the input, a set of sizes, and a set of aspect ratios, and this function will return all the anchor boxes entered.
 
-```{.python .input  n=2}
+```{.python .input}
+#@tab pytorch
+#@save
+def multibox_prior(data, sizes, ratios):
+    in_height, in_width = data.shape[-2:]
+    num_sizes, num_ratios = len(sizes), len(ratios)
+    num_boxes = in_height * in_width * (num_sizes + num_ratios - 1)
+    output = d2l.zeros((1, num_boxes, 4))
+    steps_h = 1.0 / in_height
+    steps_w = 1.0 / in_width
+    offset_h, offset_w = 0.5, 0.5
+
+    for i in range(in_height):
+        center_h = (i + offset_h) * steps_h
+        for j in range(in_width):
+            center_w = (j + offset_w) * steps_w
+            for k in range(num_sizes + num_ratios - 1):
+                if k < num_sizes:
+                    w = sizes[k] * in_height / in_width / 2.0
+                    h = sizes[k] / 2.0
+                else:
+                    w = sizes[0] * in_height / in_width * sqrt(
+                                            ratios[k - num_sizes + 1]) / 2.0
+                    h = sizes[0] / sqrt(ratios[k - num_sizes + 1] * 1.0) / 2.0
+
+                count = i * in_width * (num_sizes + num_ratios - 1) +\
+                j * (num_sizes + num_ratios - 1) + k
+
+                output[0, count, 0] = center_w - w
+                output[0, count, 1] = center_h - h
+                output[0, count, 2] = center_w + w
+                output[0, count, 3] = center_h + h
+
+    return output
+```
+
+```{.python .input}
 img = image.imread('../img/catdog.jpg').asnumpy()
 h, w = img.shape[0:2]
 
@@ -36,16 +82,29 @@ Y = npx.multibox_prior(X, sizes=[0.75, 0.5, 0.25], ratios=[1, 2, 0.5])
 Y.shape
 ```
 
+```{.python .input}
+#@tab pytorch
+img = d2l.plt.imread('../img/catdog.jpg')
+h, w = img.shape[0:2]
+
+print(h, w)
+X = torch.rand(size=(1, 3, h, w))  # Construct input data
+Y = multibox_prior(X, sizes=[0.75, 0.5, 0.25], ratios=[1, 2, 0.5])
+Y.shape
+```
+
 We can see that the shape of the returned anchor box variable `y` is (batch size, number of anchor boxes, 4). After changing the shape of the anchor box variable `y` to (image height, image width, number of anchor boxes centered on the same pixel, 4), we can obtain all the anchor boxes centered on a specified pixel position. In the following example, we access the first anchor box centered on (250, 250). It has four elements: the $x, y$ axis coordinates in the upper-left corner and the $x, y$ axis coordinates in the lower-right corner of the anchor box. The coordinate values of the $x$ and $y$ axis are divided by the width and height of the image, respectively, so the value range is between 0 and 1.
 
-```{.python .input  n=4}
+```{.python .input}
+#@tab all
 boxes = Y.reshape(h, w, 5, 4)
 boxes[250, 250, 0, :]
 ```
 
 In order to describe all anchor boxes centered on one pixel in the image, we first define the `show_bboxes` function to draw multiple bounding boxes on the image.
 
-```{.python .input  n=5}
+```{.python .input}
+#@tab all
 #@save
 def show_bboxes(axes, bboxes, labels=None, colors=None):
     """Show bounding boxes."""
@@ -59,7 +118,7 @@ def show_bboxes(axes, bboxes, labels=None, colors=None):
     colors = _make_list(colors, ['b', 'g', 'r', 'm', 'c'])
     for i, bbox in enumerate(bboxes):
         color = colors[i % len(colors)]
-        rect = d2l.bbox_to_rect(bbox.asnumpy(), color)
+        rect = d2l.bbox_to_rect(d2l.numpy(bbox), color)
         axes.add_patch(rect)
         if labels and len(labels) > i:
             text_color = 'k' if color == 'w' else 'w'
@@ -70,9 +129,10 @@ def show_bboxes(axes, bboxes, labels=None, colors=None):
 
 As we just saw, the coordinate values of the $x$ and $y$ axis in the variable `boxes` have been divided by the width and height of the image, respectively. When drawing images, we need to restore the original coordinate values of the anchor boxes and therefore define the variable `bbox_scale`. Now, we can draw all the anchor boxes centered on (250, 250) in the image. As you can see, the blue anchor box with a size of 0.75 and an aspect ratio of 1 covers the dog in the image well.
 
-```{.python .input  n=7}
+```{.python .input}
+#@tab all
 d2l.set_figsize()
-bbox_scale = np.array((w, h, w, h))
+bbox_scale = d2l.tensor((w, h, w, h))
 fig = d2l.plt.imshow(img)
 show_bboxes(fig.axes, boxes[250, 250, :, :] * bbox_scale,
             ['s=0.75, r=1', 's=0.5, r=1', 's=0.25, r=1', 's=0.75, r=2',
@@ -131,10 +191,11 @@ The default values of the constant are $\mu_x = \mu_y = \mu_w = \mu_h = 0, \sigm
 
 Below we demonstrate a detailed example. We define ground-truth bounding boxes for the cat and dog in the read image, where the first element is category (0 for dog, 1 for cat) and the remaining four elements are the $x, y$ axis coordinates at top-left corner and $x, y$ axis coordinates at lower-right corner (the value range is between 0 and 1). Here, we construct five anchor boxes to be labeled by the coordinates of the upper-left corner and the lower-right corner, which are recorded as $A_0, \ldots, A_4$, respectively (the index in the program starts from 0). First, draw the positions of these anchor boxes and the ground-truth bounding boxes in the image.
 
-```{.python .input  n=6}
-ground_truth = np.array([[0, 0.1, 0.08, 0.52, 0.92],
+```{.python .input}
+#@tab all
+ground_truth = d2l.tensor([[0, 0.1, 0.08, 0.52, 0.92],
                          [1, 0.55, 0.2, 0.9, 0.88]])
-anchors = np.array([[0, 0.1, 0.2, 0.3], [0.15, 0.2, 0.4, 0.4],
+anchors = d2l.tensor([[0, 0.1, 0.2, 0.3], [0.15, 0.2, 0.4, 0.4],
                     [0.63, 0.05, 0.88, 0.98], [0.66, 0.45, 0.8, 0.8],
                     [0.57, 0.3, 0.92, 0.9]])
 
@@ -145,7 +206,7 @@ show_bboxes(fig.axes, anchors * bbox_scale, ['0', '1', '2', '3', '4']);
 
 We can label categories and offsets for anchor boxes by using the `multibox_target` function. This function sets the background category to 0 and increments the integer index of the target category from zero by 1 (1 for dog and 2 for cat). We add example dimensions to the anchor boxes and ground-truth bounding boxes and construct random predicted results with a shape of (batch size, number of categories including background, number of anchor boxes) by using the `expand_dims` function.
 
-```{.python .input  n=7}
+```{.python .input}
 labels = npx.multibox_target(np.expand_dims(anchors, axis=0),
                              np.expand_dims(ground_truth, axis=0),
                              np.zeros((1, 3, 5)))
@@ -153,7 +214,7 @@ labels = npx.multibox_target(np.expand_dims(anchors, axis=0),
 
 There are three items in the returned result, all of which are in the tensor format. The third item is represented by the category labeled for the anchor box.
 
-```{.python .input  n=8}
+```{.python .input}
 labels[2]
 ```
 
@@ -163,13 +224,13 @@ We analyze these labelled categories based on positions of anchor boxes and grou
 The second item of the return value is a mask variable, with the shape of (batch size, four times the number of anchor boxes). The elements in the mask variable correspond one-to-one with the four offset values of each anchor box.
 Because we do not care about background detection, offsets of the negative class should not affect the target function. By multiplying by element, the 0 in the mask variable can filter out negative class offsets before calculating target function.
 
-```{.python .input  n=9}
+```{.python .input}
 labels[1]
 ```
 
 The first item returned is the four offset values labeled for each anchor box, with the offsets of negative class anchor boxes labeled as 0.
 
-```{.python .input  n=10}
+```{.python .input}
 labels[0]
 ```
 
@@ -182,7 +243,7 @@ Next, select the prediction bounding box $B_2$ with the second highest confidenc
 
 Next, we will look at a detailed example. First, construct four anchor boxes. For the sake of simplicity, we assume that predicted offsets are all 0. This means that the prediction bounding boxes are anchor boxes. Finally, we construct a predicted probability for each category.
 
-```{.python .input  n=11}
+```{.python .input}
 anchors = np.array([[0.1, 0.08, 0.52, 0.92], [0.08, 0.2, 0.56, 0.95],
                     [0.15, 0.3, 0.62, 0.91], [0.55, 0.2, 0.9, 0.88]])
 offset_preds = np.array([0] * anchors.size)
@@ -193,7 +254,7 @@ cls_probs = np.array([[0] * 4,  # Predicted probability for background
 
 Print prediction bounding boxes and their confidence levels on the image.
 
-```{.python .input  n=12}
+```{.python .input}
 fig = d2l.plt.imshow(img)
 show_bboxes(fig.axes, anchors * bbox_scale,
             ['dog=0.9', 'dog=0.8', 'dog=0.7', 'cat=0.9'])
@@ -201,7 +262,7 @@ show_bboxes(fig.axes, anchors * bbox_scale,
 
 We use the `multibox_detection` function to perform NMS and set the threshold to 0.5. This adds an example dimension to the tensor input. We can see that the shape of the returned result is (batch size, number of anchor boxes, 6). The 6 elements of each row represent the output information for the same prediction bounding box. The first element is the predicted category index, which starts from 0 (0 is dog, 1 is cat). The value -1 indicates background or removal in NMS. The second element is the confidence level of prediction bounding box. The remaining four elements are the $x, y$ axis coordinates of the upper-left corner and the $x, y$ axis coordinates of the lower-right corner of the prediction bounding box (the value range is between 0 and 1).
 
-```{.python .input  n=13}
+```{.python .input}
 output = npx.multibox_detection(
     np.expand_dims(cls_probs, axis=0),
     np.expand_dims(offset_preds, axis=0),
@@ -212,7 +273,7 @@ output
 
 We remove the prediction bounding boxes of category -1 and visualize the results retained by NMS.
 
-```{.python .input  n=14}
+```{.python .input}
 fig = d2l.plt.imshow(img)
 for i in output[0].asnumpy():
     if i[0] == -1:
@@ -237,7 +298,6 @@ In practice, we can remove prediction bounding boxes with lower confidence level
 1. Construct two bounding boxes with an IoU of 0.5, and observe their coincidence.
 1. Verify the output of offset `labels[0]` by marking the anchor box offsets as defined in this section (the constant is the default value).
 1. Modify the variable `anchors` in the "Labeling Training Set Anchor Boxes" and "Output Bounding Boxes for Prediction" sections. How do the results change?
-
 
 :begin_tab:`mxnet`
 [Discussions](https://discuss.d2l.ai/t/370)

--- a/chapter_computer-vision/anchor.md
+++ b/chapter_computer-vision/anchor.md
@@ -19,7 +19,7 @@ npx.set_np()
 %matplotlib inline
 from d2l import torch as d2l
 import torch
-from math import sqrt
+import math
 
 torch.set_printoptions(2)
 ```
@@ -57,9 +57,9 @@ def multibox_prior(data, sizes, ratios):
                     w = sizes[k] * in_height / in_width / 2.0
                     h = sizes[k] / 2.0
                 else:
-                    w = sizes[0] * in_height / in_width * sqrt(
+                    w = sizes[0] * in_height / in_width * math.sqrt(
                                             ratios[k - num_sizes + 1]) / 2.0
-                    h = sizes[0] / sqrt(ratios[k - num_sizes + 1] * 1.0) / 2.0
+                    h = sizes[0] / math.sqrt(ratios[k - num_sizes + 1] * 1.0) / 2.0
 
                 count = i * in_width * (num_sizes + num_ratios - 1) +\
                 j * (num_sizes + num_ratios - 1) + k

--- a/chapter_computer-vision/anchor.md
+++ b/chapter_computer-vision/anchor.md
@@ -186,16 +186,11 @@ As shown in :numref:`fig_anchor_label` (left), assuming that the maximum value i
 def match_anchor_to_bbox(ground_truth, anchors, iou_threshold=0.5):
     """Assign ground-truth bounding boxes to anchor boxes similar to them."""
     num_anchors, num_gt_boxes = anchors.shape[0], ground_truth.shape[0]
-    anchors = torchvision.ops.box_convert(anchors,
-                                            in_fmt='cxcywh', out_fmt='xyxy')
-    ground_truth = torchvision.ops.box_convert(ground_truth,
-                                            in_fmt='cxcywh', out_fmt='xyxy')
     # element `x_ij` in the `i^th` row and `j^th` column is the IoU
     # of the anchor box `anc_i` to the ground-truth bounding box `box_j`
     jaccard = torchvision.ops.box_iou(anchors, ground_truth)
     # Initialize the tensor to hold assigned ground truth bbox for each anchor
     anchors_bbox_map = torch.full((num_anchors,), -1, dtype=torch.long)
-
     # Assign ground truth bounding box according to the threshold
     max_ious, indices = torch.max(jaccard, dim=1)
     anc_i = torch.nonzero(max_ious >= 0.5).reshape(-1)

--- a/chapter_computer-vision/anchor.md
+++ b/chapter_computer-vision/anchor.md
@@ -200,7 +200,6 @@ def match_anchor_to_bbox(ground_truth, anchors, iou_threshold=0.5):
     anc_i = torch.argmax(jaccard, dim=0)
     box_j = torch.arange(num_gt_boxes)
     anchors_bbox_map[anc_i] = box_j
-
     return anchors_bbox_map
 ```
 
@@ -216,7 +215,18 @@ The default values of the constant are $\mu_x = \mu_y = \mu_w = \mu_h = 0, \sigm
 ```{.python .input}
 #@tab pytorch
 #@save
-def multibox_target(anchors, labels, device="cpu", eps=1e-6):
+def offset_boxes(anchors, assigned_bb, eps=1e-6):
+    c_anc = torchvision.ops.box_convert(anchors, in_fmt='xyxy',
+                                             out_fmt='cxcywh')
+    c_assigned_bb = torchvision.ops.box_convert(assigned_bb,
+                                        in_fmt='xyxy', out_fmt='cxcywh')
+    offset_xy = 10 * (c_assigned_bb[:, :2] - c_anc[:, :2]) / c_anc[:, 2:]
+    offset_wh = 5 * torch.log(eps + c_assigned_bb[:, 2:] / c_anc[:, 2:])
+    offset = torch.cat([offset_xy, offset_wh], dim=1)
+    return offset
+
+#@save
+def multibox_target(anchors, labels, device="cpu"):
     batch_size, anchors = labels.shape[0], anchors.squeeze(0)
     batch_offset, batch_mask, batch_class_labels = [], [], []
     num_anchors = anchors.shape[0]
@@ -234,15 +244,8 @@ def multibox_target(anchors, labels, device="cpu", eps=1e-6):
         bb_idx = anchors_bbox_map[indices_true]
         class_labels[indices_true] = label[bb_idx, 0].long() + 1
         assigned_bb[indices_true] = label[bb_idx, 1:]
-
         # offset transformations
-        c_anc = torchvision.ops.box_convert(anchors, in_fmt='xyxy',
-                                                 out_fmt='cxcywh')
-        c_assigned_bb = torchvision.ops.box_convert(assigned_bb,
-                                            in_fmt='xyxy', out_fmt='cxcywh')
-        offset_xy = 10 * (c_assigned_bb[:, :2] - c_anc[:, :2]) / c_anc[:, 2:]
-        offset_wh = 5 * torch.log(eps + c_assigned_bb[:, 2:] / c_anc[:, 2:])
-        offset = torch.cat([offset_xy, offset_wh], dim=1) * bbox_mask
+        offset = offset_boxes(anchors, assigned_bb) * bbox_mask
 
         batch_offset.append(offset.reshape(-1))
         batch_mask.append(bbox_mask.reshape(-1))
@@ -319,6 +322,17 @@ Next, select the prediction bounding box $B_2$ with the second highest confidenc
 
 ```{.python .input}
 #@tab pytorch
+#@save
+def offset_inverse(anchors, offset_preds):
+    c_anc = torchvision.ops.box_convert(anchors, in_fmt='xyxy',
+                                        out_fmt='cxcywh')
+    c_pred_bb_xy = (offset_preds[:, :2] * c_anc[:, 2:] / 10) + c_anc[:, :2]
+    c_pred_bb_wh = torch.exp(offset_preds[:, 2:] / 5) * c_anc[:, 2:]
+    c_pred_bb = torch.cat((c_pred_bb_xy, c_pred_bb_wh), dim=1)
+    predicted_bb = torchvision.ops.box_convert(c_pred_bb, in_fmt='cxcywh',
+                                               out_fmt='xyxy')
+    return predicted_bb
+
 #@save
 def nms(bb_info_list, nms_threshold = 0.5):
     """non-maximum suppression"""
@@ -433,4 +447,8 @@ In practice, we can remove prediction bounding boxes with lower confidence level
 
 :begin_tab:`mxnet`
 [Discussions](https://discuss.d2l.ai/t/370)
+:end_tab:
+
+:begin_tab:`pytorch`
+[Discussions](https://discuss.d2l.ai/t/1603)
 :end_tab:

--- a/chapter_computer-vision/anchor.md
+++ b/chapter_computer-vision/anchor.md
@@ -20,7 +20,6 @@ npx.set_np()
 from d2l import torch as d2l
 import torch
 import torchvision
-import collections
 
 torch.set_printoptions(2)
 ```

--- a/chapter_computer-vision/anchor.md
+++ b/chapter_computer-vision/anchor.md
@@ -246,15 +246,12 @@ def multibox_target(anchors, labels, device="cpu"):
         assigned_bb[indices_true] = label[bb_idx, 1:]
         # offset transformations
         offset = offset_boxes(anchors, assigned_bb) * bbox_mask
-
         batch_offset.append(offset.reshape(-1))
         batch_mask.append(bbox_mask.reshape(-1))
         batch_class_labels.append(class_labels)
-
     bbox_offset = torch.stack(batch_offset)
     bbox_mask = torch.stack(batch_mask)
     class_labels = torch.stack(batch_class_labels)
-
     return [bbox_offset.to(device), bbox_mask.to(device),
             class_labels.to(device)]
 ```

--- a/chapter_computer-vision/anchor.md
+++ b/chapter_computer-vision/anchor.md
@@ -334,45 +334,30 @@ def offset_inverse(anchors, offset_preds):
     return predicted_bb
 
 #@save
-def nms(bb_info_list, nms_threshold = 0.5):
-    """non-maximum suppression"""
-    keep = [] # boxes that will be kept
-    sorted_bb_info_list = sorted(bb_info_list, key = lambda x: x.confidence,
-                                 reverse=True)
-    while len(sorted_bb_info_list) != 0:
-        top = sorted_bb_info_list.pop(0)
-        keep.append(top)
-        n = len(sorted_bb_info_list)
-        if n==0:
-            break
-        bb_coords = [bb.coords for bb in sorted_bb_info_list]
-        iou = torchvision.ops.box_iou(torch.tensor([top.coords]),
-                                      torch.tensor(bb_coords))[0]
-        inds = torch.nonzero(iou <= nms_threshold).reshape(-1)
-        sorted_bb_info_list = [sorted_bb_info_list[inds]]
-    return keep
-
-#@save
-def multibox_detection(cls_probs, offset_preds, anchors, nms_threshold=0.5):
-    BB_Info = collections.namedtuple("BB_Info", ["idx", "class_labels",
-                                                 "confidence", "coords"])
+def multibox_detection(cls_probs, offset_preds, anchors, nms_threshold=0.5,
+                       score_threshold=0.0099):
     batch_size = cls_probs.shape[0]
-    outputs = []
+    anchors = anchors.squeeze(0)
+    num_classes, num_anchors = cls_probs.shape[1], cls_probs.shape[2]
+    out = []
     for i in range(batch_size):
-        cls_prob, offset_pred = cls_probs[i], offset_preds[i]
-        anchor, num_bb_pred = anchors[0], cls_prob.shape[1]
-        anchor = anchor + offset_pred.reshape(num_bb_pred, 4)
-        confidence, class_labels = torch.max(cls_prob, 0)
-        bb_info = [BB_Info(idx = i, class_labels = class_labels[i] - 1,
-                           confidence = confidence[i], coords = [*anchor[i]])
-                   for i in range(num_bb_pred)]
-        obj_bb_idx = [bb.idx for bb in nms(bb_info, nms_threshold)]
-        output = []
-        for bb in bb_info:
-            output.append([(bb.class_labels if bb.idx in obj_bb_idx else -1.0),
-                           bb.confidence, *bb.coords])
-        outputs.append(torch.tensor(output))
-    return torch.stack(outputs)
+        cls_prob, offset_pred = cls_probs[i], offset_preds[i].reshape(-1, 4)
+        conf, class_id = torch.max(cls_prob[1:], 0)
+        predicted_bb = offset_inverse(anchors, offset_pred)
+        keep = torchvision.ops.nms(predicted_bb, conf, 0.5)
+        # find all non_keep indices and set the class_id to background
+        all_idx = torch.arange(num_anchors).long()
+        combined = torch.cat((keep, all_idx))
+        uniques, counts = combined.unique(return_counts=True)
+        non_keep = uniques[counts == 1]
+        all_id_sorted = torch.cat((keep, non_keep))
+        class_id[non_keep] = -1
+        class_id = class_id[all_id_sorted]
+        pred_info = torch.cat((class_id.unsqueeze(1),
+                               conf[all_id_sorted].unsqueeze(1),
+                               predicted_bb[all_id_sorted]), dim=1)
+        out.append(pred_info)
+    return torch.stack(out)
 ```
 
 Next, we will look at a detailed example. First, construct four anchor boxes. For the sake of simplicity, we assume that predicted offsets are all 0. This means that the prediction bounding boxes are anchor boxes. Finally, we construct a predicted probability for each category.

--- a/chapter_computer-vision/multiscale-object-detection.md
+++ b/chapter_computer-vision/multiscale-object-detection.md
@@ -6,7 +6,7 @@ It is not difficult to reduce the number of anchor boxes.  An easy way is to app
 
 To demonstrate how to generate anchor boxes on multiple scales, let us read an image first.  It has a height and width of $561 \times 728$ pixels.
 
-```{.python .input  n=1}
+```{.python .input}
 %matplotlib inline
 from d2l import mxnet as d2l
 from mxnet import image, np, npx
@@ -18,13 +18,23 @@ h, w = img.shape[0:2]
 h, w
 ```
 
+```{.python .input}
+#@tab pytorch
+%matplotlib inline
+from d2l import torch as d2l
+
+img = d2l.plt.imread('../img/catdog.jpg')
+h, w = img.shape[0:2]
+h, w
+```
+
 In :numref:`sec_conv_layer`, the 2D array output of the convolutional neural network (CNN) is called
 a feature map.  We can determine the midpoints of anchor boxes uniformly sampled
 on any image by defining the shape of the feature map.
 
 The function `display_anchors` is defined below.  We are going to generate anchor boxes `anchors` centered on each unit (pixel) on the feature map `fmap`.  Since the coordinates of axes $x$ and $y$ in anchor boxes `anchors` have been divided by the width and height of the feature map `fmap`, values between 0 and 1 can be used to represent relative positions of anchor boxes in the feature map.  Since the midpoints of anchor boxes `anchors` overlap with all the units on feature map `fmap`, the relative spatial positions of the midpoints of the `anchors` on any image must have a uniform distribution.  Specifically, when the width and height of the feature map are set to `fmap_w` and `fmap_h` respectively, the function will conduct uniform sampling for `fmap_h` rows and `fmap_w` columns of pixels and use them as midpoints to generate anchor boxes with size `s` (we assume that the length of list `s` is 1) and different aspect ratios (`ratios`).
 
-```{.python .input  n=2}
+```{.python .input}
 def display_anchors(fmap_w, fmap_h, s):
     d2l.set_figsize()
     # The values from the first two dimensions will not affect the output
@@ -35,21 +45,36 @@ def display_anchors(fmap_w, fmap_h, s):
                     anchors[0] * bbox_scale)
 ```
 
+```{.python .input}
+#@tab pytorch
+def display_anchors(fmap_w, fmap_h, s):
+    d2l.set_figsize()
+    # The values from the first two dimensions will not affect the output
+    fmap = d2l.zeros((1, 10, fmap_h, fmap_w))
+    anchors = d2l.multibox_prior(fmap, sizes=s, ratios=[1, 2, 0.5])
+    bbox_scale = d2l.tensor((w, h, w, h))
+    d2l.show_bboxes(d2l.plt.imshow(img).axes,
+                    anchors[0] * bbox_scale)
+```
+
 We will first focus on the detection of small objects. In order to make it easier to distinguish upon display, the anchor boxes with different midpoints here do not overlap. We assume that the size of the anchor boxes is 0.15 and the height and width of the feature map are 4. We can see that the midpoints of anchor boxes from the 4 rows and 4 columns on the image are uniformly distributed.
 
-```{.python .input  n=3}
+```{.python .input}
+#@tab all
 display_anchors(fmap_w=4, fmap_h=4, s=[0.15])
 ```
 
 We are going to reduce the height and width of the feature map by half and use a larger anchor box to detect larger objects. When the size is set to 0.4, overlaps will occur between regions of some anchor boxes.
 
-```{.python .input  n=4}
+```{.python .input}
+#@tab all
 display_anchors(fmap_w=2, fmap_h=2, s=[0.4])
 ```
 
 Finally, we are going to reduce the height and width of the feature map by half and increase the anchor box size to 0.8. Now the midpoint of the anchor box is the center of the image.
 
-```{.python .input  n=5}
+```{.python .input}
+#@tab all
 display_anchors(fmap_w=1, fmap_h=1, s=[0.8])
 ```
 

--- a/chapter_computer-vision/multiscale-object-detection.md
+++ b/chapter_computer-vision/multiscale-object-detection.md
@@ -22,6 +22,7 @@ h, w
 #@tab pytorch
 %matplotlib inline
 from d2l import torch as d2l
+import torch
 
 img = d2l.plt.imread('../img/catdog.jpg')
 h, w = img.shape[0:2]

--- a/chapter_computer-vision/object-detection-dataset.md
+++ b/chapter_computer-vision/object-detection-dataset.md
@@ -62,7 +62,6 @@ def load_data_bananas(batch_size, edge_size=256):
 def read_data_bananas(is_train=True): #@save
     """Read the bananas dataset images and labels."""
     data_dir = d2l.download_extract('banana-detection')
-    """Read all Bananas feature images and bounding box labels."""
     csv_fname = os.path.join(data_dir, 'bananas_train' if is_train
                                     else 'bananas_val', 'label.csv')
     csv_data = pd.read_csv(csv_fname)
@@ -77,11 +76,10 @@ def read_data_bananas(is_train=True): #@save
         # The target is as follows : (`label`, `xmin`, `ymin`, `xmax`, `ymax`)
         targets.append(list(target))
 
-    return images, torch.tensor(targets).unsqueeze(1)/256
+    return images, torch.tensor(targets).unsqueeze(1) / 256
 
 
 class BananasDataset(torch.utils.data.Dataset): #@save
-    """A customized dataset to load Bananas dataset."""
     def __init__(self, is_train):
         self.features, self.labels = read_data_bananas(is_train)
         print('read ' + str(len(self.features)) + (f' training examples' if

--- a/chapter_computer-vision/object-detection-dataset.md
+++ b/chapter_computer-vision/object-detection-dataset.md
@@ -20,6 +20,20 @@ d2l.DATA_HUB['bananas'] = (d2l.DATA_URL + 'bananas.zip',
                            'aadfd1c4c5d7178616799dd1801c9a234ccdaf19')
 ```
 
+```{.python .input  n=1}
+#@tab pytorch
+%matplotlib inline
+from d2l import torch as d2l
+import torch
+import torchvision
+import os
+import json
+
+#@save
+d2l.DATA_HUB['bananas_v2'] = (d2l.DATA_URL + 'bananas_v2.zip',
+                           '5a864ff8a4744b8d07a9d7aa18d86e5da815edbc')
+```
+
 ## Reading the Dataset
 
 We are going to read the object detection dataset by creating the instance `ImageDetIter`. The "Det" in the name refers to Detection. We will read the training dataset in random order. Since the format of the dataset is RecordIO, we need the image index file `'train.idx'` to read random minibatches. In addition, for each image of the training set, we will use random cropping and require the cropped image to cover at least 95% of each object. Since the cropping is random, this requirement is not always satisfied. We preset the maximum number of random cropping attempts to 200. If none of them meets the requirement, the image will not be cropped. To ensure the certainty of the output, we will not randomly crop the images in the test dataset. We also do not need to read the test dataset in random order.
@@ -43,6 +57,55 @@ def load_data_bananas(batch_size, edge_size=256):
     return train_iter, val_iter
 ```
 
+```{.python .input  n=2}
+#@save
+def read_data_bananas(is_train=True):
+    """Read the bananas dataset images and labels."""
+    data_dir = d2l.download_extract('bananas_v2')
+    """Read all Bananas feature images and bounding box labels."""
+    json_fname = os.path.join(data_dir, 'bananas_train' if is_train
+                                    else 'bananas_val', 'label.json')
+    with open(json_fname, 'r') as f:
+        data_dict = json.load(f)
+    images, labels = [], []
+    for i, fname in enumerate(data_dict.keys()):
+        images.append(torchvision.io.read_image(
+            os.path.join(data_dir, 'bananas_train' if is_train else
+                         'bananas_val', 'images', f'{fname}')))
+        # We only have one bbox per image
+        img_bbox = list(data_dict[fname][0].values())
+        # Since all images have same type of object class,
+        # add class category '0' corresponding to banana object
+        img_bbox.insert(0, 0)
+        labels.append(img_bbox)
+        
+    return images, torch.tensor(labels).unsqueeze(1)/256
+
+
+class BananasDataset(torch.utils.data.Dataset):
+    """A customized dataset to load Bananas dataset."""
+    def __init__(self, is_train):
+        self.features, self.labels = read_data_bananas(is_train)
+        print('read ' + str(len(self.features)) + (f' training examples' if
+              is_train else f' validation examples'))
+
+    def __getitem__(self, idx):
+        return (self.features[idx], self.labels[idx])
+
+    def __len__(self):
+        return len(self.features)
+
+
+def load_data_bananas(batch_size):
+    """Load the bananas dataset."""
+    train_iter = torch.utils.data.DataLoader(BananasDataset(is_train=True),
+                                             batch_size, shuffle=True)
+    val_iter = torch.utils.data.DataLoader(BananasDataset(is_train=False),
+                                           batch_size)
+    
+    return (train_iter, val_iter)
+```
+
 Below, we read a minibatch and print the shape of the image and label. The shape of the image is the same as in the previous experiment (batch size, number of channels, height, width). The shape of the label is (batch size, $m$, 5), where $m$ is equal to the maximum number of bounding boxes contained in a single image in the dataset. Although computation for the minibatch is very efficient, it requires each image to contain the same number of bounding boxes so that they can be placed in the same batch. Since each image may have a different number of bounding boxes, we can add illegal bounding boxes to images that have less than $m$ bounding boxes until each image contains $m$ bounding boxes. Thus, we can read a minibatch of images each time. The label of each bounding box in the image is represented by an array of length 5. The first element in the array is the category of the object contained in the bounding box. When the value is -1, the bounding box is an illegal bounding box for filling purpose. The remaining four elements of the array represent the $x, y$ axis coordinates of the upper-left corner of the bounding box and the $x, y$ axis coordinates of the lower-right corner of the bounding box (the value range is between 0 and 1). The banana dataset here has only one bounding box per image, so $m=1$.
 
 ```{.python .input  n=4}
@@ -50,6 +113,13 @@ batch_size, edge_size = 32, 256
 train_iter, _ = load_data_bananas(batch_size, edge_size)
 batch = train_iter.next()
 batch.data[0].shape, batch.label[0].shape
+```
+
+```{.python .input}
+#@tab pytorch
+train_iter, _ = load_data_bananas(batch_size=32)
+batch = next(iter(train_iter))
+batch[0].shape, batch[1].shape
 ```
 
 ## Demonstration
@@ -60,6 +130,14 @@ We have ten images with bounding boxes on them. We can see that the angle, size,
 imgs = (batch.data[0][0:10].transpose(0, 2, 3, 1)) / 255
 axes = d2l.show_images(imgs, 2, 5, scale=2)
 for ax, label in zip(axes, batch.label[0][0:10]):
+    d2l.show_bboxes(ax, [label[0][1:5] * edge_size], colors=['w'])
+```
+
+```{.python .input  n=5}
+#@tab pytorch
+imgs = (batch[0][0:10].permute(0, 2, 3, 1)) / 255
+axes = d2l.show_images(imgs, 2, 5, scale=2)
+for ax, label in zip(axes, batch[1][0:10]):
     d2l.show_bboxes(ax, [label[0][1:5] * edge_size], colors=['w'])
 ```
 

--- a/chapter_computer-vision/object-detection-dataset.md
+++ b/chapter_computer-vision/object-detection-dataset.md
@@ -58,8 +58,8 @@ def load_data_bananas(batch_size, edge_size=256):
 ```
 
 ```{.python .input}
-#@save
-def read_data_bananas(is_train=True):
+#@tab pytorch
+def read_data_bananas(is_train=True): #@save
     """Read the bananas dataset images and labels."""
     data_dir = d2l.download_extract('banana-detection')
     """Read all Bananas feature images and bounding box labels."""
@@ -74,13 +74,13 @@ def read_data_bananas(is_train=True):
                          'bananas_val', 'images', f'{img_name}')))
         # Since all images have same object class i.e. category '0'
         # the `label` column corresponds to the only object i.e. banana
-        # The target is as follows : (`label`, `xmin`, `ymin`, `xmax`, `ymax`) 
+        # The target is as follows : (`label`, `xmin`, `ymin`, `xmax`, `ymax`)
         targets.append(list(target))
-        
+
     return images, torch.tensor(targets).unsqueeze(1)/256
 
 
-class BananasDataset(torch.utils.data.Dataset):
+class BananasDataset(torch.utils.data.Dataset): #@save
     """A customized dataset to load Bananas dataset."""
     def __init__(self, is_train):
         self.features, self.labels = read_data_bananas(is_train)
@@ -94,13 +94,13 @@ class BananasDataset(torch.utils.data.Dataset):
         return len(self.features)
 
 
-def load_data_bananas(batch_size):
+def load_data_bananas(batch_size): #@save
     """Load the bananas dataset."""
     train_iter = torch.utils.data.DataLoader(BananasDataset(is_train=True),
                                              batch_size, shuffle=True)
     val_iter = torch.utils.data.DataLoader(BananasDataset(is_train=False),
                                            batch_size)
-    
+
     return (train_iter, val_iter)
 ```
 

--- a/chapter_computer-vision/object-detection-dataset.md
+++ b/chapter_computer-vision/object-detection-dataset.md
@@ -7,7 +7,7 @@ There are no small datasets, like MNIST or Fashion-MNIST, in the object detectio
 
 The banana detection dataset in RecordIO format can be downloaded directly from the Internet.
 
-```{.python .input  n=1}
+```{.python .input}
 %matplotlib inline
 from d2l import mxnet as d2l
 from mxnet import gluon, image, np, npx
@@ -20,25 +20,25 @@ d2l.DATA_HUB['bananas'] = (d2l.DATA_URL + 'bananas.zip',
                            'aadfd1c4c5d7178616799dd1801c9a234ccdaf19')
 ```
 
-```{.python .input  n=1}
+```{.python .input}
 #@tab pytorch
 %matplotlib inline
 from d2l import torch as d2l
 import torch
 import torchvision
 import os
-import json
+import pandas as pd
 
 #@save
-d2l.DATA_HUB['bananas_v2'] = (d2l.DATA_URL + 'bananas_v2.zip',
-                           '5a864ff8a4744b8d07a9d7aa18d86e5da815edbc')
+d2l.DATA_HUB['banana-detection'] = (d2l.DATA_URL + 'banana-detection.zip',
+                           '5de26c8fce5ccdea9f91267273464dc968d20d72')
 ```
 
 ## Reading the Dataset
 
 We are going to read the object detection dataset by creating the instance `ImageDetIter`. The "Det" in the name refers to Detection. We will read the training dataset in random order. Since the format of the dataset is RecordIO, we need the image index file `'train.idx'` to read random minibatches. In addition, for each image of the training set, we will use random cropping and require the cropped image to cover at least 95% of each object. Since the cropping is random, this requirement is not always satisfied. We preset the maximum number of random cropping attempts to 200. If none of them meets the requirement, the image will not be cropped. To ensure the certainty of the output, we will not randomly crop the images in the test dataset. We also do not need to read the test dataset in random order.
 
-```{.python .input  n=2}
+```{.python .input}
 #@save
 def load_data_bananas(batch_size, edge_size=256):
     """Load the bananas dataset."""
@@ -57,29 +57,27 @@ def load_data_bananas(batch_size, edge_size=256):
     return train_iter, val_iter
 ```
 
-```{.python .input  n=2}
+```{.python .input}
 #@save
 def read_data_bananas(is_train=True):
     """Read the bananas dataset images and labels."""
-    data_dir = d2l.download_extract('bananas_v2')
+    data_dir = d2l.download_extract('banana-detection')
     """Read all Bananas feature images and bounding box labels."""
-    json_fname = os.path.join(data_dir, 'bananas_train' if is_train
-                                    else 'bananas_val', 'label.json')
-    with open(json_fname, 'r') as f:
-        data_dict = json.load(f)
-    images, labels = [], []
-    for i, fname in enumerate(data_dict.keys()):
+    csv_fname = os.path.join(data_dir, 'bananas_train' if is_train
+                                    else 'bananas_val', 'label.csv')
+    csv_data = pd.read_csv(csv_fname)
+    csv_data = csv_data.set_index('img_name')
+    images, targets = [], []
+    for img_name, target in csv_data.iterrows():
         images.append(torchvision.io.read_image(
             os.path.join(data_dir, 'bananas_train' if is_train else
-                         'bananas_val', 'images', f'{fname}')))
-        # We only have one bbox per image
-        img_bbox = list(data_dict[fname][0].values())
-        # Since all images have same type of object class,
-        # add class category '0' corresponding to banana object
-        img_bbox.insert(0, 0)
-        labels.append(img_bbox)
+                         'bananas_val', 'images', f'{img_name}')))
+        # Since all images have same object class i.e. category '0'
+        # the `label` column corresponds to the only object i.e. banana
+        # The target is as follows : (`label`, `xmin`, `ymin`, `xmax`, `ymax`) 
+        targets.append(list(target))
         
-    return images, torch.tensor(labels).unsqueeze(1)/256
+    return images, torch.tensor(targets).unsqueeze(1)/256
 
 
 class BananasDataset(torch.utils.data.Dataset):
@@ -108,7 +106,7 @@ def load_data_bananas(batch_size):
 
 Below, we read a minibatch and print the shape of the image and label. The shape of the image is the same as in the previous experiment (batch size, number of channels, height, width). The shape of the label is (batch size, $m$, 5), where $m$ is equal to the maximum number of bounding boxes contained in a single image in the dataset. Although computation for the minibatch is very efficient, it requires each image to contain the same number of bounding boxes so that they can be placed in the same batch. Since each image may have a different number of bounding boxes, we can add illegal bounding boxes to images that have less than $m$ bounding boxes until each image contains $m$ bounding boxes. Thus, we can read a minibatch of images each time. The label of each bounding box in the image is represented by an array of length 5. The first element in the array is the category of the object contained in the bounding box. When the value is -1, the bounding box is an illegal bounding box for filling purpose. The remaining four elements of the array represent the $x, y$ axis coordinates of the upper-left corner of the bounding box and the $x, y$ axis coordinates of the lower-right corner of the bounding box (the value range is between 0 and 1). The banana dataset here has only one bounding box per image, so $m=1$.
 
-```{.python .input  n=4}
+```{.python .input}
 batch_size, edge_size = 32, 256
 train_iter, _ = load_data_bananas(batch_size, edge_size)
 batch = train_iter.next()
@@ -126,14 +124,14 @@ batch[0].shape, batch[1].shape
 
 We have ten images with bounding boxes on them. We can see that the angle, size, and position of banana are different in each image. Of course, this is a simple artificial dataset. In actual practice, the data are usually much more complicated.
 
-```{.python .input  n=5}
+```{.python .input}
 imgs = (batch.data[0][0:10].transpose(0, 2, 3, 1)) / 255
 axes = d2l.show_images(imgs, 2, 5, scale=2)
 for ax, label in zip(axes, batch.label[0][0:10]):
     d2l.show_bboxes(ax, [label[0][1:5] * edge_size], colors=['w'])
 ```
 
-```{.python .input  n=5}
+```{.python .input}
 #@tab pytorch
 imgs = (batch[0][0:10].permute(0, 2, 3, 1)) / 255
 axes = d2l.show_images(imgs, 2, 5, scale=2)

--- a/chapter_computer-vision/object-detection-dataset.md
+++ b/chapter_computer-vision/object-detection-dataset.md
@@ -113,7 +113,8 @@ batch.data[0].shape, batch.label[0].shape
 
 ```{.python .input}
 #@tab pytorch
-train_iter, _ = load_data_bananas(batch_size=32)
+batch_size, edge_size = 32, 256
+train_iter, _ = load_data_bananas(batch_size)
 batch = next(iter(train_iter))
 batch[0].shape, batch[1].shape
 ```

--- a/chapter_computer-vision/object-detection-dataset.md
+++ b/chapter_computer-vision/object-detection-dataset.md
@@ -86,7 +86,7 @@ class BananasDataset(torch.utils.data.Dataset): #@save
               is_train else f' validation examples'))
 
     def __getitem__(self, idx):
-        return (self.features[idx], self.labels[idx])
+        return (self.features[idx].float(), self.labels[idx])
 
     def __len__(self):
         return len(self.features)

--- a/chapter_computer-vision/ssd.md
+++ b/chapter_computer-vision/ssd.md
@@ -498,6 +498,42 @@ print(f'{train_iter.num_image / timer.stop():.1f} examples/sec on '
       f'{str(device)}')
 ```
 
+```{.python .input}
+#@tab pytorch
+num_epochs, timer = 20, d2l.Timer()
+animator = d2l.Animator(xlabel='epoch', xlim=[1, num_epochs],
+                        legend=['class error', 'bbox mae'])
+net = net.to(device)
+for epoch in range(num_epochs):
+    # accuracy_sum, mae_sum, num_examples, num_labels
+    metric = d2l.Accumulator(4)
+    net.train()
+    for features, target in train_iter:
+        timer.start()
+        trainer.zero_grad()
+        X, Y = features.to(device), target.to(device)
+        # Generate multiscale anchor boxes and predict the category and
+        # offset of each
+        anchors, cls_preds, bbox_preds = net(X)
+        # Label the category and offset of each anchor box
+        bbox_labels, bbox_masks, cls_labels = d2l.multibox_target(anchors,
+                                                        Y.cpu(), Y.device)
+        # Calculate the loss function using the predicted and labeled
+        # category and offset values
+        l = calc_loss(cls_preds, cls_labels.long(), bbox_preds, bbox_labels,
+                      bbox_masks)
+        l.mean().backward()
+        trainer.step()
+        metric.add(cls_eval(cls_preds, cls_labels), cls_labels.numel(),
+                   bbox_eval(bbox_preds, bbox_labels, bbox_masks),
+                   bbox_labels.numel())
+    cls_err, bbox_mae = 1 - metric[0] / metric[1], metric[2] / metric[3]
+    animator.add(epoch + 1, (cls_err, bbox_mae))
+print(f'class err {cls_err:.2e}, bbox mae {bbox_mae:.2e}')
+print(f'{len(train_iter.dataset) / timer.stop():.1f} examples/sec on '
+      f'{str(device)}')
+```
+
 ## Prediction
 
 In the prediction stage, we want to detect all objects of interest in the image. Below, we read the test image and transform its size. Then, we convert it to the four-dimensional format required by the convolutional layer.

--- a/chapter_computer-vision/ssd.md
+++ b/chapter_computer-vision/ssd.md
@@ -66,7 +66,7 @@ the parameters $a$ and $q$, it uses a $3\times3$ convolutional layer with a
 padding of 1. The heights and widths of the input and output of this
 convolutional layer remain unchanged.
 
-```{.python .input  n=1}
+```{.python .input}
 %matplotlib inline
 from d2l import mxnet as d2l
 from mxnet import autograd, gluon, image, init, np, npx
@@ -79,13 +79,33 @@ def cls_predictor(num_anchors, num_classes):
                      padding=1)
 ```
 
+```{.python .input}
+#@tab pytorch
+%matplotlib inline
+from d2l import torch as d2l
+import torch
+import torchvision
+from torch import nn
+from torch.nn import functional as F
+
+def cls_predictor(num_inputs, num_anchors, num_classes):
+    return nn.Conv2d(num_inputs, num_anchors * (num_classes + 1),
+                     kernel_size=3, padding=1)
+```
+
 ### Bounding Box Prediction Layer
 
 The design of the bounding box prediction layer is similar to that of the category prediction layer. The only difference is that, here, we need to predict 4 offsets for each anchor box, rather than $q+1$ categories.
 
-```{.python .input  n=2}
+```{.python .input}
 def bbox_predictor(num_anchors):
     return nn.Conv2D(num_anchors * 4, kernel_size=3, padding=1)
+```
+
+```{.python .input}
+#@tab pytorch
+def bbox_predictor(num_inputs, num_anchors):
+    return nn.Conv2d(num_inputs, num_anchors * 4, kernel_size=3, padding=1)
 ```
 
 ### Concatenating Predictions for Multiple Scales
@@ -94,7 +114,7 @@ As we mentioned, SSD uses feature maps based on multiple scales to generate anch
 
 In the following example, we use the same batch of data to construct feature maps of two different scales, `Y1` and `Y2`. Here, `Y2` has half the height and half the width of `Y1`. Using category prediction as an example, we assume that each element in the `Y1` and `Y2` feature maps generates five (Y1) or three (Y2) anchor boxes. When there are 10 object categories, the number of category prediction output channels is either $5\times(10+1)=55$ or $3\times(10+1)=33$. The format of the prediction output is (batch size, number of channels, height, width). As you can see, except for the batch size, the sizes of the other dimensions are different. Therefore, we must transform them into a consistent format and concatenate the predictions of the multiple scales to facilitate subsequent computation.
 
-```{.python .input  n=3}
+```{.python .input}
 def forward(x, block):
     block.initialize()
     return block(x)
@@ -104,9 +124,19 @@ Y2 = forward(np.zeros((2, 16, 10, 10)), cls_predictor(3, 10))
 (Y1.shape, Y2.shape)
 ```
 
+```{.python .input}
+#@tab pytorch
+def forward(x, block):
+    return block(x)
+
+Y1 = forward(torch.zeros((2, 8, 20, 20)), cls_predictor(8, 5, 10))
+Y2 = forward(torch.zeros((2, 16, 10, 10)), cls_predictor(16, 3, 10))
+(Y1.shape, Y2.shape)
+```
+
 The channel dimension contains the predictions for all anchor boxes with the same center. We first move the channel dimension to the final dimension. Because the batch size is the same for all scales, we can convert the prediction results to binary format (batch size, height $\times$ width $\times$ number of channels) to facilitate subsequent concatenation on the $1^{\mathrm{st}}$ dimension.
 
-```{.python .input  n=4}
+```{.python .input}
 def flatten_pred(pred):
     return npx.batch_flatten(pred.transpose(0, 2, 3, 1))
 
@@ -114,9 +144,19 @@ def concat_preds(preds):
     return np.concatenate([flatten_pred(p) for p in preds], axis=1)
 ```
 
+```{.python .input}
+#@tab pytorch
+def flatten_pred(pred):
+    return torch.flatten(pred.permute(0, 2, 3, 1), start_dim=1)
+
+def concat_preds(preds):
+    return torch.cat([flatten_pred(p) for p in preds], dim=1)
+```
+
 Thus, regardless of the different shapes of `Y1` and `Y2`, we can still concatenate the prediction results for the two different scales of the same batch.
 
-```{.python .input  n=5}
+```{.python .input}
+#@tab all
 concat_preds([Y1, Y2]).shape
 ```
 
@@ -124,7 +164,7 @@ concat_preds([Y1, Y2]).shape
 
 For multiscale object detection, we define the following `down_sample_blk` block, which reduces the height and width by 50%. This block consists of two $3\times3$ convolutional layers with a padding of 1 and a $2\times2$ maximum pooling layer with a stride of 2 connected in a series. As we know, $3\times3$ convolutional layers with a padding of 1 do not change the shape of feature maps. However, the subsequent pooling layer directly reduces the size of the feature map by half. Because $1\times 2+(3-1)+(3-1)=6$, each element in the output feature map has a receptive field on the input feature map of the shape $6\times6$. As you can see, the height and width downsample block enlarges the receptive field of each element in the output feature map.
 
-```{.python .input  n=6}
+```{.python .input}
 def down_sample_blk(num_channels):
     blk = nn.Sequential()
     for _ in range(2):
@@ -135,17 +175,36 @@ def down_sample_blk(num_channels):
     return blk
 ```
 
+```{.python .input}
+#@tab pytorch
+def down_sample_blk(in_channels, out_channels):
+    blk = []
+    for _ in range(2):
+        blk.append(nn.Conv2d(in_channels, out_channels,
+                             kernel_size=3, padding=1))
+        blk.append(nn.BatchNorm2d(out_channels))
+        blk.append(nn.ReLU())
+        in_channels = out_channels
+    blk.append(nn.MaxPool2d(2))
+    return nn.Sequential(*blk)
+```
+
 By testing forward computation in the height and width downsample block, we can see that it changes the number of input channels and halves the height and width.
 
-```{.python .input  n=7}
+```{.python .input}
 forward(np.zeros((2, 3, 20, 20)), down_sample_blk(10)).shape
+```
+
+```{.python .input}
+#@tab pytorch
+forward(torch.zeros((2, 3, 20, 20)), down_sample_blk(3, 10)).shape
 ```
 
 ### Base Network Block
 
 The base network block is used to extract features from original images. To simplify the computation, we will construct a small base network. This network consists of three height and width downsample blocks connected in a series, so it doubles the number of channels at each step. When we input an original image with the shape $256\times256$, the base network block outputs a feature map with the shape $32 \times 32$.
 
-```{.python .input  n=8}
+```{.python .input}
 def base_net():
     blk = nn.Sequential()
     for num_filters in [16, 32, 64]:
@@ -153,6 +212,18 @@ def base_net():
     return blk
 
 forward(np.zeros((2, 3, 256, 256)), base_net()).shape
+```
+
+```{.python .input}
+#@tab pytorch
+def base_net():
+    blk = []
+    num_filters = [3, 16, 32, 64]
+    for i in range(len(num_filters) - 1):
+        blk.append(down_sample_blk(num_filters[i], num_filters[i+1]))
+    return nn.Sequential(*blk)
+
+forward(torch.zeros((2, 3, 256, 256)), base_net()).shape
 ```
 
 ### The Complete Model
@@ -164,7 +235,7 @@ four are height and width downsample blocks, and the fifth module is a global
 maximum pooling layer that reduces the height and width to 1. Therefore, modules
 two to five are all multiscale feature blocks shown in :numref:`fig_ssd`.
 
-```{.python .input  n=9}
+```{.python .input}
 def get_blk(i):
     if i == 0:
         blk = base_net()
@@ -175,9 +246,23 @@ def get_blk(i):
     return blk
 ```
 
+```{.python .input}
+#@tab pytorch
+def get_blk(i):
+    if i == 0:
+        blk = base_net()
+    elif i == 1:
+        blk = down_sample_blk(64, 128)
+    elif i == 4:
+        blk = nn.AdaptiveMaxPool2d((1,1))
+    else:
+        blk = down_sample_blk(128, 128)
+    return blk
+```
+
 Now, we will define the forward computation process for each module. In contrast to the previously-described convolutional neural networks, this module not only returns feature map `Y` output by convolutional computation, but also the anchor boxes of the current scale generated from `Y` and their predicted categories and offsets.
 
-```{.python .input  n=10}
+```{.python .input}
 def blk_forward(X, blk, size, ratio, cls_predictor, bbox_predictor):
     Y = blk(X)
     anchors = npx.multibox_prior(Y, sizes=size, ratios=ratio)
@@ -186,9 +271,20 @@ def blk_forward(X, blk, size, ratio, cls_predictor, bbox_predictor):
     return (Y, anchors, cls_preds, bbox_preds)
 ```
 
+```{.python .input}
+#@tab pytorch
+def blk_forward(X, blk, size, ratio, cls_predictor, bbox_predictor):
+    Y = blk(X)
+    anchors = d2l.multibox_prior(Y, sizes=size, ratios=ratio)
+    cls_preds = cls_predictor(Y)
+    bbox_preds = bbox_predictor(Y)
+    return (Y, anchors, cls_preds, bbox_preds)
+```
+
 As we mentioned, the closer a multiscale feature block is to the top in :numref:`fig_ssd`, the larger the objects it detects and the larger the anchor boxes it must generate. Here, we first divide the interval from 0.2 to 1.05 into five equal parts to determine the sizes of smaller anchor boxes at different scales: 0.2, 0.37, 0.54, etc. Then, according to $\sqrt{0.2 \times 0.37} = 0.272$, $\sqrt{0.37 \times 0.54} = 0.447$, and similar formulas, we determine the sizes of larger anchor boxes at the different scales.
 
-```{.python .input  n=11}
+```{.python .input}
+#@tab all
 sizes = [[0.2, 0.272], [0.37, 0.447], [0.54, 0.619], [0.71, 0.79],
          [0.88, 0.961]]
 ratios = [[1, 2, 0.5]] * 5
@@ -197,7 +293,7 @@ num_anchors = len(sizes[0]) + len(ratios[0]) - 1
 
 Now, we can define the complete model, `TinySSD`.
 
-```{.python .input  n=12}
+```{.python .input}
 class TinySSD(nn.Block):
     def __init__(self, num_classes, **kwargs):
         super(TinySSD, self).__init__(**kwargs)
@@ -225,12 +321,55 @@ class TinySSD(nn.Block):
         return anchors, cls_preds, bbox_preds
 ```
 
+```{.python .input}
+#@tab pytorch
+class TinySSD(nn.Module):
+    def __init__(self, num_classes, **kwargs):
+        super(TinySSD, self).__init__(**kwargs)
+        self.num_classes = num_classes
+        idx_to_in_channels = [64, 128, 128, 128, 128]
+        for i in range(5):
+            # The assignment statement is self.blk_i = get_blk(i)
+            setattr(self, f'blk_{i}', get_blk(i))
+            setattr(self, f'cls_{i}', cls_predictor(idx_to_in_channels[i],
+                                                    num_anchors, num_classes))
+            setattr(self, f'bbox_{i}', bbox_predictor(idx_to_in_channels[i],
+                                                      num_anchors))
+
+    def forward(self, X):
+        anchors, cls_preds, bbox_preds = [None] * 5, [None] * 5, [None] * 5
+        for i in range(5):
+            # getattr(self, 'blk_%d' % i) accesses self.blk_i
+            X, anchors[i], cls_preds[i], bbox_preds[i] = blk_forward(
+                X, getattr(self, f'blk_{i}'), sizes[i], ratios[i],
+                getattr(self, f'cls_{i}'), getattr(self, f'bbox_{i}'))
+        # In the reshape function, 0 indicates that the batch size remains
+        # unchanged
+        anchors = torch.cat(anchors, dim=1)
+        cls_preds = concat_preds(cls_preds)
+        cls_preds = cls_preds.reshape(
+            cls_preds.shape[0], -1, self.num_classes + 1)
+        bbox_preds = concat_preds(bbox_preds)
+        return anchors, cls_preds, bbox_preds
+```
+
 We now create an SSD model instance and use it to perform forward computation on image minibatch `X`, which has a height and width of 256 pixels. As we verified previously, the first module outputs a feature map with the shape $32 \times 32$. Because modules two to four are height and width downsample blocks, module five is a global pooling layer, and each element in the feature map is used as the center for 4 anchor boxes, a total of $(32^2 + 16^2 + 8^2 + 4^2 + 1)\times 4 = 5444$ anchor boxes are generated for each image at the five scales.
 
-```{.python .input  n=13}
+```{.python .input}
 net = TinySSD(num_classes=1)
 net.initialize()
 X = np.zeros((32, 3, 256, 256))
+anchors, cls_preds, bbox_preds = net(X)
+
+print('output anchors:', anchors.shape)
+print('output class preds:', cls_preds.shape)
+print('output bbox preds:', bbox_preds.shape)
+```
+
+```{.python .input}
+#@tab pytorch
+net = TinySSD(num_classes=1)
+X = torch.zeros((32, 3, 256, 256))
 anchors, cls_preds, bbox_preds = net(X)
 
 print('output anchors:', anchors.shape)
@@ -246,25 +385,32 @@ Now, we will explain, step by step, how to train the SSD model for object detect
 
 We read the banana detection dataset we created in the previous section.
 
-```{.python .input  n=14}
+```{.python .input}
+#@tab all
 batch_size = 32
 train_iter, _ = d2l.load_data_bananas(batch_size)
 ```
 
 There is 1 category in the banana detection dataset. After defining the module, we need to initialize the model parameters and define the optimization algorithm.
 
-```{.python .input  n=15}
+```{.python .input}
 device, net = d2l.try_gpu(), TinySSD(num_classes=1)
 net.initialize(init=init.Xavier(), ctx=device)
 trainer = gluon.Trainer(net.collect_params(), 'sgd',
                         {'learning_rate': 0.2, 'wd': 5e-4})
 ```
 
+```{.python .input}
+#@tab pytorch
+device, net = d2l.try_gpu(), TinySSD(num_classes=1)
+trainer = torch.optim.SGD(net.parameters(), lr=0.2, weight_decay=5e-4)
+```
+
 ### Defining Loss and Evaluation Functions
 
 Object detection is subject to two types of losses. The first is anchor box category loss. For this, we can simply reuse the cross-entropy loss function we used in image classification. The second loss is positive anchor box offset loss. Offset prediction is a normalization problem. However, here, we do not use the squared loss introduced previously. Rather, we use the $L_1$ norm loss, which is the absolute value of the difference between the predicted value and the ground-truth value. The mask variable `bbox_masks` removes negative anchor boxes and padding anchor boxes from the loss calculation. Finally, we add the anchor box category and offset losses to find the final loss function for the model.
 
-```{.python .input  n=16}
+```{.python .input}
 cls_loss = gluon.loss.SoftmaxCrossEntropyLoss()
 bbox_loss = gluon.loss.L1Loss()
 
@@ -274,9 +420,23 @@ def calc_loss(cls_preds, cls_labels, bbox_preds, bbox_labels, bbox_masks):
     return cls + bbox
 ```
 
+```{.python .input}
+#@tab pytorch
+cls_loss = nn.CrossEntropyLoss(reduction='none')
+bbox_loss = nn.L1Loss(reduction='none')
+
+def calc_loss(cls_preds, cls_labels, bbox_preds, bbox_labels, bbox_masks):
+    batch_size, num_classes = cls_preds.shape[0], cls_preds.shape[2]
+    cls = cls_loss(cls_preds.reshape(-1, num_classes),
+                   cls_labels.reshape(-1)).reshape(batch_size, -1).mean(dim=1)
+    bbox = bbox_loss(bbox_preds * bbox_masks,
+                     bbox_labels * bbox_masks).mean(dim=1)
+    return cls + bbox
+```
+
 We can use the accuracy rate to evaluate the classification results. As we use the $L_1$ norm loss, we will use the average absolute error to evaluate the bounding box prediction results.
 
-```{.python .input  n=17}
+```{.python .input}
 def cls_eval(cls_preds, cls_labels):
     # Because the category prediction results are placed in the final
     # dimension, argmax must specify this dimension
@@ -287,11 +447,23 @@ def bbox_eval(bbox_preds, bbox_labels, bbox_masks):
     return float((np.abs((bbox_labels - bbox_preds) * bbox_masks)).sum())
 ```
 
+```{.python .input}
+#@tab pytorch
+def cls_eval(cls_preds, cls_labels):
+    # Because the category prediction results are placed in the final
+    # dimension, argmax must specify this dimension
+    return float((cls_preds.argmax(dim=-1).type(
+        cls_labels.dtype) == cls_labels).sum())
+
+def bbox_eval(bbox_preds, bbox_labels, bbox_masks):
+    return float((torch.abs((bbox_labels - bbox_preds) * bbox_masks)).sum())
+```
+
 ### Training the Model
 
 During model training, we must generate multiscale anchor boxes (`anchors`) in the model's forward computation process and predict the category (`cls_preds`) and offset (`bbox_preds`) for each anchor box. Afterwards, we label the category (`cls_labels`) and offset (`bbox_labels`) of each generated anchor box based on the label information `Y`. Finally, we calculate the loss function using the predicted and labeled category and offset values. To simplify the code, we do not evaluate the training dataset here.
 
-```{.python .input  n=29}
+```{.python .input}
 num_epochs, timer = 20, d2l.Timer()
 animator = d2l.Animator(xlabel='epoch', xlim=[1, num_epochs],
                         legend=['class error', 'bbox mae'])
@@ -319,10 +491,10 @@ for epoch in range(num_epochs):
         metric.add(cls_eval(cls_preds, cls_labels), cls_labels.size,
                    bbox_eval(bbox_preds, bbox_labels, bbox_masks),
                    bbox_labels.size)
-    cls_err, bbox_mae = 1-metric[0]/metric[1], metric[2]/metric[3]
-    animator.add(epoch+1, (cls_err, bbox_mae))
+    cls_err, bbox_mae = 1 - metric[0] / metric[1], metric[2] / metric[3]
+    animator.add(epoch + 1, (cls_err, bbox_mae))
 print(f'class err {cls_err:.2e}, bbox mae {bbox_mae:.2e}')
-print(f'{train_iter.num_image/timer.stop():.1f} examples/sec on '
+print(f'{train_iter.num_image / timer.stop():.1f} examples/sec on '
       f'{str(device)}')
 ```
 
@@ -330,7 +502,7 @@ print(f'{train_iter.num_image/timer.stop():.1f} examples/sec on '
 
 In the prediction stage, we want to detect all objects of interest in the image. Below, we read the test image and transform its size. Then, we convert it to the four-dimensional format required by the convolutional layer.
 
-```{.python .input  n=20}
+```{.python .input}
 img = image.imread('../img/banana.jpg')
 feature = image.imresize(img, 256, 256).astype('float32')
 X = np.expand_dims(feature.transpose(2, 0, 1), axis=0)
@@ -338,7 +510,7 @@ X = np.expand_dims(feature.transpose(2, 0, 1), axis=0)
 
 Using the `MultiBoxDetection` function, we predict the bounding boxes based on the anchor boxes and their predicted offsets. Then, we use non-maximum suppression to remove similar bounding boxes.
 
-```{.python .input  n=21}
+```{.python .input}
 def predict(X):
     anchors, cls_preds, bbox_preds = net(X.as_in_ctx(device))
     cls_probs = npx.softmax(cls_preds).transpose(0, 2, 1)
@@ -351,7 +523,7 @@ output = predict(X)
 
 Finally, we take all the bounding boxes with a confidence level of at least 0.3 and display them as the final output.
 
-```{.python .input  n=22}
+```{.python .input}
 def display(img, output, threshold):
     d2l.set_figsize((5, 5))
     fig = d2l.plt.imshow(img.asnumpy())
@@ -392,7 +564,7 @@ $$
 
 When $\sigma$ is large, this loss is similar to the $L_1$ norm loss. When the value is small, the loss function is smoother.
 
-```{.python .input  n=23}
+```{.python .input}
 sigmas = [10, 1, 0.5]
 lines = ['-', '--', '-.']
 x = np.arange(-2, 2, 0.1)
@@ -401,6 +573,28 @@ d2l.set_figsize()
 for l, s in zip(lines, sigmas):
     y = npx.smooth_l1(x, scalar=s)
     d2l.plt.plot(x.asnumpy(), y.asnumpy(), l, label='sigma=%.1f' % s)
+d2l.plt.legend();
+```
+
+```{.python .input}
+#@tab pytorch
+def smooth_l1(data, scalar):
+    out = []
+    for i in data:
+        if abs(i) < 1 / (scalar ** 2):
+            out.append(((scalar * i) ** 2) / 2)
+        else:
+            out.append(abs(i) - 0.5 / (scalar ** 2))
+    return torch.tensor(out)
+
+sigmas = [10, 1, 0.5]
+lines = ['-', '--', '-.']
+x = torch.arange(-2, 2, 0.1)
+d2l.set_figsize()
+
+for l, s in zip(lines, sigmas):
+    y = smooth_l1(x, scalar=s)
+    d2l.plt.plot(x, y, l, label='sigma=%.1f' % s)
 d2l.plt.legend();
 ```
 
@@ -414,7 +608,7 @@ $$ - \alpha (1-p_j)^{\gamma} \log p_j.$$
 
 As you can see, by increasing $\gamma$, we can effectively reduce the loss when the probability of predicting the correct category is high.
 
-```{.python .input  n=24}
+```{.python .input}
 def focal_loss(gamma, x):
     return -(1 - x) ** gamma * np.log(x)
 
@@ -422,6 +616,17 @@ x = np.arange(0.01, 1, 0.01)
 for l, gamma in zip(lines, [0, 1, 5]):
     y = d2l.plt.plot(x.asnumpy(), focal_loss(gamma, x).asnumpy(), l,
                      label='gamma=%.1f' % gamma)
+d2l.plt.legend();
+```
+
+```{.python .input}
+#@tab pytorch
+def focal_loss(gamma, x):
+    return -(1 - x) ** gamma * torch.log(x)
+
+x = torch.arange(0.01, 1, 0.01)
+for l, gamma in zip(lines, [0, 1, 5]):
+    y = d2l.plt.plot(x, focal_loss(gamma, x), l, label='gamma=%.1f' % gamma)
 d2l.plt.legend();
 ```
 

--- a/d2l/mxnet.py
+++ b/d2l/mxnet.py
@@ -1473,7 +1473,7 @@ def show_bboxes(axes, bboxes, labels=None, colors=None):
     colors = _make_list(colors, ['b', 'g', 'r', 'm', 'c'])
     for i, bbox in enumerate(bboxes):
         color = colors[i % len(colors)]
-        rect = d2l.bbox_to_rect(bbox.asnumpy(), color)
+        rect = d2l.bbox_to_rect(d2l.numpy(bbox), color)
         axes.add_patch(rect)
         if labels and len(labels) > i:
             text_color = 'k' if color == 'w' else 'w'

--- a/d2l/mxnet.py
+++ b/d2l/mxnet.py
@@ -984,7 +984,7 @@ def bleu(pred_seq, label_seq, k):
     return score
 
 
-# Defined in file: ./chapter_attention-mechanisms/attention.md
+# Defined in file: ./chapter_attention-mechanisms/attention-cues.md
 def show_heatmaps(matrices, xlabel, ylabel, titles=None, figsize=(2.5, 2.5),
                   cmap='Reds'):
     d2l.use_svg_display()

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -1543,34 +1543,35 @@ def bbox_to_rect(bbox, color):
 def multibox_prior(data, sizes, ratios):
     in_height, in_width = data.shape[-2:]
     num_sizes, num_ratios = len(sizes), len(ratios)
-    num_boxes = in_height * in_width * (num_sizes + num_ratios - 1)
-    output = d2l.zeros((1, num_boxes, 4))
-    steps_h = 1.0 / in_height
-    steps_w = 1.0 / in_width
+    boxes_per_pixel = (num_sizes + num_ratios - 1)
+    size_tensor, ratio_tensor = torch.tensor(sizes), torch.tensor(ratios)
+    # offsets are required to move the anchor to center of a pixel
+    # since pixel (height=1, width=1), we choose to offset our centers by 0.5
     offset_h, offset_w = 0.5, 0.5
+    steps_h = 1.0 / in_height    # scaled steps in y axis
+    steps_w = 1.0 / in_width     # scaled steps in x axis
 
-    for i in range(in_height):
-        center_h = (i + offset_h) * steps_h
-        for j in range(in_width):
-            center_w = (j + offset_w) * steps_w
-            for k in range(num_sizes + num_ratios - 1):
-                if k < num_sizes:
-                    w = sizes[k] * in_height / in_width / 2.0
-                    h = sizes[k] / 2.0
-                else:
-                    w = sizes[0] * in_height / in_width * math.sqrt(
-                                            ratios[k - num_sizes + 1]) / 2.0
-                    h = sizes[0] / math.sqrt(ratios[k - num_sizes + 1] * 1.0) / 2.0
+    # generate all center points for the anchor boxes
+    center_h = (torch.arange(in_height) + offset_h) * steps_h
+    center_w = (torch.arange(in_width) + offset_w) * steps_w
+    shift_y, shift_x = torch.meshgrid(center_h, center_w)
+    shift_y, shift_x = shift_y.reshape(-1), shift_x.reshape(-1)
 
-                count = i * in_width * (num_sizes + num_ratios - 1) +\
-                j * (num_sizes + num_ratios - 1) + k
+    # generate boxes_per_pixel number of heights and widths which are later
+    # used to create anchor box corner coordinates (xmin, xmax, ymin, ymax)
+    w = torch.cat((size_tensor, sizes[0] * torch.sqrt(ratio_tensor[1:])))\
+                * in_height / in_width / 2
+    h = torch.cat((size_tensor, sizes[0] / torch.sqrt(ratio_tensor[1:]))) / 2
+    anchor_manipulations = torch.stack((-w, -h, w, h)).T.repeat(
+                                        in_height * in_width, 1)
 
-                output[0, count, 0] = center_w - w
-                output[0, count, 1] = center_h - h
-                output[0, count, 2] = center_w + w
-                output[0, count, 3] = center_h + h
+    # each center point will have boxes_per_pixel number of anchor boxes, so
+    # generate grid of all anchor box centers with boxes_per_pixel repeats
+    out_grid = torch.stack([shift_x, shift_y, shift_x, shift_y],
+                dim=1).repeat_interleave(boxes_per_pixel, dim=0)
 
-    return output
+    output = out_grid + anchor_manipulations
+    return output.unsqueeze(0)
 
 
 # Defined in file: ./chapter_computer-vision/anchor.md

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -1083,7 +1083,7 @@ def bleu(pred_seq, label_seq, k):
     return score
 
 
-# Defined in file: ./chapter_attention-mechanisms/attention.md
+# Defined in file: ./chapter_attention-mechanisms/attention-cues.md
 def show_heatmaps(matrices, xlabel, ylabel, titles=None, figsize=(2.5, 2.5),
                   cmap='Reds'):
     d2l.use_svg_display()
@@ -1648,15 +1648,12 @@ def multibox_target(anchors, labels, device="cpu"):
         assigned_bb[indices_true] = label[bb_idx, 1:]
         # offset transformations
         offset = offset_boxes(anchors, assigned_bb) * bbox_mask
-
         batch_offset.append(offset.reshape(-1))
         batch_mask.append(bbox_mask.reshape(-1))
         batch_class_labels.append(class_labels)
-
     bbox_offset = torch.stack(batch_offset)
     bbox_mask = torch.stack(batch_mask)
     class_labels = torch.stack(batch_class_labels)
-
     return [bbox_offset.to(device), bbox_mask.to(device),
             class_labels.to(device)]
 

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -1605,7 +1605,6 @@ d2l.DATA_HUB['banana-detection'] = (d2l.DATA_URL + 'banana-detection.zip',
 def read_data_bananas(is_train=True):
     """Read the bananas dataset images and labels."""
     data_dir = d2l.download_extract('banana-detection')
-    """Read all Bananas feature images and bounding box labels."""
     csv_fname = os.path.join(data_dir, 'bananas_train' if is_train
                                     else 'bananas_val', 'label.csv')
     csv_data = pd.read_csv(csv_fname)
@@ -1620,11 +1619,10 @@ def read_data_bananas(is_train=True):
         # The target is as follows : (`label`, `xmin`, `ymin`, `xmax`, `ymax`)
         targets.append(list(target))
 
-    return images, torch.tensor(targets).unsqueeze(1)/256
+    return images, torch.tensor(targets).unsqueeze(1) / 256
 
 
 class BananasDataset(torch.utils.data.Dataset):
-    """A customized dataset to load Bananas dataset."""
     def __init__(self, is_train):
         self.features, self.labels = read_data_bananas(is_train)
         print('read ' + str(len(self.features)) + (f' training examples' if

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -1629,7 +1629,7 @@ class BananasDataset(torch.utils.data.Dataset):
               is_train else f' validation examples'))
 
     def __getitem__(self, idx):
-        return (self.features[idx], self.labels[idx])
+        return (self.features[idx].float(), self.labels[idx])
 
     def __len__(self):
         return len(self.features)

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -1600,16 +1600,11 @@ def show_bboxes(axes, bboxes, labels=None, colors=None):
 def match_anchor_to_bbox(ground_truth, anchors, iou_threshold=0.5):
     """Assign ground-truth bounding boxes to anchor boxes similar to them."""
     num_anchors, num_gt_boxes = anchors.shape[0], ground_truth.shape[0]
-    anchors = torchvision.ops.box_convert(anchors,
-                                            in_fmt='cxcywh', out_fmt='xyxy')
-    ground_truth = torchvision.ops.box_convert(ground_truth,
-                                            in_fmt='cxcywh', out_fmt='xyxy')
     # element `x_ij` in the `i^th` row and `j^th` column is the IoU
     # of the anchor box `anc_i` to the ground-truth bounding box `box_j`
     jaccard = torchvision.ops.box_iou(anchors, ground_truth)
     # Initialize the tensor to hold assigned ground truth bbox for each anchor
     anchors_bbox_map = torch.full((num_anchors,), -1, dtype=torch.long)
-
     # Assign ground truth bounding box according to the threshold
     max_ious, indices = torch.max(jaccard, dim=1)
     anc_i = torch.nonzero(max_ious >= 0.5).reshape(-1)

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -1539,6 +1539,62 @@ def bbox_to_rect(bbox, color):
         fill=False, edgecolor=color, linewidth=2)
 
 
+# Defined in file: ./chapter_computer-vision/anchor.md
+def multibox_prior(data, sizes, ratios):
+    in_height, in_width = data.shape[-2:]
+    num_sizes, num_ratios = len(sizes), len(ratios)
+    num_boxes = in_height * in_width * (num_sizes + num_ratios - 1)
+    output = d2l.zeros((1, num_boxes, 4))
+    steps_h = 1.0 / in_height
+    steps_w = 1.0 / in_width
+    offset_h, offset_w = 0.5, 0.5
+
+    for i in range(in_height):
+        center_h = (i + offset_h) * steps_h
+        for j in range(in_width):
+            center_w = (j + offset_w) * steps_w
+            for k in range(num_sizes + num_ratios - 1):
+                if k < num_sizes:
+                    w = sizes[k] * in_height / in_width / 2.0
+                    h = sizes[k] / 2.0
+                else:
+                    w = sizes[0] * in_height / in_width * sqrt(
+                                            ratios[k - num_sizes + 1]) / 2.0
+                    h = sizes[0] / sqrt(ratios[k - num_sizes + 1] * 1.0) / 2.0
+
+                count = i * in_width * (num_sizes + num_ratios - 1) +\
+                j * (num_sizes + num_ratios - 1) + k
+
+                output[0, count, 0] = center_w - w
+                output[0, count, 1] = center_h - h
+                output[0, count, 2] = center_w + w
+                output[0, count, 3] = center_h + h
+
+    return output
+
+
+# Defined in file: ./chapter_computer-vision/anchor.md
+def show_bboxes(axes, bboxes, labels=None, colors=None):
+    """Show bounding boxes."""
+    def _make_list(obj, default_values=None):
+        if obj is None:
+            obj = default_values
+        elif not isinstance(obj, (list, tuple)):
+            obj = [obj]
+        return obj
+    labels = _make_list(labels)
+    colors = _make_list(colors, ['b', 'g', 'r', 'm', 'c'])
+    for i, bbox in enumerate(bboxes):
+        color = colors[i % len(colors)]
+        rect = d2l.bbox_to_rect(d2l.numpy(bbox), color)
+        axes.add_patch(rect)
+        if labels and len(labels) > i:
+            text_color = 'k' if color == 'w' else 'w'
+            axes.text(rect.xy[0], rect.xy[1], labels[i],
+                      va='center', ha='center', fontsize=9, color=text_color,
+                      bbox=dict(facecolor=color, lw=0))
+
+
 # Defined in file: ./chapter_computer-vision/semantic-segmentation-and-dataset.md
 d2l.DATA_HUB['voc2012'] = (d2l.DATA_URL + 'VOCtrainval_11-May-2012.tar',
                            '4e443f8a2eca6b1dac8a6c57641b67dd40621a49')


### PR DESCRIPTION
### This PR refactors the four sections corresponding to Object Detection:

- [x] 13.4. Anchor Boxes
- [x] 13.5. Multiscale Object Detection
- [x] 13.6. The Object Detection Dataset
- [x] 13.7. Single Shot Multibox Detection (SSD)

Scratch implementation added for `multibox_prior`, `multibox_target`, `multibox_detection`

The bananas dataset has been switched to use a standard `dataset` and `dataloader`, while also reading the data from the standard file instead of the `RecordIO` dataset which is only native to MxNet.

### Follow Up PRs

- A subsequent PR will switch mxnet native functions to the scratch approach used in PyTorch.
- Later a PR will also update the text for both the frameworks.  
<hr/>

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
