### PR TITLE
Update naive-bayes.md

### DIFF
--- a/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
+++ b/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
@@ -168,7 +168,7 @@ By itself, this expression does not get us any further. We still must estimate r
 
 $$ \hat{y} = \mathrm{argmax}_y \> \prod_{i=1}^d p(x_i  \mid  y) p(y).$$
 
-If we can estimate $p(x_i=1  \mid  y)$ for every $i$ and $y$, and save its value in $P_{xy}[i, y]$, here $P_{xy}$ is a $d\times n$ matrix with $n$ being the number of classes and $y\in\{1, \ldots, n\}$, i.e.,
+If we can estimate $p(x_i=1  \mid  y)$ for every $i$ and $y$, and save its value in $P_{xy}[i, y]$, here $P_{xy}$ is a $d\times n$ matrix with $n$ being the number of classes and $y\in\{1, \ldots, n\}$, then we can also use this to estimate $p(x_i = 0 \mid y)$, i.e.,
 
 $$ 
 p(x_i = t_i \mid y) = 

--- a/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
+++ b/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
@@ -180,15 +180,10 @@ $$
 
 In addition, we estimate $p(y)$ for every $y$ and save it in $P_y[y]$, with $P_y$ a $n$-length vector. Then, for any new example $\mathbf t = (t_1, t_2, \ldots, t_d)$, we could compute
 
-$$
-\begin{aligned}
-\hat{y} 
+$$\begin{aligned} \hat{y} 
 &= \mathrm{argmax}_y \ p(y)\prod_{i=1}^d   p(x_t = t_i \mid y)\\
-&= \mathrm{argmax}_y \ P_y[y]\prod_{i=1}^d \ P_{xy}[i, y]^{t_i}\, \left(1 - P_{xy}[i, y]\right)^{1-t_i}
-\end{aligned}
-$$
+&= \mathrm{argmax}_y \ P_y[y]\prod_{i=1}^d \ P_{xy}[i, y]^{t_i}\, \left(1 - P_{xy}[i, y]\right)^{1-t_i} \end{aligned}$$
 :eqlabel:`eq_naive_bayes_estimation`
-
 
 for any $y$. So our assumption of conditional independence has taken the complexity of our model from an exponential dependence on the number of features $\mathcal{O}(2^dn)$ to a linear dependence, which is $\mathcal{O}(dn)$.
 

--- a/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
+++ b/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
@@ -180,9 +180,14 @@ $$
 
 In addition, we estimate $p(y)$ for every $y$ and save it in $P_y[y]$, with $P_y$ a $n$-length vector. Then, for any new example $\mathbf t = (t_1, t_2, \ldots, t_d)$, we could compute
 
-$$\begin{aligned} \hat{y} 
-&= \mathrm{argmax}_y \ p(y)\prod_{i=1}^d   p(x_t = t_i \mid y)\\
-&= \mathrm{argmax}_y \ P_y[y]\prod_{i=1}^d \ P_{xy}[i, y]^{t_i}\, \left(1 - P_{xy}[i, y]\right)^{1-t_i} \end{aligned}$$
+$$
+\begin{aligned}
+\hat{y} 
+&= \mathrm{argmax}_ y \ p(y)\prod_{i=1}^d   p(x_t = t_i \mid y)
+\\
+&= \mathrm{argmax}_y \ P_y[y]\prod_{i=1}^d \ P_{xy}[i, y]^{t_i}\, \left(1 - P_{xy}[i, y]\right)^{1-t_i}
+\end{aligned}
+$$
 :eqlabel:`eq_naive_bayes_estimation`
 
 for any $y$. So our assumption of conditional independence has taken the complexity of our model from an exponential dependence on the number of features $\mathcal{O}(2^dn)$ to a linear dependence, which is $\mathcal{O}(dn)$.

--- a/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
+++ b/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
@@ -180,9 +180,7 @@ $$
 
 In addition, we estimate $p(y)$ for every $y$ and save it in $P_y[y]$, with $P_y$ a $n$-length vector. Then, for any new example $\mathbf t = (t_1, t_2, \ldots, t_d)$, we could compute
 
