### PR TITLE
[TF] To reproduce TF-2.3.1 cudnn errors

### DIFF
--- a/chapter_attention-mechanisms/transformer.md
+++ b/chapter_attention-mechanisms/transformer.md
@@ -128,11 +128,6 @@ from d2l import tensorflow as d2l
 import numpy as np
 import pandas as pd
 import tensorflow as tf
-
-gpus = tf.config.list_physical_devices("GPU")
-if gpus:
-    for gpu in gpus:
-        tf.config.experimental.set_memory_growth(gpu, True)
 ```
 
 ## Positionwise Feed-Forward Networks


### PR DESCRIPTION
This PR is to see if TF-2.3.1 cudnn errors could be reproduced. This is in response to this [discussion](https://github.com/d2l-ai/d2l-en/pull/1768#discussion_r647041750).


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
