### PR TITLE
docs: fix simple typo, excecuted -> executed

### DIFF
--- a/chapter_computational-performance/hybridize.md
+++ b/chapter_computational-performance/hybridize.md
@@ -17,7 +17,7 @@ def fancy_func(a, b, c, d):
 print(fancy_func(1, 2, 3, 4))
 ```
 
-Python is an interpreted language. When evaluating `fancy_func` it performs the operations making up the function's body *in sequence*. That is, it will evaluate `e = add(a, b)` and it will store the results as variable `e`, thereby changing the program's state. The next two statements `f = add(c, d)` and `g = add(e, f)` will be excecuted similarly, performing additions and storing the results as variables. :numref:`fig_compute_graph` illustrates the flow of data.
+Python is an interpreted language. When evaluating `fancy_func` it performs the operations making up the function's body *in sequence*. That is, it will evaluate `e = add(a, b)` and it will store the results as variable `e`, thereby changing the program's state. The next two statements `f = add(c, d)` and `g = add(e, f)` will be executed similarly, performing additions and storing the results as variables. :numref:`fig_compute_graph` illustrates the flow of data.
 
 ![Data flow in an imperative program.](../img/computegraph.svg)
 :label:`fig_compute_graph`


### PR DESCRIPTION
There is a small typo in chapter_computational-performance/hybridize.md.

Should read `executed` rather than `excecuted`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md