### PR TITLE
Include difference of net(X) and net.forward(X)

### DIFF
--- a/chapter_deep-learning-computation/model-construction.md
+++ b/chapter_deep-learning-computation/model-construction.md
@@ -156,9 +156,14 @@ it chains each `Block` in the list together,
 passing the output of each as the input to the next.
 Note that until now, we have been invoking our models
 via the construction `net(X)` to obtain their outputs.
-This is actually just shorthand for `net.forward(X)`,
+This is actually just shorthand for `net.__call__(X)`,
 a slick Python trick achieved via
 the `Block` class's `__call__` function.
+This `__call__`function then uses net.forward(X) and also
+executes any hooks of the model, which are functions the model requires
+to be executed during the forward or backward pass.
+In general, a model should be used with `net(X)` and not
+`net.forward(X)`, so all hooks are executed correctly.
 :end_tab:
 
 :begin_tab:`pytorch`

--- a/chapter_deep-learning-computation/model-construction.md
+++ b/chapter_deep-learning-computation/model-construction.md
@@ -186,7 +186,7 @@ the `Module` class's `__call__` function.
 This `__call__`function then uses net.forward(X) and also
 executes any hooks of the model, which are functions the model requires
 to be executed during the forward or backward pass.
-In general, a Module should be used with `net(X)` and not
+In general, a `Module` should be used with `net(X)` and not
 `net.forward(X)`, so all hooks are executed correctly.
 :end_tab:
 

--- a/chapter_deep-learning-computation/model-construction.md
+++ b/chapter_deep-learning-computation/model-construction.md
@@ -161,8 +161,8 @@ a slick Python trick achieved via
 the `Block` class's `__call__` function.
 This `__call__`function then uses net.forward(X) and also
 executes any hooks of the model, which are functions the model requires
-to be executed during the forward or backward pass.
-In general, a model should be used with `net(X)` and not
+to be executed during the forward pass.
+In general, a Block should be used with `net(X)` and not
 `net.forward(X)`, so all hooks are executed correctly.
 :end_tab:
 
@@ -180,9 +180,14 @@ it chains each block in the list together,
 passing the output of each as the input to the next.
 Note that until now, we have been invoking our models
 via the construction `net(X)` to obtain their outputs.
-This is actually just shorthand for `net.forward(X)`,
+This is actually just shorthand for `net.__call__(X)`,
 a slick Python trick achieved via
-the Block class's `__call__` function.
+the `Module` class's `__call__` function.
+This `__call__`function then uses net.forward(X) and also
+executes any hooks of the model, which are functions the model requires
+to be executed during the forward or backward pass.
+In general, a Module should be used with `net(X)` and not
+`net.forward(X)`, so all hooks are executed correctly.
 :end_tab:
 
 :begin_tab:`tensorflow`

--- a/chapter_deep-learning-computation/model-construction.md
+++ b/chapter_deep-learning-computation/model-construction.md
@@ -162,7 +162,7 @@ the `Block` class's `__call__` function.
 This `__call__`function then uses net.forward(X) and also
 executes any hooks of the model, which are functions the model requires
 to be executed during the forward pass.
-In general, a Block should be used with `net(X)` and not
+In general, a `Block` should be used with `net(X)` and not
 `net.forward(X)`, so all hooks are executed correctly.
 :end_tab:
 


### PR DESCRIPTION
In pytorch, `net(X)` is shorthand for `net.__call__(X)` which is not exactly the same as `net.forward(X)`.
`net.__call__(X)` also includes hooks which might be necessary for the forward and backward pass.
This book, as far as I understand, does not include any mention of Pytorch's hooks and the reader might think that both calls are identical.
However, `net(X)` is the right way to use the model, since calling `net.forward(X)` directly will not call possibly required hooks.
In my opinion, this difference should be mentioned at some point in the book.
The exact wording can be changed, of course, but some explanation of the difference would be helpful for the reader.

This difference is also present in MXNet and hooks should be explained here as well.

[Source code in Pytorch](https://github.com/pytorch/pytorch/blob/9d8bd216f9e29251685389a22dce69614ab648a5/torch/nn/modules/module.py#L908)
[Source code in MXNet](https://github.com/apache/incubator-mxnet/blob/124d8417984ed9205f972eb1c2cadbf028b94eb3/python/mxnet/gluon/block.py#L846)

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
