### PR TITLE
[TF] Add TensorFlow version of deep rnn

### DIFF
--- a/chapter_recurrent-modern/deep-rnn.md
+++ b/chapter_recurrent-modern/deep-rnn.md
@@ -99,6 +99,14 @@ batch_size, num_steps = 32, 35
 train_iter, vocab = d2l.load_data_time_machine(batch_size, num_steps)
 ```
 
+```{.python .input}
+#@tab tensorflow
+from d2l import tensorflow as d2l
+import tensorflow as tf
+batch_size, num_steps = 32, 35
+train_iter, vocab = d2l.load_data_time_machine(batch_size, num_steps)
+```
+
 The architectural decisions such as choosing hyperparameters are very similar to those of :numref:`sec_lstm`. 
 We pick the same number of inputs and outputs as we have distinct tokens, i.e., `vocab_size`.
 The number of hidden units is still 256.
@@ -121,14 +129,34 @@ model = d2l.RNNModel(lstm_layer, len(vocab))
 model = model.to(device)
 ```
 
+```{.python .input}
+#@tab tensorflow
+vocab_size, num_hiddens, num_layers = len(vocab), 256, 2
+num_inputs = vocab_size
+device_name = d2l.try_gpu()._device_name
+strategy = tf.distribute.OneDeviceStrategy(device_name)
+rnn_cells = [tf.keras.layers.LSTMCell(num_hiddens) for _ in range(num_layers)]
+stacked_lstm = tf.keras.layers.StackedRNNCells(rnn_cells)
+lstm_layer = tf.keras.layers.RNN(stacked_lstm, time_major=True,
+                                 return_sequences=True, return_state=True)
+with strategy.scope():
+    model = d2l.RNNModel(lstm_layer, len(vocab))
+```
+
 ## Training and Prediction
 
 Since now we instantiate two layers with the LSTM model, this rather more complex architecture slows down training considerably.
 
 ```{.python .input}
-#@tab all
+#@tab mxnet, pytorch
 num_epochs, lr = 500, 2
 d2l.train_ch8(model, train_iter, vocab, lr, num_epochs, device)
+```
+
+```{.python .input}
+#@tab tensorflow
+num_epochs, lr = 500, 2
+d2l.train_ch8(model, train_iter, vocab, lr, num_epochs, strategy)
 ```
 
 ## Summary


### PR DESCRIPTION
This PR adds a TensorFlow version of the deep rnn.
As far as I understood, the TensorFlow version just needs more lines since there is no parameter to adjust (num_layers).
Instead I use tf.keras.layers.StackedRNNCells to have more layers.


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.