### PR TITLE
[tensorflow] tf implementation of section 12.1, compilers and interpreters

### DIFF
--- a/chapter_computational-performance/hybridize.md
+++ b/chapter_computational-performance/hybridize.md
@@ -172,7 +172,7 @@ net(x)
 
 ```{.python .input}
 #@tab tensorflow
-net = tf.function(net, jit_compile=True)
+net = tf.function(net)
 net(x)
 ```
 
@@ -186,8 +186,7 @@ By converting the model using `torch.jit.script` This seems almost too good to b
 
 :begin_tab:`tensorflow`
 Converting the model using `tf.function` gives us incredible power in tensorflow: write the same code as before and simply convert the model using `tf.function`. Once this happens the network is built as a computational graph in tensorflow's MLIR intermediate representation and is heavily optimized at the compiler level for rapid execution (we will benchmark the performance below).
-Explicitly adding the `jit_compile = True` flag enables XLA (Accelerated Linear Algebra) functionality in tensorflow. XLA can further optimize JIT compiled code in certain instances. Graph-mode execution is enabled without this explicit definition, however XLA can make certain large linear algebra operations (in the vein of those we see in deep learning applcations) much faster, particularly in a GPU environment. 
-In this case we don't notice a substantial increase between the graph-mode executed network and the XLA executed, however both are faster than the eagerly executed code. 
+Explicitly adding the `jit_compile = True` flag to the `tf.function()` call enables XLA (Accelerated Linear Algebra) functionality in tensorflow. XLA can further optimize JIT compiled code in certain instances. Graph-mode execution is enabled without this explicit definition, however XLA can make certain large linear algebra operations (in the vein of those we see in deep learning applcations) much faster, particularly in a GPU environment.
 :end_tab:
 
 ### Acceleration by Hybridization
@@ -252,10 +251,6 @@ with Benchmark('Eager Mode'):
 
 net = tf.function(net)
 with Benchmark('Graph Mode'):
-    for i in range(1000): net(x)
-
-net = tf.function(net, jit_compile = True)
-with Benchmark('Graph Mode with XLA'):
     for i in range(1000): net(x)
 ```
 

--- a/chapter_computational-performance/hybridize.md
+++ b/chapter_computational-performance/hybridize.md
@@ -278,7 +278,8 @@ One of the benefits of compiling the models is that we can serialize (save) the 
 :end_tab:
 
 :begin_tab:`tensorflow`
-One of the benefits of compiling the models is that we can serialize (save) the model and its parameters to disk. This allows us to store a model in a manner that is independent of the front-end language of choice. This allows us to deploy trained models to other devices and easily use other front-end programming languages or execute a trained model on a server. At the same time the code is often faster than what can be achieved in imperative programming. The low-level API that allows us to save in tensorflow is `tf.saved_model`. 
+One of the benefits of compiling the models is that we can serialize (save) the model and its parameters to disk. This allows us to store a model in a manner that is independent of the front-end language of choice. This allows us to deploy trained models to other devices and easily use other front-end programming languages or execute a trained model on a server. At the same time the code is often faster than what can be achieved in imperative programming. 
+The low-level API that allows us to save in tensorflow is `tf.saved_model`. 
 Let's see the `saved_model` instance in action.
 :end_tab:
 

--- a/chapter_computational-performance/hybridize.md
+++ b/chapter_computational-performance/hybridize.md
@@ -279,7 +279,7 @@ One of the benefits of compiling the models is that we can serialize (save) the 
 
 :begin_tab:`tensorflow`
 One of the benefits of compiling the models is that we can serialize (save) the model and its parameters to disk. This allows us to store a model in a manner that is independent of the front-end language of choice. This allows us to deploy trained models to other devices and easily use other front-end programming languages or execute a trained model on a server. At the same time the code is often faster than what can be achieved in imperative programming. The low-level API that allows us to save in tensorflow is `tf.saved_model`. 
-Let us see the `saved_model` class and subsequent methods in action.
+Let's see the `saved_model` instance in action.
 :end_tab:
 
 ```{.python .input}
@@ -312,7 +312,7 @@ Things are slightly more tricky when it comes to models that resemble code more 
 
 Contrary to the Block instance, which needs to use the `forward` function, for a HybridBlock instance we need to use the `hybrid_forward` function.
 
