### PR TITLE
Adding no_grad context manager block to the PyTorch versions of `eval…

### DIFF
--- a/chapter_convolutional-neural-networks/lenet.md
+++ b/chapter_convolutional-neural-networks/lenet.md
@@ -256,14 +256,16 @@ def evaluate_accuracy_gpu(net, data_iter, device=None): #@save
             device = next(iter(net.parameters())).device
     # No. of correct predictions, no. of predictions
     metric = d2l.Accumulator(2)
-    for X, y in data_iter:
-        if isinstance(X, list):
-            # Required for BERT Fine-tuning (to be covered later)
-            X = [x.to(device) for x in X]
-        else:
-            X = X.to(device)
-        y = y.to(device)
-        metric.add(d2l.accuracy(net(X), y), d2l.size(y))
+    
+    with torch.no_grad():
+        for X, y in data_iter:
+            if isinstance(X, list):
+                # Required for BERT Fine-tuning (to be covered later)
+                X = [x.to(device) for x in X]
+            else:
+                X = X.to(device)
+            y = y.to(device)
+            metric.add(d2l.accuracy(net(X), y), d2l.size(y))
     return metric[0] / metric[1]
 ```
 

--- a/chapter_linear-networks/softmax-regression-scratch.md
+++ b/chapter_linear-networks/softmax-regression-scratch.md
@@ -317,8 +317,10 @@ def evaluate_accuracy(net, data_iter):  #@save
     if isinstance(net, torch.nn.Module):
         net.eval()  # Set the model to evaluation mode
     metric = Accumulator(2)  # No. of correct predictions, no. of predictions
-    for X, y in data_iter:
-        metric.add(accuracy(net(X), y), d2l.size(y))
+    
+    with torch.no_grad():
+        for X, y in data_iter:
+            metric.add(accuracy(net(X), y), d2l.size(y))
     return metric[0] / metric[1]
 ```
 


### PR DESCRIPTION
…uate_accuracy` and `evaluate_accuracy_gpu` functions

As detailed in the PyTorch forums (https://discuss.pytorch.org/t/model-eval-vs-with-torch-no-grad/19615/2), evaluation should use both `net.eval()` and `with torch.no_grad()` since they serve different purposes and there are clear performance benefits to be gotten when using `with torch.no_grad()`. Attaching a notebook with finetuning on the Hot Dog dataset to demonstrate the differences in training speed (please change extension to .ipynb to verify, Github wasn't allowing me to upload a .ipynb file  so converted it to .txt).


[no_grad_expts.txt](https://github.com/d2l-ai/d2l-en/files/6641217/no_grad_expts.txt)


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
