### PR TITLE
[TF] Add TensorFlow implementation of GRU and make training loop more flexible

### DIFF
--- a/chapter_recurrent-modern/gru.md
+++ b/chapter_recurrent-modern/gru.md
@@ -260,9 +260,9 @@ def get_params(vocab_size, num_hiddens):
         return d2l.normal(shape=shape,stddev=0.01,mean=0,dtype=tf.float32)
 
     def three():
-        return tf.Variable(normal((num_inputs, num_hiddens)), dtype=tf.float32),\
-               tf.Variable(normal((num_hiddens, num_hiddens)), dtype=tf.float32),\
-               tf.Variable(d2l.zeros(num_hiddens), dtype=tf.float32)
+        return (tf.Variable(normal((num_inputs, num_hiddens)), dtype=tf.float32),
+                tf.Variable(normal((num_hiddens, num_hiddens)), dtype=tf.float32),
+                tf.Variable(d2l.zeros(num_hiddens), dtype=tf.float32))
     
     W_xz, W_hz, b_z = three()  # Update gate parameters
     W_xr, W_hr, b_r = three()  # Reset gate parameters

--- a/chapter_recurrent-neural-networks/rnn-concise.md
+++ b/chapter_recurrent-neural-networks/rnn-concise.md
@@ -238,6 +238,7 @@ class RNNModel(tf.keras.layers.Layer):
 
     def call(self, inputs, state):
         X = tf.one_hot(tf.transpose(inputs), self.vocab_size)
+        # Later RNN like `tf.keras.layers.LSTMCell` return more than two values
         Y, *state = self.rnn(X, state)
         output = self.dense(tf.reshape(Y, (-1, Y.shape[-1])))
         return output, state

--- a/chapter_recurrent-neural-networks/rnn-concise.md
+++ b/chapter_recurrent-neural-networks/rnn-concise.md
@@ -235,11 +235,13 @@ class RNNModel(tf.keras.layers.Layer):
         self.rnn = rnn_layer
         self.vocab_size = vocab_size
         self.dense = tf.keras.layers.Dense(vocab_size)
-    def call(self, inputs, state, _):
+
+    def call(self, inputs, state):
         X = tf.one_hot(tf.transpose(inputs), self.vocab_size)
-        Y,state = self.rnn(X, state)
+        Y, *state = self.rnn(X, state)
         output = self.dense(tf.reshape(Y, (-1, Y.shape[-1])))
         return output, state
+
     def begin_state(self, *args, **kwargs):
         return self.rnn.cell.get_initial_state(*args, **kwargs)
 ```
@@ -270,9 +272,7 @@ strategy = tf.distribute.OneDeviceStrategy(device_name)
 with strategy.scope():
     model = RNNModel(rnn_layer, vocab_size=len(vocab))
 
-get_params = lambda _, __: model.trainable_variables
-params = get_params(len(vocab), num_hiddens)
-d2l.predict_ch8('time traveller', 10, model, vocab, params)
+d2l.predict_ch8('time traveller', 10, model, vocab)
 ```
 
 As is quite obvious, this model does not work at all. Next, we call `train_ch8` with the same hyperparameters defined in :numref:`sec_rnn_scratch` and train our model with high-level APIs.
@@ -291,7 +291,7 @@ d2l.train_ch8(net, train_iter, vocab, lr, num_epochs, device)
 ```{.python .input}
 #@tab tensorflow
 num_epochs, lr = 500, 1
-d2l.train_ch8(model, train_iter, vocab, num_hiddens, lr, num_epochs, strategy, get_params)
+d2l.train_ch8(model, train_iter, vocab, num_hiddens, lr, num_epochs, strategy)
 ```
 
 Compared with the last section, this model achieves comparable perplexity,

--- a/chapter_recurrent-neural-networks/rnn-scratch.md
+++ b/chapter_recurrent-neural-networks/rnn-scratch.md
@@ -33,7 +33,6 @@ from torch.nn import functional as F
 %matplotlib inline
 from d2l import tensorflow as d2l
 import math