-Earlier, we demonstrated that, after calling the `hybridize` method, the model is able to achieve superior computing performance and portability. Note, though that hybridization can affect model flexibility, in particular in terms of control flow. We will illustrate how to design more general models and also how compilation will remove spurious Python elements.
+Earlier, we demonstrated that, after calling the `hybridize` function, the model is able to achieve superior computing performance and portability. Note, though that hybridization can affect model flexibility, in particular in terms of control flow. We will illustrate how to design more general models and also how compilation will remove spurious Python elements.
 :end_tab:
 
 ```{.python .input}

--- a/chapter_computational-performance/hybridize.md
+++ b/chapter_computational-performance/hybridize.md
@@ -186,7 +186,7 @@ By converting the model using `torch.jit.script` This seems almost too good to b
 
 :begin_tab:`tensorflow`
 Converting the model using `tf.function` gives us incredible power in TensorFlow: write the same code as before and simply convert the model using `tf.function`. Once this happens the network is built as a computational graph in TensorFlow's MLIR intermediate representation and is heavily optimized at the compiler level for rapid execution (we will benchmark the performance below).
-Explicitly adding the `jit_compile = True` flag to the `tf.function()` call enables XLA (Accelerated Linear Algebra) functionality in tensorflow. XLA can further optimize JIT compiled code in certain instances. Graph-mode execution is enabled without this explicit definition, however XLA can make certain large linear algebra operations (in the vein of those we see in deep learning applcations) much faster, particularly in a GPU environment.
+Explicitly adding the `jit_compile = True` flag to the `tf.function()` call enables XLA (Accelerated Linear Algebra) functionality in TensorFlow. XLA can further optimize JIT compiled code in certain instances. Graph-mode execution is enabled without this explicit definition, however XLA can make certain large linear algebra operations (in the vein of those we see in deep learning applications) much faster, particularly in a GPU environment.
 :end_tab:
 
 ### Acceleration by Hybridization

--- a/chapter_computational-performance/hybridize.md
+++ b/chapter_computational-performance/hybridize.md
@@ -79,6 +79,10 @@ In practice this means that we build models using either the `HybridBlock` or th
 As mentioned above, PyTorch is based on imperative programming and uses dynamic computation graphs. In an effort to leverage the portability and efficiency of symbolic programming, developers considered whether it would be possible to combine the benefits of both programming models. This led to a torchscript that lets users develop and debug using pure imperative programming, while having the ability to convert most programs into symbolic programs to be run when product-level computing performance and deployment are required.
 :end_tab:
 
+:begin_tab:`tensorflow`
+The imperative programming paradigm is now the default in Tensorflow 2.X, a welcome change for those new to the language. However, the same symbolic programming techniques and subsequent computational graphs still exist in tensorflow, and can be accessed by the easy-to-use `tf.function` decorator. This brought the imperative programming paradigm to tensorflow, allowed users to define more intuitive functions, then wrap them and compile them into computational graphs automatically using a feature the Tensorflow team refers to as [autograph](https://www.tensorflow.org/api_docs/python/tf/autograph).
+:end_tab:
+
 ## HybridSequential
 
 The easiest way to get a feel for how hybridization works is to consider deep networks with multiple layers. Conventionally the Python interpreter will need to execute the code for all layers to generate an instruction that can then be forwarded to a CPU or a GPU. For a single (fast) compute device this does not cause any major issues. On the other hand, if we use an advanced 8-GPU server such as an AWS P3dn.24xlarge instance Python will struggle to keep all GPUs busy. The single-threaded Python interpreter becomes the bottleneck here. Let us see how we can address this for significant parts of the code by replacing `Sequential` by `HybridSequential`. We begin by defining a simple MLP.

--- a/chapter_computational-performance/hybridize.md
+++ b/chapter_computational-performance/hybridize.md
@@ -80,7 +80,7 @@ As mentioned above, PyTorch is based on imperative programming and uses dynamic 
 :end_tab:
 
 :begin_tab:`tensorflow`
-The imperative programming paradigm is now the default in Tensorflow 2.X, a welcome change for those new to the language. However, the same symbolic programming techniques and subsequent computational graphs still exist in tensorflow, and can be accessed by the easy-to-use `tf.function` decorator. This brought the imperative programming paradigm to tensorflow, allowed users to define more intuitive functions, then wrap them and compile them into computational graphs automatically using a feature the Tensorflow team refers to as [autograph](https://www.tensorflow.org/api_docs/python/tf/autograph).
+The imperative programming paradigm is now the default in Tensorflow 2, a welcoming change for those new to the language. However, the same symbolic programming techniques and subsequent computational graphs still exist in TensorFlow, and can be accessed by the easy-to-use `tf.function` decorator. This brought the imperative programming paradigm to TensorFlow, allowed users to define more intuitive functions, then wrap them and compile them into computational graphs automatically using a feature the TensorFlow team refers to as [autograph](https://www.tensorflow.org/api_docs/python/tf/autograph).
 :end_tab:
 
 ## HybridSequential

--- a/chapter_computational-performance/hybridize.md
+++ b/chapter_computational-performance/hybridize.md
@@ -185,7 +185,7 @@ By converting the model using `torch.jit.script` This seems almost too good to b
 :end_tab:
 
 :begin_tab:`tensorflow`
-Converting the model using `tf.function` gives us incredible power in tensorflow: write the same code as before and simply convert the model using `tf.function`. Once this happens the network is built as a computational graph in tensorflow's MLIR intermediate representation and is heavily optimized at the compiler level for rapid execution (we will benchmark the performance below).
+Converting the model using `tf.function` gives us incredible power in TensorFlow: write the same code as before and simply convert the model using `tf.function`. Once this happens the network is built as a computational graph in TensorFlow's MLIR intermediate representation and is heavily optimized at the compiler level for rapid execution (we will benchmark the performance below).
 Explicitly adding the `jit_compile = True` flag to the `tf.function()` call enables XLA (Accelerated Linear Algebra) functionality in tensorflow. XLA can further optimize JIT compiled code in certain instances. Graph-mode execution is enabled without this explicit definition, however XLA can make certain large linear algebra operations (in the vein of those we see in deep learning applcations) much faster, particularly in a GPU environment.
 :end_tab:
 


### PR DESCRIPTION
Added tf implementation for section 12.1. I took a small liberty in the section on JIT compilation and added an example that compiles with XLA as well as standard graph-mode JIT. If we want it to be closer to the mxnet and pytorch versions then I can remove this. Additionally the final example of this section takes advantage of multi-dispatch functionality that I believe is exclusive to mxnet, so I did not do a tensorflow example for that. There was not a pytorch example either for this specific one.

Thanks,  

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
