### PR TITLE
[TF] Add Implementation of rnn-concise

### DIFF
--- a/chapter_recurrent-neural-networks/rnn-concise.md
+++ b/chapter_recurrent-neural-networks/rnn-concise.md
@@ -29,6 +29,14 @@ batch_size, num_steps = 32, 35
 train_iter, vocab = d2l.load_data_time_machine(batch_size, num_steps)
 ```
 
+```{.python .input}
+#@tab tensorflow
+from d2l import tensorflow as d2l
+import tensorflow as tf
+batch_size, num_steps = 32, 35
+train_iter, vocab = d2l.load_data_time_machine(batch_size, num_steps)
+```
+
 ## Defining the Model
 
 High-level APIs provide implementations of recurrent neural networks.
@@ -46,6 +54,15 @@ rnn_layer.initialize()
 #@tab pytorch
 num_hiddens = 256
 rnn_layer = nn.RNN(len(vocab), num_hiddens)
+```
+
+```{.python .input}
+#@tab tensorflow
+num_hiddens = 256
+rnn_cell = tf.keras.layers.SimpleRNNCell(num_hiddens,
+    kernel_initializer='glorot_uniform')
+rnn_layer = tf.keras.layers.RNN(rnn_cell, time_major=True,
+    return_sequences=True, return_state=True)
 ```
 
 :begin_tab:`mxnet`
@@ -78,6 +95,12 @@ len(state), state[0].shape
 ```{.python .input}
 #@tab pytorch
 state = torch.zeros((1, batch_size, num_hiddens))
+state.shape
+```
+
+```{.python .input}
+#@tab tensorflow
+state = rnn_cell.get_initial_state(batch_size=batch_size, dtype=tf.float32)
 state.shape
 ```
 
@@ -121,6 +144,13 @@ Y.shape, len(state_new), state_new[0].shape
 X = torch.rand(size=(num_steps, batch_size, len(vocab)))
 Y, state_new = rnn_layer(X, state)
 Y.shape, state_new.shape
+```
+
+```{.python .input}
+#@tab tensorflow
+X = tf.random.uniform((num_steps, batch_size, len(vocab)))
+Y, state_new = rnn_layer(X, state)
+Y.shape, len(state_new), state_new[0].shape
 ```
 
 Similar to :numref:`sec_rnn_scratch`,
@@ -196,6 +226,24 @@ class RNNModel(nn.Module):
                         batch_size, self.num_hiddens), device=device))
 ```
 
+```{.python .input}
+#@tab tensorflow
+#@save
+class RNNModel(tf.keras.layers.Layer):
+    def __init__(self, rnn_layer, vocab_size, **kwargs):
+        super(RNNModel, self).__init__(**kwargs)
+        self.rnn = rnn_layer
+        self.vocab_size = vocab_size
+        self.dense = tf.keras.layers.Dense(vocab_size)
+    def call(self, inputs, state, _):
+        X = tf.one_hot(tf.transpose(inputs), self.vocab_size)
+        Y,state = self.rnn(X, state)
+        output = self.dense(tf.reshape(Y, (-1, Y.shape[-1])))
+        return output, state
+    def begin_state(self, *args, **kwargs):
+        return self.rnn.cell.get_initial_state(*args, **kwargs)
+```
+
 ## Training and Predicting
 
 Before training the model, let us make a prediction with the a model that has random weights.
@@ -215,12 +263,35 @@ net = net.to(device)
 d2l.predict_ch8('time traveller', 10, net, vocab, device)
 ```
 
+```{.python .input}
+#@tab tensorflow
+device_name = d2l.try_gpu()._device_name
+strategy = tf.distribute.OneDeviceStrategy(device_name)
+with strategy.scope():
+    model = RNNModel(rnn_layer, vocab_size=len(vocab))
+    
+get_params = lambda _, __: model.trainable_variables 
+params = get_params(len(vocab), num_hiddens)
+d2l.predict_ch8('time traveller', 10, model, vocab, params)
+```
+
 As is quite obvious, this model does not work at all. Next, we call `train_ch8` with the same hyperparameters defined in :numref:`sec_rnn_scratch` and train our model with high-level APIs.
 
 ```{.python .input}
-#@tab all
 num_epochs, lr = 500, 1
 d2l.train_ch8(net, train_iter, vocab, lr, num_epochs, device)
+```
+
+```{.python .input}
+#@tab pytorch
+num_epochs, lr = 500, 1
+d2l.train_ch8(net, train_iter, vocab, lr, num_epochs, device)
+```
+
+```{.python .input}
+#@tab tensorflow
+num_epochs, lr = 500, 1
+d2l.train_ch8(model, train_iter, vocab, num_hiddens, lr, num_epochs, strategy, get_params)
 ```
 
 Compared with the last section, this model achieves comparable perplexity,

--- a/chapter_recurrent-neural-networks/rnn-scratch.md
+++ b/chapter_recurrent-neural-networks/rnn-scratch.md
@@ -314,7 +314,7 @@ class RNNModelScratch: #@save
         X = tf.cast(X, tf.float32)
         return self.forward_fn(X, state, params)
 
-    def begin_state(self, batch_size):
+    def begin_state(self, batch_size, *args, **kwargs):
         return self.init_state(batch_size, self.num_hiddens)
 ```
 

