### PR TITLE
Fix for issue #1678 and remove unused parameter for train_ch8 in TF

### DIFF
--- a/chapter_recurrent-modern/gru.md
+++ b/chapter_recurrent-modern/gru.md
@@ -372,7 +372,7 @@ num_epochs, lr = 500, 1
 with strategy.scope():
     model = d2l.RNNModelScratch(len(vocab), num_hiddens, init_gru_state, gru, get_params)
 
-d2l.train_ch8(model, train_iter, vocab, num_hiddens, lr, num_epochs, strategy)
+d2l.train_ch8(model, train_iter, vocab, lr, num_epochs, strategy)
 ```
 
 ## Concise Implementation
@@ -410,7 +410,7 @@ strategy = tf.distribute.OneDeviceStrategy(device_name)
 with strategy.scope():
     model = d2l.RNNModel(gru_layer, vocab_size=len(vocab))
 
-d2l.train_ch8(model, train_iter, vocab, num_hiddens, lr, num_epochs, strategy)
+d2l.train_ch8(model, train_iter, vocab, lr, num_epochs, strategy)
 ```
 
 ## Summary

--- a/chapter_recurrent-modern/lstm.md
+++ b/chapter_recurrent-modern/lstm.md
@@ -341,7 +341,7 @@ num_epochs, lr = 500, 1
 strategy = tf.distribute.OneDeviceStrategy(device_name)
 with strategy.scope():
     model = d2l.RNNModelScratch(len(vocab), num_hiddens, init_lstm_state, lstm, get_lstm_params)
-d2l.train_ch8(model, train_iter, vocab, num_hiddens, lr, num_epochs, strategy)
+d2l.train_ch8(model, train_iter, vocab, lr, num_epochs, strategy)
 ```
 
 ## Concise Implementation
@@ -375,7 +375,7 @@ device_name = d2l.try_gpu()._device_name
 strategy = tf.distribute.OneDeviceStrategy(device_name)
 with strategy.scope():
     model = d2l.RNNModel(lstm_layer, vocab_size=len(vocab))
-d2l.train_ch8(model, train_iter, vocab, num_hiddens, lr, num_epochs, strategy)
+d2l.train_ch8(model, train_iter, vocab, lr, num_epochs, strategy)
 ```
 
 LSTMs are the prototypical latent variable autoregressive model with nontrivial state control.

--- a/chapter_recurrent-neural-networks/rnn-concise.md
+++ b/chapter_recurrent-neural-networks/rnn-concise.md
@@ -273,7 +273,7 @@ strategy = tf.distribute.OneDeviceStrategy(device_name)
 with strategy.scope():
     net = RNNModel(rnn_layer, vocab_size=len(vocab))
 
-d2l.predict_ch8('time traveller', 10, model, vocab)
+d2l.predict_ch8('time traveller', 10, net, vocab)
 ```
 
 As is quite obvious, this model does not work at all. Next, we call `train_ch8` with the same hyperparameters defined in :numref:`sec_rnn_scratch` and train our model with high-level APIs.

--- a/chapter_recurrent-neural-networks/rnn-concise.md
+++ b/chapter_recurrent-neural-networks/rnn-concise.md
@@ -271,7 +271,7 @@ d2l.predict_ch8('time traveller', 10, net, vocab, device)
 device_name = d2l.try_gpu()._device_name
 strategy = tf.distribute.OneDeviceStrategy(device_name)
 with strategy.scope():
-    model = RNNModel(rnn_layer, vocab_size=len(vocab))
+    net = RNNModel(rnn_layer, vocab_size=len(vocab))
 
 d2l.predict_ch8('time traveller', 10, model, vocab)
 ```
@@ -292,7 +292,7 @@ d2l.train_ch8(net, train_iter, vocab, lr, num_epochs, device)
 ```{.python .input}
 #@tab tensorflow
 num_epochs, lr = 500, 1
-d2l.train_ch8(model, train_iter, vocab, num_hiddens, lr, num_epochs, strategy)
+d2l.train_ch8(net, train_iter, vocab, lr, num_epochs, strategy)
 ```
 
 Compared with the last section, this model achieves comparable perplexity,

