### PR TITLE
[MXNet] Add Obj Detection Dataset scratch

### DIFF
--- a/chapter_computer-vision/object-detection-dataset.md
+++ b/chapter_computer-vision/object-detection-dataset.md
@@ -12,12 +12,13 @@ The banana detection dataset in RecordIO format can be downloaded directly from 
 from d2l import mxnet as d2l
 from mxnet import gluon, image, np, npx
 import os
+import pandas as pd
 
 npx.set_np()
 
 #@save
-d2l.DATA_HUB['bananas'] = (d2l.DATA_URL + 'bananas.zip',
-                           'aadfd1c4c5d7178616799dd1801c9a234ccdaf19')
+d2l.DATA_HUB['banana-detection'] = (d2l.DATA_URL + 'banana-detection.zip',
+                           '5de26c8fce5ccdea9f91267273464dc968d20d72')
 ```
 
 ```{.python .input}
@@ -40,21 +41,48 @@ We are going to read the object detection dataset by creating the instance `Imag
 
 ```{.python .input}
 #@save
-def load_data_bananas(batch_size, edge_size=256):
+def read_data_bananas(is_train=True):
+    """Read the bananas dataset images and labels."""
+    data_dir = d2l.download_extract('banana-detection')
+    csv_fname = os.path.join(data_dir, 'bananas_train' if is_train
+                                    else 'bananas_val', 'label.csv')
+    csv_data = pd.read_csv(csv_fname)
+    csv_data = csv_data.set_index('img_name')
+    images, targets = [], []
+    for img_name, target in csv_data.iterrows():
+        images.append(image.imread(
+            os.path.join(data_dir, 'bananas_train' if is_train else
+                         'bananas_val', 'images', f'{img_name}')))
+        # Since all images have same object class i.e. category '0',
+        # the `label` column corresponds to the only object i.e. banana
+        # The target is as follows : (`label`, `xmin`, `ymin`, `xmax`, `ymax`)
+        targets.append(list(target))
+    return images, np.expand_dims(np.array(targets), 1) / 256
+
+
+#@save
+class BananasDataset(gluon.data.Dataset):
+    def __init__(self, is_train):
+        self.features, self.labels = read_data_bananas(is_train)
+        print('read ' + str(len(self.features)) + (f' training examples' if
+              is_train else f' validation examples'))
+
+    def __getitem__(self, idx):
+        return (self.features[idx].astype('float32').transpose(2, 0, 1),
+                self.labels[idx])
+
+    def __len__(self):
+        return len(self.features)
+
+
+#@save
+def load_data_bananas(batch_size):
     """Load the bananas dataset."""
-    data_dir = d2l.download_extract('bananas')
-    train_iter = image.ImageDetIter(
-        path_imgrec=os.path.join(data_dir, 'train.rec'),
-        path_imgidx=os.path.join(data_dir, 'train.idx'),
-        batch_size=batch_size,
-        data_shape=(3, edge_size, edge_size),  # The shape of the output image
-        shuffle=True,  # Read the dataset in random order
-        rand_crop=1,  # The probability of random cropping is 1
-        min_object_covered=0.95, max_attempts=200)
-    val_iter = image.ImageDetIter(
-        path_imgrec=os.path.join(data_dir, 'val.rec'), batch_size=batch_size,
-        data_shape=(3, edge_size, edge_size), shuffle=False)
-    return train_iter, val_iter
+    train_iter = gluon.data.DataLoader(BananasDataset(is_train=True),
+                                       batch_size, shuffle=True)
+    val_iter = gluon.data.DataLoader(BananasDataset(is_train=False),
+                                     batch_size)
+    return (train_iter, val_iter)
 ```
 
 ```{.python .input}
@@ -106,14 +134,7 @@ def load_data_bananas(batch_size):
 Below, we read a minibatch and print the shape of the image and label. The shape of the image is the same as in the previous experiment (batch size, number of channels, height, width). The shape of the label is (batch size, $m$, 5), where $m$ is equal to the maximum number of bounding boxes contained in a single image in the dataset. Although computation for the minibatch is very efficient, it requires each image to contain the same number of bounding boxes so that they can be placed in the same batch. Since each image may have a different number of bounding boxes, we can add illegal bounding boxes to images that have less than $m$ bounding boxes until each image contains $m$ bounding boxes. Thus, we can read a minibatch of images each time. The label of each bounding box in the image is represented by an array of length 5. The first element in the array is the category of the object contained in the bounding box. When the value is -1, the bounding box is an illegal bounding box for filling purpose. The remaining four elements of the array represent the $x, y$ axis coordinates of the upper-left corner of the bounding box and the $x, y$ axis coordinates of the lower-right corner of the bounding box (the value range is between 0 and 1). The banana dataset here has only one bounding box per image, so $m=1$.
 
 ```{.python .input}
-batch_size, edge_size = 32, 256
-train_iter, _ = load_data_bananas(batch_size, edge_size)
-batch = train_iter.next()
-batch.data[0].shape, batch.label[0].shape
-```
-
-```{.python .input}
-#@tab pytorch
+#@tab all
 batch_size, edge_size = 32, 256
 train_iter, _ = load_data_bananas(batch_size)
 batch = next(iter(train_iter))
@@ -125,9 +146,9 @@ batch[0].shape, batch[1].shape
 We have ten images with bounding boxes on them. We can see that the angle, size, and position of banana are different in each image. Of course, this is a simple artificial dataset. In actual practice, the data are usually much more complicated.
 
 ```{.python .input}
-imgs = (batch.data[0][0:10].transpose(0, 2, 3, 1)) / 255
+imgs = (batch[0][0:10].transpose(0, 2, 3, 1)) / 255
 axes = d2l.show_images(imgs, 2, 5, scale=2)
-for ax, label in zip(axes, batch.label[0][0:10]):
+for ax, label in zip(axes, batch[1][0:10]):
     d2l.show_bboxes(ax, [label[0][1:5] * edge_size], colors=['w'])
 ```
 

--- a/chapter_computer-vision/ssd.md
+++ b/chapter_computer-vision/ssd.md
@@ -470,11 +470,10 @@ animator = d2l.Animator(xlabel='epoch', xlim=[1, num_epochs],
 for epoch in range(num_epochs):
     # accuracy_sum, mae_sum, num_examples, num_labels
     metric = d2l.Accumulator(4)
-    train_iter.reset()  # Read data from the start.
-    for batch in train_iter:
+    for features, target in train_iter:
         timer.start()
-        X = batch.data[0].as_in_ctx(device)
-        Y = batch.label[0].as_in_ctx(device)
+        X = features.as_in_ctx(device)
+        Y = target.as_in_ctx(device)
         with autograd.record():
             # Generate multiscale anchor boxes and predict the category and
             # offset of each
@@ -494,7 +493,7 @@ for epoch in range(num_epochs):
     cls_err, bbox_mae = 1 - metric[0] / metric[1], metric[2] / metric[3]
     animator.add(epoch + 1, (cls_err, bbox_mae))
 print(f'class err {cls_err:.2e}, bbox mae {bbox_mae:.2e}')
-print(f'{train_iter.num_image / timer.stop():.1f} examples/sec on '
+print(f'{len(train_iter._dataset) / timer.stop():.1f} examples/sec on '
       f'{str(device)}')
 ```
 


### PR DESCRIPTION
*Description of changes:*
This PR is a follow-up to #1565. It adds scratch dataloader for bananas dataset in mxnet and we move away from the in-built method `image.ImageDetIter` used in mxnet version earlier.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