--- a/chapter_recurrent-neural-networks/rnn-scratch.md
+++ b/chapter_recurrent-neural-networks/rnn-scratch.md
@@ -414,7 +414,7 @@ def predict_ch8(prefix, num_preds, net, vocab, device):  #@save
 #@tab tensorflow
 def predict_ch8(prefix, num_preds, net, vocab, params):  #@save
     """Generate new characters following the `prefix`."""
-    state = net.begin_state(batch_size=1)
+    state = net.begin_state(batch_size=1, dtype=tf.float32)
     outputs = [vocab[prefix[0]]]
     get_input = lambda: d2l.reshape(d2l.tensor([outputs[-1]]), (1, 1)).numpy()
     for y in prefix[1:]:  # Warm-up period
@@ -652,7 +652,7 @@ def train_epoch_ch8(net, train_iter, loss, updater, params, use_random_iter):
         if state is None or use_random_iter:
             # Initialize `state` when either it is the first iteration or
             # using random sampling
-            state = net.begin_state(batch_size=X.shape[0])
+            state = net.begin_state(batch_size=X.shape[0], dtype=tf.float32)
         with tf.GradientTape(persistent=True) as g:
             g.watch(params)
             y_hat, state= net(X, state, params)

--- a/d2l/tensorflow.py
+++ b/d2l/tensorflow.py
@@ -761,6 +761,22 @@ def train_ch8(net, train_iter, vocab, num_hiddens, lr, num_epochs, strategy,
     print(predict('traveller'))
 
 
+# Defined in file: ./chapter_recurrent-neural-networks/rnn-concise.md
+class RNNModel(tf.keras.layers.Layer):
+    def __init__(self, rnn_layer, vocab_size, **kwargs):
+        super(RNNModel, self).__init__(**kwargs)
+        self.rnn = rnn_layer
+        self.vocab_size = vocab_size
+        self.dense = tf.keras.layers.Dense(vocab_size)
+    def call(self, inputs, state, _):
+        X = tf.one_hot(tf.transpose(inputs), self.vocab_size)
+        Y,state = self.rnn(X, state)
+        output = self.dense(tf.reshape(Y, (-1, Y.shape[-1])))
+        return output, state
+    def begin_state(self, *args, **kwargs):
+        return self.rnn.cell.get_initial_state(*args, **kwargs)
+
+
 # Defined in file: ./chapter_recurrent-modern/machine-translation-and-dataset.md
 d2l.DATA_HUB['fra-eng'] = (d2l.DATA_URL + 'fra-eng.zip',
                            '94646ad1522d915e7b0f9296181140edcf86a4f5')

--- a/d2l/tensorflow.py
+++ b/d2l/tensorflow.py
@@ -682,7 +682,7 @@ class RNNModelScratch:
 # Defined in file: ./chapter_recurrent-neural-networks/rnn-scratch.md
 def predict_ch8(prefix, num_preds, net, vocab, params):
     """Generate new characters following the `prefix`."""
-    state = net.begin_state(batch_size=1)
+    state = net.begin_state(batch_size=1, dtype=tf.float32)
     outputs = [vocab[prefix[0]]]
     get_input = lambda: d2l.reshape(d2l.tensor([outputs[-1]]), (1, 1)).numpy()
     for y in prefix[1:]:  # Warm-up period
@@ -720,7 +720,7 @@ def train_epoch_ch8(net, train_iter, loss, updater, params, use_random_iter):
         if state is None or use_random_iter:
             # Initialize `state` when either it is the first iteration or
             # using random sampling
-            state = net.begin_state(batch_size=X.shape[0])
+            state = net.begin_state(batch_size=X.shape[0], dtype=tf.float32)
         with tf.GradientTape(persistent=True) as g:
             g.watch(params)
             y_hat, state = net(X, state, params)


### PR DESCRIPTION
This pull requests adds the concise implementation for RNN for TF.
It is heavily based on @terrytangyuan previous suggestion (PR #1467) and I want to thank him for his work.
Some small changes for the previous chapter for rnn-scratch were necessary and I tested these changes.
A screenshot of the result of rnn-concise is attached:
![rnn-concise-tf](https://user-images.githubusercontent.com/35968719/111378067-acafef80-86a1-11eb-847b-1c114147ef55.png)

I created a new PR since I had no write access to the repo without my own fork.
As soon as this PR is merged I will continue with the TF version for the following chapters on GRU (9.1) and LSTM (9.2).
Looking forward to your feedback :)

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.