--- a/chapter_recurrent-neural-networks/rnn-scratch.md
+++ b/chapter_recurrent-neural-networks/rnn-scratch.md
@@ -731,7 +731,8 @@ def train_ch8(net, train_iter, vocab, lr, num_epochs, device,
 ```{.python .input}
 #@tab tensorflow
 #@save
-def train_ch8(net, train_iter, vocab, num_hiddens, lr, num_epochs, strategy, use_random_iter=False):
+def train_ch8(net, train_iter, vocab, lr, num_epochs, strategy,
+              use_random_iter=False):
     """Train a model (defined in Chapter 8)."""
     with strategy.scope():
         loss = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)
@@ -763,7 +764,7 @@ train_ch8(net, train_iter, vocab, lr, num_epochs, d2l.try_gpu())
 ```{.python .input}
 #@tab tensorflow
 num_epochs, lr = 500, 1
-train_ch8(net, train_iter, vocab, num_hiddens, lr, num_epochs, strategy)
+train_ch8(net, train_iter, vocab, lr, num_epochs, strategy)
 ```
 
 Finally,
@@ -777,8 +778,8 @@ train_ch8(net, train_iter, vocab, lr, num_epochs, d2l.try_gpu(),
 
 ```{.python .input}
 #@tab tensorflow
-train_ch8(net, train_iter, vocab_random_iter, num_hiddens, lr,
-          num_epochs, strategy, use_random_iter=True)
+train_ch8(net, train_iter, vocab_random_iter, lr, num_epochs, strategy,
+          use_random_iter=True)
 ```
 
 While implementing the above RNN model from scratch is instructive, it is not convenient.

--- a/chapter_recurrent-neural-networks/rnn-scratch.md
+++ b/chapter_recurrent-neural-networks/rnn-scratch.md
@@ -348,7 +348,8 @@ strategy = tf.distribute.OneDeviceStrategy(device_name)
 
 num_hiddens = 512
 with strategy.scope():
-    net = RNNModelScratch(len(vocab), num_hiddens, init_rnn_state, rnn, get_params)
+    net = RNNModelScratch(len(vocab), num_hiddens, init_rnn_state, rnn,
+                          get_params)
 state = net.begin_state(X.shape[0])
 Y, new_state = net(X, state)
 Y.shape, len(new_state), new_state[0].shape
@@ -771,13 +772,26 @@ Finally,
 let us check the results of using the random sampling method.
 
 ```{.python .input}
-#@tab mxnet,pytorch
+#@tab mxnet
+net = RNNModelScratch(len(vocab), num_hiddens, d2l.try_gpu(), get_params,
+                      init_rnn_state, rnn)
+train_ch8(net, train_iter, vocab, lr, num_epochs, d2l.try_gpu(),
+          use_random_iter=True)
+```
+
+```{.python .input}
+#@tab pytorch
+net = RNNModelScratch(len(vocab), num_hiddens, d2l.try_gpu(), get_params,
+                      init_rnn_state, rnn)
 train_ch8(net, train_iter, vocab, lr, num_epochs, d2l.try_gpu(),
           use_random_iter=True)
 ```
 
 ```{.python .input}
 #@tab tensorflow
+with strategy.scope():
+    net = RNNModelScratch(len(vocab), num_hiddens, init_rnn_state, rnn,
+                          get_params)
 train_ch8(net, train_iter, vocab_random_iter, lr, num_epochs, strategy,
           use_random_iter=True)
 ```

--- a/chapter_recurrent-neural-networks/rnn-scratch.md
+++ b/chapter_recurrent-neural-networks/rnn-scratch.md
@@ -412,7 +412,7 @@ def predict_ch8(prefix, num_preds, net, vocab, device):  #@save
 
 ```{.python .input}
 #@tab tensorflow
-def predict_ch8(prefix, num_preds, net, vocab): #@save
+def predict_ch8(prefix, num_preds, net, vocab):  #@save
     """Generate new characters following the `prefix`."""
     state = net.begin_state(batch_size=1, dtype=tf.float32)
     outputs = [vocab[prefix[0]]]
@@ -743,7 +743,8 @@ def train_ch8(net, train_iter, vocab, lr, num_epochs, strategy,
     predict = lambda prefix: predict_ch8(prefix, 50, net, vocab)
     # Train and predict
     for epoch in range(num_epochs):
-        ppl, speed = train_epoch_ch8(net, train_iter, loss, updater, use_random_iter)
+        ppl, speed = train_epoch_ch8(net, train_iter, loss, updater,
+                                     use_random_iter)
         if (epoch + 1) % 10 == 0:
             print(predict('time traveller'))
             animator.add(epoch + 1, [ppl])

--- a/d2l/tensorflow.py
+++ b/d2l/tensorflow.py
@@ -740,7 +740,7 @@ def train_epoch_ch8(net, train_iter, loss, updater, use_random_iter):
 
 
 # Defined in file: ./chapter_recurrent-neural-networks/rnn-scratch.md
-def train_ch8(net, train_iter, vocab, num_hiddens, lr, num_epochs, strategy,
+def train_ch8(net, train_iter, vocab, lr, num_epochs, strategy,
               use_random_iter=False):
     """Train a model (defined in Chapter 8)."""
     with strategy.scope():


### PR DESCRIPTION
This PR fixes issue #1678 and it also removes an unused parameter for train_ch8 in TensorFlow.
train_ch8 now has the same parameters and is used the same way in all 3 frameworks, except for the device in mxnet and PyTorch which is called strategy in TensorFlow (since they are not 100% the same thing).
The PR also includes some minor formatting fixes which were given as feedback to prior PR after they had been merged.

After this PR is merged, I will create a PR for my finished TensorFlow implementation of chapter 9.3.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.