### PR TITLE
Modifying grad_clipping function of TF

### DIFF
--- a/chapter_recurrent-neural-networks/rnn-scratch.md
+++ b/chapter_recurrent-neural-networks/rnn-scratch.md
@@ -520,19 +520,23 @@ def grad_clipping(net, theta):  #@save
 
 ```{.python .input}
 #@tab tensorflow
-def grad_clipping(grads, theta): #@save
+def grad_clipping(grads, theta):  #@save
     """Clip the gradient."""
     theta = tf.constant(theta, dtype=tf.float32)
-    norm = tf.math.sqrt(sum((tf.reduce_sum(grad ** 2)).numpy()
-                        for grad in grads))
-    norm = tf.cast(norm, tf.float32)
     new_grad = []
-    if tf.greater(norm, theta):
-        for grad in grads:
-            new_grad.append(grad * theta / norm)
-    else:
-        for grad in grads:
+    for grad in grads:
+        if isinstance(grad, tf.IndexedSlices):
+            new_grad.append(tf.convert_to_tensor(grad))
+        else:
             new_grad.append(grad)
+    norm = tf.math.sqrt(sum((tf.reduce_sum(grad ** 2)).numpy()
+                        for grad in new_grad))
+    norm = tf.cast(norm, tf.float32)
+    if tf.greater(norm, theta):
+        for i, grad in enumerate(new_grad):
+            new_grad[i] = grad * theta / norm
+    else:
+        new_grad = new_grad
     return new_grad
 ```
 


### PR DESCRIPTION
The existing `grad_clipping` function won't work when gradients are `IndexedSlices`. When embedding layers are used in the model (as in section 9.7 and in chapter 10), gradients of embedding layer are stored as `tf.IndexedSlices`. So before applying gradient clipping, `IndexedSlices` need to be converted into tensors. The new function basically does that. It also works perfectly fine when all the gradients are tensors. So by modifying the old function we can make it useful for future chapters.


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
