### PR TITLE
Include get_params in the d2l tensorflow package

### DIFF
--- a/chapter_recurrent-neural-networks/rnn-scratch.md
+++ b/chapter_recurrent-neural-networks/rnn-scratch.md
@@ -160,7 +160,7 @@ def get_params(vocab_size, num_hiddens, device):
 
 ```{.python .input}
 #@tab tensorflow
-def get_params(vocab_size, num_hiddens):
+def get_params(vocab_size, num_hiddens):    #@save
     num_inputs = num_outputs = vocab_size
     
     def normal(shape):

--- a/d2l/tensorflow.py
+++ b/d2l/tensorflow.py
@@ -664,6 +664,24 @@ def load_data_time_machine(batch_size, num_steps, use_random_iter=False,
 
 
 # Defined in file: ./chapter_recurrent-neural-networks/rnn-scratch.md
+def get_params(vocab_size, num_hiddens):
+    num_inputs = num_outputs = vocab_size
+    
+    def normal(shape):
+        return tf.random.normal(shape=shape,stddev=0.01,mean=0,dtype=tf.float32)
+
+    # Hidden layer parameters
+    W_xh = tf.Variable(normal((num_inputs, num_hiddens)), dtype=tf.float32)
+    W_hh = tf.Variable(normal((num_hiddens, num_hiddens)), dtype=tf.float32)
+    b_h = tf.Variable(tf.zeros(num_hiddens), dtype=tf.float32)
+    # Output layer parameters
+    W_hq = tf.Variable(normal((num_hiddens, num_outputs)), dtype=tf.float32)
+    b_q = tf.Variable(tf.zeros(num_outputs), dtype=tf.float32)
+    params = [W_xh, W_hh, b_h, W_hq, b_q]
+    return params
+
+
+# Defined in file: ./chapter_recurrent-neural-networks/rnn-scratch.md
 class RNNModelScratch:
     """A RNN Model implemented from scratch."""
     def __init__(self, vocab_size, num_hiddens, init_state, forward_fn):


### PR DESCRIPTION
If the code for 8.5 rnn-scratch is supposed to work if we load the "saved" code from the d2l library, we need the get_params method called by train_ch8.
Unfortunately, this method is not saved. However, it should.
To test the code, change train_ch8 to d2l.train_ch8 in e.g. rnn-scratch.ipynb (tensorflow version) and you will get an error.
The method d2l.train_ch8 does not work for the tensorflow version of the d2l package.


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
