### PR TITLE
[PyTorch] hide output after weight init

### DIFF
--- a/chapter_multilayer-perceptrons/dropout.md
+++ b/chapter_multilayer-perceptrons/dropout.md
@@ -500,7 +500,7 @@ def init_weights(m):
     if type(m) == nn.Linear:
         torch.nn.init.normal_(m.weight, std=0.01)
 
-net.apply(init_weights)
+net.apply(init_weights);
 ```
 
 ```{.python .input}


### PR DESCRIPTION
*Description of changes:*
This pr adds a minor fix to PyTorch adaptation hiding unnecessary output and making the section consistent with other frameworks.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
