### PR TITLE
Releave 0.16.0 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](http://ci.d2l.ai/job/d2l-en/job/master/badge/icon)](http://ci.d2l.ai/job/d2l-en/job/master/)
 
-[Book website](https://d2l.ai/) | [STAT 157 Course at UC Berkeley, Spring 2019](http://courses.d2l.ai/berkeley-stat-157/index.html) | Latest version: v0.15.1
+[Book website](https://d2l.ai/) | [STAT 157 Course at UC Berkeley, Spring 2019](http://courses.d2l.ai/berkeley-stat-157/index.html) | Latest version: v0.16.0
 
 <h5 align="center"><i>The best way to understand deep learning is learning by doing.</i></h5>
 

--- a/chapter_computer-vision/image-augmentation.md
+++ b/chapter_computer-vision/image-augmentation.md
@@ -180,7 +180,7 @@ d2l.show_images(gluon.data.vision.CIFAR10(
 
 ```{.python .input}
 #@tab pytorch
-all_images = torchvision.datasets.CIFAR10(train=True, root="../temp",
+all_images = torchvision.datasets.CIFAR10(train=True, root="../data",
                                           download=True)
 d2l.show_images([all_images[i][0] for i in range(32)], 4, 8, scale=0.8);
 ```
@@ -223,8 +223,8 @@ def load_cifar10(is_train, augs, batch_size):
 ```{.python .input}
 #@tab pytorch
 def load_cifar10(is_train, augs, batch_size):
-    dataset = torchvision.datasets.CIFAR10(root="../temp", train=is_train,
-                                           transform=augs, download=True)
+    dataset = torchvision.datasets.CIFAR10(
+        root="../data/cifar10", train=is_train, transform=augs, download=True)
     dataloader = torch.utils.data.DataLoader(dataset, batch_size=batch_size,
                     shuffle=is_train, num_workers=d2l.get_dataloader_workers())
     return dataloader


### PR DESCRIPTION
PyTorch cifar-10 data root location must be located to ../data to avoid large files in colab-pytorch-git (Git only allows files < 100MB)




By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