-$$
-\begin{aligned}\hat{y} &= \mathrm{argmax}_ y \ p(y)\prod_{i=1}^d   p(x_t = t_i \mid y) \\ &= \mathrm{argmax}_y \ P_y[y]\prod_{i=1}^d \ P_{xy}[i, y]^{t_i}\, \left(1 - P_{xy}[i, y]\right)^{1-t_i}\end{aligned}
-$$
+$$\begin{aligned}\hat{y} &= \mathrm{argmax}_ y \ p(y)\prod_{i=1}^d   p(x_t = t_i \mid y) \\ &= \mathrm{argmax}_y \ P_y[y]\prod_{i=1}^d \ P_{xy}[i, y]^{t_i}\, \left(1 - P_{xy}[i, y]\right)^{1-t_i}\end{aligned}$$
 :eqlabel:`eq_naive_bayes_estimation`
 
 for any $y$. So our assumption of conditional independence has taken the complexity of our model from an exponential dependence on the number of features $\mathcal{O}(2^dn)$ to a linear dependence, which is $\mathcal{O}(dn)$.

--- a/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
+++ b/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
@@ -178,7 +178,7 @@ p(x_i = t_i \mid y) =
 \end{cases}
 $$
 
-In addition, we estimate $p(y)$ for every $y$ and save it in $P_y[y]$, with $P_y$ a $n$-length vector. Then for any new example $\mathbf t = (t_1, t_2, \ldots, t_d)$, we could compute
+In addition, we estimate $p(y)$ for every $y$ and save it in $P_y[y]$, with $P_y$ a $n$-length vector. Then, for any new example $\mathbf t = (t_1, t_2, \ldots, t_d)$, we could compute
 
 $$\begin{aligned}
 \hat{y} 

--- a/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
+++ b/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
@@ -181,6 +181,7 @@ $$
 &= \mathrm{argmax}_y \ \prod_{i=1}^d P_y[y]\ P_{xy}[i, y]^{t_i}\, \left(1 - P_{xy}[i, y]\right)^{1-t_i},
 \end{aligned}
 $$
+
 :eqlabel:`eq_naive_bayes_estimation`
 
 for any $y$. So our assumption of conditional independence has taken the complexity of our model from an exponential dependence on the number of features $\mathcal{O}(2^dn)$ to a linear dependence, which is $\mathcal{O}(dn)$.

--- a/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
+++ b/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
@@ -170,7 +170,17 @@ $$ \hat{y} = \mathrm{argmax}_y \> \prod_{i=1}^d p(x_i  \mid  y) p(y).$$
 
 If we can estimate $\prod_i p(x_i=1  \mid  y)$ for every $i$ and $y$, and save its value in $P_{xy}[i, y]$, here $P_{xy}$ is a $d\times n$ matrix with $n$ being the number of classes and $y\in\{1, \ldots, n\}$. In addition, we estimate $p(y)$ for every $y$ and save it in $P_y[y]$, with $P_y$ a $n$-length vector. Then for any new example $\mathbf x$, we could compute
 
-$$ \hat{y} = \mathrm{argmax}_y \> \prod_{i=1}^d P_{xy}[x_i, y]P_y[y],$$
+$$ 
+\begin{aligned}
+\hat{y} 
+&= \mathrm{argmax}_y \ \prod_{i=1}^d P_y[y]
+    \begin{cases}
+        P_{xy}[i, y] & \text{for } t_i=1\\
+        1 - P_{xy}[i, y] & \text{for } t_i = 0
+    \end{cases} \\
+&= \mathrm{argmax}_y \ \prod_{i=1}^d P_y[y]\ P_{xy}[i, y]^{t_i}\, \left(1 - P_{xy}[i, y]\right)^{1-t_i},
+\end{aligned}
+$$
 :eqlabel:`eq_naive_bayes_estimation`
 
 for any $y$. So our assumption of conditional independence has taken the complexity of our model from an exponential dependence on the number of features $\mathcal{O}(2^dn)$ to a linear dependence, which is $\mathcal{O}(dn)$.

--- a/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
+++ b/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
@@ -181,12 +181,7 @@ $$
 In addition, we estimate $p(y)$ for every $y$ and save it in $P_y[y]$, with $P_y$ a $n$-length vector. Then, for any new example $\mathbf t = (t_1, t_2, \ldots, t_d)$, we could compute
 
 $$