-import numpy as np
 import tensorflow as tf
 ```
 
@@ -305,14 +304,15 @@ class RNNModelScratch: #@save
 class RNNModelScratch: #@save
     """A RNN Model implemented from scratch."""
     def __init__(self, vocab_size, num_hiddens,
-                 init_state, forward_fn):
+                 init_state, forward_fn, get_params):
         self.vocab_size, self.num_hiddens = vocab_size, num_hiddens
         self.init_state, self.forward_fn = init_state, forward_fn
+        self.trainable_variables = get_params(vocab_size, num_hiddens)
 
-    def __call__(self, X, state, params):
+    def __call__(self, X, state):
         X = tf.one_hot(tf.transpose(X), self.vocab_size)
         X = tf.cast(X, tf.float32)
-        return self.forward_fn(X, state, params)
+        return self.forward_fn(X, state, self.trainable_variables)
 
     def begin_state(self, batch_size, *args, **kwargs):
         return self.init_state(batch_size, self.num_hiddens)
@@ -348,10 +348,9 @@ strategy = tf.distribute.OneDeviceStrategy(device_name)
 
 num_hiddens = 512
 with strategy.scope():
-    net = RNNModelScratch(len(vocab), num_hiddens, init_rnn_state, rnn)
+    net = RNNModelScratch(len(vocab), num_hiddens, init_rnn_state, rnn, get_params)
 state = net.begin_state(X.shape[0])
-params = get_params(len(vocab), num_hiddens)
-Y, new_state = net(X, state, params)
+Y, new_state = net(X, state)
 Y.shape, len(new_state), new_state[0].shape
 ```
 
@@ -412,16 +411,16 @@ def predict_ch8(prefix, num_preds, net, vocab, device):  #@save
 
 ```{.python .input}
 #@tab tensorflow
-def predict_ch8(prefix, num_preds, net, vocab, params):  #@save
+def predict_ch8(prefix, num_preds, net, vocab): #@save
     """Generate new characters following the `prefix`."""
     state = net.begin_state(batch_size=1, dtype=tf.float32)
     outputs = [vocab[prefix[0]]]
     get_input = lambda: d2l.reshape(d2l.tensor([outputs[-1]]), (1, 1)).numpy()
     for y in prefix[1:]:  # Warm-up period
-        _, state = net(get_input(), state, params)
+        _, state = net(get_input(), state)
         outputs.append(vocab[y])
     for _ in range(num_preds):  # Predict `num_preds` steps
-        y, state = net(get_input(), state, params)
+        y, state = net(get_input(), state)
         outputs.append(int(y.numpy().argmax(axis=1).reshape(1)))
     return ''.join([vocab.idx_to_token[i] for i in outputs])
 ```
@@ -438,7 +437,7 @@ predict_ch8('time traveller ', 10, net, vocab, d2l.try_gpu())
 
 ```{.python .input}
 #@tab tensorflow
-predict_ch8('time traveller ', 10, net, vocab, params)
+predict_ch8('time traveller ', 10, net, vocab)
 ```
 
 ## Gradient Clipping
@@ -644,7 +643,7 @@ def train_epoch_ch8(net, train_iter, loss, updater, device, use_random_iter):
 ```{.python .input}
 #@tab tensorflow
 #@save
-def train_epoch_ch8(net, train_iter, loss, updater, params, use_random_iter):
+def train_epoch_ch8(net, train_iter, loss, updater, use_random_iter):
     """Train a model within one epoch (defined in Chapter 8)."""
     state, timer = None, d2l.Timer()
     metric = d2l.Accumulator(2)  # Sum of training loss, no. of tokens
@@ -654,14 +653,14 @@ def train_epoch_ch8(net, train_iter, loss, updater, params, use_random_iter):
             # using random sampling
             state = net.begin_state(batch_size=X.shape[0], dtype=tf.float32)
         with tf.GradientTape(persistent=True) as g:
-            g.watch(params)
-            y_hat, state= net(X, state, params)
+            y_hat, state = net(X, state)
             y = d2l.reshape(tf.transpose(Y), (-1))
             l = loss(y, y_hat)
+        params = net.trainable_variables
         grads = g.gradient(l, params)
         grads = grad_clipping(grads, 1)
         updater.apply_gradients(zip(grads, params))
-        
+
         # Keras loss by default returns the average loss in a batch
         # l_sum = l * float(d2l.size(y)) if isinstance(
         #     loss, tf.keras.losses.Loss) else tf.reduce_sum(l)
@@ -732,20 +731,17 @@ def train_ch8(net, train_iter, vocab, lr, num_epochs, device,
 ```{.python .input}
 #@tab tensorflow
 #@save
-def train_ch8(net, train_iter, vocab, num_hiddens, lr, num_epochs, strategy,
-              get_params, use_random_iter=False):
+def train_ch8(net, train_iter, vocab, num_hiddens, lr, num_epochs, strategy, use_random_iter=False):
     """Train a model (defined in Chapter 8)."""
     with strategy.scope():
-        params = get_params(len(vocab), num_hiddens)
         loss = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)
         updater = tf.keras.optimizers.SGD(lr)
     animator = d2l.Animator(xlabel='epoch', ylabel='perplexity',
                             legend=['train'], xlim=[10, num_epochs])
