### PR TITLE
[PyTorch] Fix Warning Transformer tensor cast

### DIFF
--- a/chapter_attention-mechanisms/transformer.md
+++ b/chapter_attention-mechanisms/transformer.md
@@ -813,7 +813,7 @@ dec_self_attention_weights.shape, dec_inter_attention_weights.shape
 
 ```{.python .input}
 #@tab pytorch
-dec_attention_weights_2d = [d2l.tensor(head[0]).tolist()
+dec_attention_weights_2d = [head[0].tolist()
                             for step in dec_attention_weight_seq
                             for attn in step for blk in attn for head in blk]
 dec_attention_weights_filled = d2l.tensor(


### PR DESCRIPTION
*Description of changes:*

Fixes the following warning:
```
UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or
sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
```

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