-\begin{aligned}
-\hat{y} 
-&= \mathrm{argmax}_ y \ p(y)\prod_{i=1}^d   p(x_t = t_i \mid y)
-\\
-&= \mathrm{argmax}_y \ P_y[y]\prod_{i=1}^d \ P_{xy}[i, y]^{t_i}\, \left(1 - P_{xy}[i, y]\right)^{1-t_i}
-\end{aligned}
+\begin{aligned}\hat{y} &= \mathrm{argmax}_ y \ p(y)\prod_{i=1}^d   p(x_t = t_i \mid y) \\ &= \mathrm{argmax}_y \ P_y[y]\prod_{i=1}^d \ P_{xy}[i, y]^{t_i}\, \left(1 - P_{xy}[i, y]\right)^{1-t_i}\end{aligned}
 $$
 :eqlabel:`eq_naive_bayes_estimation`
 

--- a/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
+++ b/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
@@ -168,21 +168,28 @@ By itself, this expression does not get us any further. We still must estimate r
 
 $$ \hat{y} = \mathrm{argmax}_y \> \prod_{i=1}^d p(x_i  \mid  y) p(y).$$
 
-If we can estimate $\prod_i p(x_i=1  \mid  y)$ for every $i$ and $y$, and save its value in $P_{xy}[i, y]$, here $P_{xy}$ is a $d\times n$ matrix with $n$ being the number of classes and $y\in\{1, \ldots, n\}$. In addition, we estimate $p(y)$ for every $y$ and save it in $P_y[y]$, with $P_y$ a $n$-length vector. Then for any new example $\mathbf x$, we could compute
+If we can estimate $\prod_i p(x_i=1  \mid  y)$ for every $i$ and $y$, and save its value in $P_{xy}[i, y]$, here $P_{xy}$ is a $d\times n$ matrix with $n$ being the number of classes and $y\in\{1, \ldots, n\}$, i.e.,
+
+
+$$ 
+P_{xy}[i, y] = 
+\begin{cases}
+    P_{xy}[i, y] & \text{for } t_i=1 ;\\
+    1 - P_{xy}[i, y] & \text{for } t_i = 0 .
+\end{cases}
+$$
+
+In addition, we estimate $p(y)$ for every $y$ and save it in $P_y[y]$, with $P_y$ a $n$-length vector. Then for any new example $\mathbf x$, we could compute
 
 $$ 
 \begin{aligned}
 \hat{y} 
-&= \mathrm{argmax}_y \ \prod_{i=1}^d P_y[y]
-    \begin{cases}
-        P_{xy}[i, y] & \text{for } t_i=1\\
-        1 - P_{xy}[i, y] & \text{for } t_i = 0
-    \end{cases} \\
+&= \mathrm{argmax}_y \ \prod_{i=1}^d P_y[y] \times P_{xy}[i, y]\\
 &= \mathrm{argmax}_y \ \prod_{i=1}^d P_y[y]\ P_{xy}[i, y]^{t_i}\, \left(1 - P_{xy}[i, y]\right)^{1-t_i},
 \end{aligned}
 $$
-
 :eqlabel:`eq_naive_bayes_estimation`
+
 
 for any $y$. So our assumption of conditional independence has taken the complexity of our model from an exponential dependence on the number of features $\mathcal{O}(2^dn)$ to a linear dependence, which is $\mathcal{O}(dn)$.
 

