### PR TITLE
[TF]Add get_params as a parameter for train_ch8 for tensorflow

### DIFF
--- a/chapter_recurrent-neural-networks/rnn-scratch.md
+++ b/chapter_recurrent-neural-networks/rnn-scratch.md
@@ -733,7 +733,7 @@ def train_ch8(net, train_iter, vocab, lr, num_epochs, device,
 #@tab tensorflow
 #@save
 def train_ch8(net, train_iter, vocab, num_hiddens, lr, num_epochs, strategy,
-              use_random_iter=False):
+              get_params, use_random_iter=False):
     """Train a model (defined in Chapter 8)."""
     with strategy.scope():
         params = get_params(len(vocab), num_hiddens)
@@ -767,7 +767,7 @@ train_ch8(net, train_iter, vocab, lr, num_epochs, d2l.try_gpu())
 ```{.python .input}
 #@tab tensorflow
 num_epochs, lr = 500, 1
-train_ch8(net, train_iter, vocab, num_hiddens, lr, num_epochs, strategy)
+train_ch8(net, train_iter, vocab, num_hiddens, lr, num_epochs, strategy, get_params)
 ```
 
 Finally,
@@ -783,7 +783,7 @@ train_ch8(net, train_iter, vocab, lr, num_epochs, d2l.try_gpu(),
 #@tab tensorflow
 params = get_params(len(vocab_random_iter), num_hiddens)
 train_ch8(net, train_random_iter, vocab_random_iter, num_hiddens, lr,
-          num_epochs, strategy, use_random_iter=True)
+          num_epochs, strategy, get_params, use_random_iter=True)
 ```
 
 While implementing the above RNN model from scratch is instructive, it is not convenient.

--- a/d2l/tensorflow.py
+++ b/d2l/tensorflow.py
@@ -739,7 +739,7 @@ def train_epoch_ch8(net, train_iter, loss, updater, params, use_random_iter):
 
 # Defined in file: ./chapter_recurrent-neural-networks/rnn-scratch.md
 def train_ch8(net, train_iter, vocab, num_hiddens, lr, num_epochs, strategy,
-              use_random_iter=False):
+              get_params, use_random_iter=False):
     """Train a model (defined in Chapter 8)."""
     with strategy.scope():
         params = get_params(len(vocab), num_hiddens)


### PR DESCRIPTION
If we want to save train_ch8 in tensorflow.py, we need access to get_params.
Since this method is not saved and will be different for e.g. lstm, we need to pass it in as a parameter.
Changing train_ch8 to d2l.train_ch8 for rnn-scratch (tensorflow version) will currently cause an error!
I also changed rnn-scratch where this method is defined.
I checked this new version of rnn-scratch and it runs as expected.


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
