### PR TITLE
[pytorch] use randn in dropout

### DIFF
--- a/chapter_multilayer-perceptrons/dropout.md
+++ b/chapter_multilayer-perceptrons/dropout.md
@@ -255,7 +255,7 @@ def dropout_layer(X, dropout):
     # In this case, all elements are kept
     if dropout == 0:
         return X
-    mask = (torch.Tensor(X.shape).uniform_(0, 1) > dropout).float()
+    mask = (torch.rand(X.shape) > dropout).float()
     return mask * X / (1.0 - dropout)
 ```
 


### PR DESCRIPTION
simply the code, we should avoid use _ functions

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