--- a/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
+++ b/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
@@ -166,7 +166,7 @@ $$p(x_1  \mid y) \cdot p(x_2  \mid  x_1, y) \cdot ... \cdot p( x_d  \mid  x_1, .
 
 By itself, this expression does not get us any further. We still must estimate roughly $2^d$ parameters. However, if we assume that *the features are conditionally independent of each other, given the label*, then suddenly we are in much better shape, as this term simplifies to $\prod_i p(x_i  \mid  y)$, giving us the predictor
 
-$$ \hat{y} = \mathrm{argmax}_y \> \prod_{i=1}^d p(x_i  \mid  y) p(y).$$
+$$\hat{y} = \mathrm{argmax}_y \> \prod_{i=1}^d p(x_i  \mid  y) p(y).$$
 
 If we can estimate $p(x_i=1  \mid  y)$ for every $i$ and $y$, and save its value in $P_{xy}[i, y]$, here $P_{xy}$ is a $d\times n$ matrix with $n$ being the number of classes and $y\in\{1, \ldots, n\}$, then we can also use this to estimate $p(x_i = 0 \mid y)$, i.e.,
 

--- a/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
+++ b/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
@@ -168,26 +168,23 @@ By itself, this expression does not get us any further. We still must estimate r
 
 $$ \hat{y} = \mathrm{argmax}_y \> \prod_{i=1}^d p(x_i  \mid  y) p(y).$$
 
-If we can estimate $\prod_i p(x_i=1  \mid  y)$ for every $i$ and $y$, and save its value in $P_{xy}[i, y]$, here $P_{xy}$ is a $d\times n$ matrix with $n$ being the number of classes and $y\in\{1, \ldots, n\}$, i.e.,
-
+If we can estimate $p(x_i=1  \mid  y)$ for every $i$ and $y$, and save its value in $P_{xy}[i, y]$, here $P_{xy}$ is a $d\times n$ matrix with $n$ being the number of classes and $y\in\{1, \ldots, n\}$, i.e.,
 
 $$ 
-P_{xy}[i, y] = 
+p(x_i = t_i \mid y) = 
 \begin{cases}
     P_{xy}[i, y] & \text{for } t_i=1 ;\\
     1 - P_{xy}[i, y] & \text{for } t_i = 0 .
 \end{cases}
 $$
 
-In addition, we estimate $p(y)$ for every $y$ and save it in $P_y[y]$, with $P_y$ a $n$-length vector. Then for any new example $\mathbf x$, we could compute
+In addition, we estimate $p(y)$ for every $y$ and save it in $P_y[y]$, with $P_y$ a $n$-length vector. Then for any new example $\mathbf t = (t_1, t_2, \ldots, t_d)$, we could compute
 
-$$ 
-\begin{aligned}
+$$\begin{aligned}
 \hat{y} 
-&= \mathrm{argmax}_y \ \prod_{i=1}^d P_y[y] \times P_{xy}[i, y]\\
-&= \mathrm{argmax}_y \ \prod_{i=1}^d P_y[y]\ P_{xy}[i, y]^{t_i}\, \left(1 - P_{xy}[i, y]\right)^{1-t_i},
-\end{aligned}
-$$
+&= \mathrm{argmax}_y \ p(y)\prod_{i=1}^d   p(x_t = t_i \mid y)\\
+&= \mathrm{argmax}_y \ P_y[y]\prod_{i=1}^d \ P_{xy}[i, y]^{t_i}\, \left(1 - P_{xy}[i, y]\right)^{1-t_i}
+\end{aligned}$$
 :eqlabel:`eq_naive_bayes_estimation`
 
 

--- a/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
+++ b/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
@@ -180,11 +180,13 @@ $$
 
 In addition, we estimate $p(y)$ for every $y$ and save it in $P_y[y]$, with $P_y$ a $n$-length vector. Then, for any new example $\mathbf t = (t_1, t_2, \ldots, t_d)$, we could compute
 
-$$\begin{aligned}
+$$
+\begin{aligned}
 \hat{y} 
 &= \mathrm{argmax}_y \ p(y)\prod_{i=1}^d   p(x_t = t_i \mid y)\\
 &= \mathrm{argmax}_y \ P_y[y]\prod_{i=1}^d \ P_{xy}[i, y]^{t_i}\, \left(1 - P_{xy}[i, y]\right)^{1-t_i}
-\end{aligned}$$
+\end{aligned}
+$$
 :eqlabel:`eq_naive_bayes_estimation`
 
 

--- a/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
+++ b/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
@@ -328,7 +328,7 @@ print('logarithm is normal:', 784*tf.math.log(a).numpy())
 
 Since the logarithm is an increasing function, we can rewrite :eqref:`eq_naive_bayes_estimation` as
 
-$$ \hat{y} = \mathrm{argmax}_y \> \sum_{i=1}^d \log P_{xy}[x_i, y] + \log P_y[y].$$
+$$ \hat{y} = \mathrm{argmax}_y \ \log P_y[y] + \sum_{i=1}^d \Big[t_i\log P_{xy}[x_i, y] + (1-t_i) \log (1 - P_{xy}[x_i, y]) \Big].$$
 
 We can implement the following stable version:
 


### PR DESCRIPTION
*Description of changes:*

There's a mistake in the formula for calculating naive bayes estimates.
P[x_i, y] is not defined. Only P[i, y] is defined which is the conditional probability p(x_i = 1 | y). 


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