-    predict = lambda prefix: predict_ch8(prefix, 50, net, vocab, params)
+    predict = lambda prefix: predict_ch8(prefix, 50, net, vocab)
     # Train and predict
     for epoch in range(num_epochs):
-        ppl, speed = train_epoch_ch8(
-             net, train_iter, loss, updater, params, use_random_iter)
+        ppl, speed = train_epoch_ch8(net, train_iter, loss, updater, use_random_iter)
         if (epoch + 1) % 10 == 0:
             print(predict('time traveller'))
             animator.add(epoch + 1, [ppl])
@@ -767,7 +763,7 @@ train_ch8(net, train_iter, vocab, lr, num_epochs, d2l.try_gpu())
 ```{.python .input}
 #@tab tensorflow
 num_epochs, lr = 500, 1
-train_ch8(net, train_iter, vocab, num_hiddens, lr, num_epochs, strategy, get_params)
+train_ch8(net, train_iter, vocab, num_hiddens, lr, num_epochs, strategy)
 ```
 
 Finally,
@@ -781,9 +777,8 @@ train_ch8(net, train_iter, vocab, lr, num_epochs, d2l.try_gpu(),
 
 ```{.python .input}
 #@tab tensorflow
-params = get_params(len(vocab_random_iter), num_hiddens)
-train_ch8(net, train_random_iter, vocab_random_iter, num_hiddens, lr,
-          num_epochs, strategy, get_params, use_random_iter=True)
+train_ch8(net, train_iter, vocab_random_iter, num_hiddens, lr,
+          num_epochs, strategy, use_random_iter=True)
 ```
 
 While implementing the above RNN model from scratch is instructive, it is not convenient.

--- a/d2l/tensorflow.py
+++ b/d2l/tensorflow.py
@@ -666,30 +666,32 @@ def load_data_time_machine(batch_size, num_steps, use_random_iter=False,
 # Defined in file: ./chapter_recurrent-neural-networks/rnn-scratch.md
 class RNNModelScratch:
     """A RNN Model implemented from scratch."""
-    def __init__(self, vocab_size, num_hiddens, init_state, forward_fn):
+    def __init__(self, vocab_size, num_hiddens,
+                 init_state, forward_fn, get_params):
         self.vocab_size, self.num_hiddens = vocab_size, num_hiddens
         self.init_state, self.forward_fn = init_state, forward_fn
+        self.trainable_variables = get_params(vocab_size, num_hiddens)
 
-    def __call__(self, X, state, params):
+    def __call__(self, X, state):
         X = tf.one_hot(tf.transpose(X), self.vocab_size)
         X = tf.cast(X, tf.float32)
-        return self.forward_fn(X, state, params)
+        return self.forward_fn(X, state, self.trainable_variables)
 
-    def begin_state(self, batch_size):
+    def begin_state(self, batch_size, *args, **kwargs):
         return self.init_state(batch_size, self.num_hiddens)
 
 
 # Defined in file: ./chapter_recurrent-neural-networks/rnn-scratch.md
-def predict_ch8(prefix, num_preds, net, vocab, params):
+def predict_ch8(prefix, num_preds, net, vocab):
     """Generate new characters following the `prefix`."""
     state = net.begin_state(batch_size=1, dtype=tf.float32)
     outputs = [vocab[prefix[0]]]
     get_input = lambda: d2l.reshape(d2l.tensor([outputs[-1]]), (1, 1)).numpy()
     for y in prefix[1:]:  # Warm-up period
-        _, state = net(get_input(), state, params)
+        _, state = net(get_input(), state)
         outputs.append(vocab[y])
     for _ in range(num_preds):  # Predict `num_preds` steps
-        y, state = net(get_input(), state, params)
+        y, state = net(get_input(), state)
         outputs.append(int(y.numpy().argmax(axis=1).reshape(1)))
     return ''.join([vocab.idx_to_token[i] for i in outputs])
 
@@ -712,7 +714,7 @@ def grad_clipping(grads, theta):
 
 
 # Defined in file: ./chapter_recurrent-neural-networks/rnn-scratch.md
-def train_epoch_ch8(net, train_iter, loss, updater, params, use_random_iter):
+def train_epoch_ch8(net, train_iter, loss, updater, use_random_iter):
     """Train a model within one epoch (defined in Chapter 8)."""
     state, timer = None, d2l.Timer()
     metric = d2l.Accumulator(2)  # Sum of training loss, no. of tokens
@@ -722,10 +724,10 @@ def train_epoch_ch8(net, train_iter, loss, updater, params, use_random_iter):
             # using random sampling
             state = net.begin_state(batch_size=X.shape[0], dtype=tf.float32)
         with tf.GradientTape(persistent=True) as g:
-            g.watch(params)
-            y_hat, state = net(X, state, params)
+            y_hat, state = net(X, state)
             y = d2l.reshape(tf.transpose(Y), (-1))
             l = loss(y, y_hat)
+        params = net.trainable_variables
         grads = g.gradient(l, params)
         grads = grad_clipping(grads, 1)
         updater.apply_gradients(zip(grads, params))
@@ -738,20 +740,17 @@ def train_epoch_ch8(net, train_iter, loss, updater, params, use_random_iter):
 
 
 # Defined in file: ./chapter_recurrent-neural-networks/rnn-scratch.md
-def train_ch8(net, train_iter, vocab, num_hiddens, lr, num_epochs, strategy,
-              get_params, use_random_iter=False):
+def train_ch8(net, train_iter, vocab, num_hiddens, lr, num_epochs, strategy, use_random_iter=False):
     """Train a model (defined in Chapter 8)."""
     with strategy.scope():
-        params = get_params(len(vocab), num_hiddens)
         loss = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)
         updater = tf.keras.optimizers.SGD(lr)
     animator = d2l.Animator(xlabel='epoch', ylabel='perplexity',
                             legend=['train'], xlim=[10, num_epochs])
-    predict = lambda prefix: predict_ch8(prefix, 50, net, vocab, params)
+    predict = lambda prefix: predict_ch8(prefix, 50, net, vocab)
     # Train and predict
     for epoch in range(num_epochs):
-        ppl, speed = train_epoch_ch8(net, train_iter, loss, updater, params,
-                                     use_random_iter)
+        ppl, speed = train_epoch_ch8(net, train_iter, loss, updater, use_random_iter)
         if (epoch + 1) % 10 == 0:
             print(predict('time traveller'))
             animator.add(epoch + 1, [ppl])
@@ -768,11 +767,13 @@ class RNNModel(tf.keras.layers.Layer):
         self.rnn = rnn_layer
         self.vocab_size = vocab_size
         self.dense = tf.keras.layers.Dense(vocab_size)
-    def call(self, inputs, state, _):
+
+    def call(self, inputs, state):
         X = tf.one_hot(tf.transpose(inputs), self.vocab_size)
-        Y,state = self.rnn(X, state)
+        Y, *state = self.rnn(X, state)
         output = self.dense(tf.reshape(Y, (-1, Y.shape[-1])))
         return output, state
+
     def begin_state(self, *args, **kwargs):
         return self.rnn.cell.get_initial_state(*args, **kwargs)
 

--- a/d2l/tensorflow.py
+++ b/d2l/tensorflow.py
@@ -770,6 +770,7 @@ class RNNModel(tf.keras.layers.Layer):
 
     def call(self, inputs, state):
         X = tf.one_hot(tf.transpose(inputs), self.vocab_size)
+        # Later RNN like `tf.keras.layers.LSTMCell` return more than two values
         Y, *state = self.rnn(X, state)
         output = self.dense(tf.reshape(Y, (-1, Y.shape[-1])))
         return output, state


### PR DESCRIPTION
This PR adds a TensorFlow implementation for GRU which is somewhat based on the code of @PHOENIXFURY007  and his PR #1597
The code contains both the implementation from scratch and the concise one with keras.

Some changes had to be made to the training loop and the models from the previous chapters:
- When we initialize RNNModelScratch, we now pass in the function get_params which is executed at initialization to create the learnable weights.
- The training loop does not access these weights before the first model invocation. If we access them to early before invocation, keras implementations will return an empty list. The weights for keras are created during the first model invocation (call).
- The weights of the RNN (and later RNN models like GRU or LSTM) are accessed using model.trainable_variables for the implementation from scratch since this makes it compatible with Keras models. **This decision is up for discussion and we could use an if-else statement depending on the type of the model.**
- Parameters are now never passed in as arguments in addition to the model but always taken from the model using model.trainable_variables. This solves the issue of accessing them too early or having wrong values in params.
- The RNNModel now accepts more than two output values from the keras layer. The first output is always Y and the rest are a saved together as the list state. For RNN and GRU, the list state is just the state value. However for keras implementation for LSTM, we get back 3 values! H and C are then combined into state as is the case for the other frameworks. The code, hence, is compatible with more different RNN layers. I also experimented with adding a lambda layer in between, but this causes too much added complexity in my opinion. **However, I am always thankful for other suggestions.**

I already have a finished LSTM implementation in TensorFlow which I will create a PR for, as soon as this PR is merged.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
