### PR TITLE
Fix moving var initialization: 0 -> 1

### DIFF
--- a/chapter_convolutional-modern/batch-norm.md
+++ b/chapter_convolutional-modern/batch-norm.md
@@ -337,9 +337,9 @@ class BatchNorm(nn.Block):
         # initialized to 1 and 0, respectively
         self.gamma = self.params.get('gamma', shape=shape, init=init.One())
         self.beta = self.params.get('beta', shape=shape, init=init.Zero())
-        # The variables that are not model parameters are initialized to 0
+        # The variables that are not model parameters are initialized to 0 and 1
         self.moving_mean = np.zeros(shape)
-        self.moving_var = np.zeros(shape)
+        self.moving_var = np.ones(shape)
 
     def forward(self, X):
         # If `X` is not on the main memory, copy `moving_mean` and
@@ -370,9 +370,9 @@ class BatchNorm(nn.Module):
         # initialized to 1 and 0, respectively
         self.gamma = nn.Parameter(torch.ones(shape))
         self.beta = nn.Parameter(torch.zeros(shape))
-        # The variables that are not model parameters are initialized to 0
+        # The variables that are not model parameters are initialized to 0 and 1
         self.moving_mean = torch.zeros(shape)
-        self.moving_var = torch.zeros(shape)
+        self.moving_var = torch.ones(shape)
 
     def forward(self, X):
         # If `X` is not on the main memory, copy `moving_mean` and
@@ -406,7 +406,7 @@ class BatchNorm(tf.keras.layers.Layer):
             shape=weight_shape, initializer=tf.initializers.zeros,
             trainable=False)
         self.moving_variance = self.add_weight(name='moving_variance',
-            shape=weight_shape, initializer=tf.initializers.zeros,
+            shape=weight_shape, initializer=tf.initializers.ones,
             trainable=False)
         super(BatchNorm, self).build(input_shape)
 


### PR DESCRIPTION
*Description of changes:*

By default frameworks like PyTorch/Tensorflow initialize moving variance to ones instead of zeros (here):
- pytorch: https://github.com/pytorch/pytorch/blob/a111a9291c704c218cae99aeb3d8be23a54368ff/torch/nn/modules/batchnorm.py#L60
- tensorflow: https://www.tensorflow.org/api_docs/python/tf/keras/layers/BatchNormalization
- maybe, same for MXNet

In this PR, simply replaces `zeros` to `ones` for moving variance initialization.


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.

