### PR TITLE
Removing unused self.relu from pytorch implementation

### DIFF
--- a/chapter_convolutional-modern/resnet.md
+++ b/chapter_convolutional-modern/resnet.md
@@ -136,7 +136,6 @@ class Residual(nn.Module):  #@save
             self.conv3 = None
         self.bn1 = nn.BatchNorm2d(num_channels)
         self.bn2 = nn.BatchNorm2d(num_channels)
-        self.relu = nn.ReLU(inplace=True)
 
     def forward(self, X):
         Y = F.relu(self.bn1(self.conv1(X)))


### PR DESCRIPTION
Removing unused self.relu from pytorch implementation.


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
