### PR TITLE
Update conv-layer.md

### DIFF
--- a/chapter_convolutional-neural-networks/conv-layer.md
+++ b/chapter_convolutional-neural-networks/conv-layer.md
@@ -300,7 +300,7 @@ for i in range(10):
 conv2d = nn.Conv2d(1,1, kernel_size=(1, 2), bias=False)
 
 # The two-dimensional convolutional layer uses four-dimensional input and
-# output in the format of (example channel, height, width), where the batch
+# output in the format of (example, channel, height, width), where the batch
 # size (number of examples in the batch) and the number of channels are both 1
 X = X.reshape((1, 1, 6, 8))
 Y = Y.reshape((1, 1, 6, 7))
@@ -324,7 +324,7 @@ for i in range(10):
 conv2d = tf.keras.layers.Conv2D(1, (1, 2), use_bias=False)
 
 # The two-dimensional convolutional layer uses four-dimensional input and
-# output in the format of (example channel, height, width), where the batch
+# output in the format of (example, height, width, channel), where the batch
 # size (number of examples in the batch) and the number of channels are both 1
 X = tf.reshape(X, (1, 6, 8, 1))
 Y = tf.reshape(Y, (1, 6, 7, 1))


### PR DESCRIPTION
Fix the dimension in comment in tensorflow code in Learning a Kernel and missing comma in dimension in PyTorch code.

*Description of changes:* 
The order of 'dimensions' used in PyTorch and Tensorflow is supposed to be different. So, the dimensions specified in the tensorflow code in Learning a Kernel was fixed. Also, a missing comma in PyTorch comment about the dimensions was also fixed.


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
