### PR TITLE
[TF] Add TensorFlow version for LSTM

### DIFF
--- a/chapter_recurrent-modern/lstm.md
+++ b/chapter_recurrent-modern/lstm.md
@@ -219,11 +219,13 @@ def get_lstm_params(vocab_size, num_hiddens):
     num_inputs = num_outputs = vocab_size
 
     def normal(shape):
-        return tf.Variable(tf.random.normal(shape=shape,stddev=0.01,mean=0,dtype=tf.float32))
+        return tf.Variable(tf.random.normal(shape=shape,stddev=0.01,mean=0,
+                                            dtype=tf.float32))
     def three():
         return (normal((num_inputs, num_hiddens)),
                 normal((num_hiddens, num_hiddens)),
                 tf.Variable(tf.zeros(num_hiddens), dtype=tf.float32))
+
     W_xi, W_hi, b_i = three()  # Input gate parameters
     W_xf, W_hf, b_f = three()  # Forget gate parameters
     W_xo, W_ho, b_o = three()  # Output gate parameters


### PR DESCRIPTION
This PR adds a TensorFlow implementation for LSTM.
It is based on the previous work of @PHOENIXFURY007 and replaces the PR #1598 .
Ir requires no changes to `RNNModel` since they had been made previously so this model accepts states consisting out of multiple values.


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
