### PR TITLE
[PyTorch ] Switch to torchvision nightly build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,7 @@ stage("Build and Publish") {
 
       sh label: "Sanity Check", script: """set -ex
       conda activate ${ENV_NAME}
+      d2lbook clear
       d2lbook build outputcheck tabcheck
       """
 

--- a/static/build.yml
+++ b/static/build.yml
@@ -7,9 +7,9 @@ dependencies:
     - mxnet-cu101==1.7.0
     - torch
     - --pre
-    - -f https://download.pytorch.org/whl/nightly/cu110/torch_nightly.html
+    - -f https://download.pytorch.org/whl/nightly/cu101/torch_nightly.html
     - torchvision
     - --pre
-    - -f https://download.pytorch.org/whl/nightly/cu110/torch_nightly.html
+    - -f https://download.pytorch.org/whl/nightly/cu101/torch_nightly.html
     - tensorflow==2.3.1
     - tensorflow-probability==0.11.1

--- a/static/build.yml
+++ b/static/build.yml
@@ -5,10 +5,10 @@ dependencies:
     - ..  # d2l
     - git+https://github.com/d2l-ai/d2l-book
     - mxnet-cu101==1.7.0
-    - torch
+    - torch==1.8.0.dev20201219+cu101
     - --pre
     - -f https://download.pytorch.org/whl/nightly/cu101/torch_nightly.html
-    - torchvision
+    - torchvision==0.9.0.dev20201219+cu101
     - --pre
     - -f https://download.pytorch.org/whl/nightly/cu101/torch_nightly.html
     - tensorflow==2.3.1

--- a/static/build.yml
+++ b/static/build.yml
@@ -5,8 +5,11 @@ dependencies:
     - ..  # d2l
     - git+https://github.com/d2l-ai/d2l-book
     - mxnet-cu101==1.7.0
-    - torchvision==0.8.2+cu101
-    - -f https://download.pytorch.org/whl/torch_stable.html
-    - torch==1.7.1+cu101
+    - torch
+    - --pre
+    - -f https://download.pytorch.org/whl/nightly/cu110/torch_nightly.html
+    - torchvision
+    - --pre
+    - -f https://download.pytorch.org/whl/nightly/cu110/torch_nightly.html
     - tensorflow==2.3.1
     - tensorflow-probability==0.11.1


### PR DESCRIPTION
*Description of changes:*
 This is a temporary change to incorporate and use native `torchvision.io` instead of `PIL` in semantic segmentation dataset section as mentioned in #1567. We'll switch back to the stable releases as soon as the next torch/torchvision versions are out.
This will also fix issues with `PIL.Image` errors in #1566.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
