### PR TITLE
Update googlenet.md

### DIFF
--- a/chapter_convolutional-modern/googlenet.md
+++ b/chapter_convolutional-modern/googlenet.md
@@ -335,7 +335,7 @@ net.add(b1, b2, b3, b4, b5, nn.Dense(10))
 #@tab pytorch
 b5 = nn.Sequential(Inception(832, 256, (160, 320), (32, 128), 128),
                    Inception(832, 384, (192, 384), (48, 128), 128),
-                   nn.AdaptiveMaxPool2d((1,1)),
+                   nn.AdaptiveAvgPool2d((1,1)),
                    nn.Flatten())
 
 net = nn.Sequential(b1, b2, b3, b4, b5, nn.Linear(1024, 10))


### PR DESCRIPTION

*Description of changes: Instead of global average pooling, global max-pooling was used in the Pytorch version.* 



By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.


Example: 

```{python}

import torch
import torch.nn as nn

t = torch.range(0,39).reshape(1,10,2,2)
t

```
Example tensor:
```
tensor([[[[ 0.,  1.],
          [ 2.,  3.]],

         [[ 4.,  5.],
          [ 6.,  7.]],

         [[ 8.,  9.],
          [10., 11.]],

         [[12., 13.],
          [14., 15.]],

         [[16., 17.],
          [18., 19.]],

         [[20., 21.],
          [22., 23.]],

         [[24., 25.],
          [26., 27.]],

         [[28., 29.],
          [30., 31.]],

         [[32., 33.],
          [34., 35.]],

         [[36., 37.],
          [38., 39.]]]])
```

Using Global average pooling:

```{python}

avg2d = nn.AdaptiveAvgPool2d((1,1))
avg2d(t)
```
Result:
```
tensor([[[[ 1.5000]],

         [[ 5.5000]],

         [[ 9.5000]],

         [[13.5000]],

         [[17.5000]],

         [[21.5000]],

         [[25.5000]],

         [[29.5000]],

         [[33.5000]],

         [[37.5000]]]])
```

Using Global max pooling:

```{python}

max2d = nn.AdaptiveMaxPool2d((1,1))
max2d(t)
```
Result:
```
tensor([[[[ 3.]],

         [[ 7.]],

         [[11.]],

         [[15.]],

         [[19.]],

         [[23.]],

         [[27.]],

         [[31.]],

         [[35.]],

         [[39.]]]])
```

Hence, I think usage of `nn.AdaptiveAvgPool2d((1,1))`, is better choice as per design.


