### PR TITLE
Update softmax-regression-concise.md

### DIFF
--- a/chapter_linear-networks/softmax-regression-concise.md
+++ b/chapter_linear-networks/softmax-regression-concise.md
@@ -137,7 +137,7 @@ $$
 $$
 
 We will want to keep the conventional softmax function handy
-in case we ever want to evaluate the output probabilities by our model. Thus, while this new equation is original Softmax function is equivalent to the one shown in the last section, it avoids both the overflow and underflow issue discussed. 
+in case we ever want to evaluate the output probabilities by our model. Thus, while this new equation is equivalent to the softmax equation shown in the last section, it avoids both the overflow and underflow issue discussed. 
 But instead of passing softmax probabilities into our new loss function,
 we will just pass the logits and compute the softmax and its log
 all at once inside the cross-entropy loss function,

--- a/chapter_linear-networks/softmax-regression-concise.md
+++ b/chapter_linear-networks/softmax-regression-concise.md
@@ -126,18 +126,18 @@ softmax and cross-entropy together,
 we can escape the numerical stability issues
 that might otherwise plague us during backpropagation.
 As shown in the equation below, we avoid calculating $\exp(o_j)$
-and can use instead $o_j$ directly due to the canceling in $\log(\exp(\cdot))$.
+and can use instead $o_j$ - $\max(o_k)$ directly due to the canceling in $\log(\exp(\cdot))$.
 
 $$
 \begin{aligned}
-\log{(\hat y_j)} & = \log\left( \frac{\exp(o_j)}{\sum_k \exp(o_k)}\right) \\
-& = \log{(\exp(o_j))}-\log{\left( \sum_k \exp(o_k) \right)} \\
-& = o_j -\log{\left( \sum_k \exp(o_k) \right)}.
+\log{(\hat y_j)} & = \log\left( \frac{\exp(o_j - \max(o_k))}{\sum_k \exp(o_k - \max(o_k))}\right) \\
+& = \log{(\exp(o_j - \max(o_k)))}-\log{\left( \sum_k \exp(o_k - \max(o_k)) \right)} \\
+& = o_j - \max(o_k) -\log{\left( \sum_k \exp(o_k - \max(o_k)) \right)}.
 \end{aligned}
 $$
 
 We will want to keep the conventional softmax function handy
-in case we ever want to evaluate the output probabilities by our model.
+in case we ever want to evaluate the output probabilities by our model. Thus, while this new equation is original Softmax function is equivalent to the one shown in the last section, it avoids both the overflow and underflow issue discussed. 
 But instead of passing softmax probabilities into our new loss function,
 we will just pass the logits and compute the softmax and its log
 all at once inside the cross-entropy loss function,


### PR DESCRIPTION
The current version of the modified softmax function and text (equation 3.7.1)  is not clear. It is not clear how it helps with the overflow error that can happen explained earlier in the paragraph; even though this equation helps with not evaluating 𝑜𝑗 in the numerator, it still has to be evaluated in the sum taken in -log(∑𝑘exp(𝑜𝑘)).  It looks like that this section is trying to show Log-sum-exp trick explained here: https://timvieira.github.io/blog/post/2014/02/11/exp-normalize-trick/ (and briefly mentioned in the text), so that equation 3.7.1 should include the normalization.  I included the normalization in the proposed change, and text more clearly explaining what it is doing.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
