### PR TITLE
Bump torch to 1.9.0 and torchvision to 0.10.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,7 @@ stage("Build and Publish") {
 
       sh label: "Sanity Check", script: """set -ex
       conda activate ${ENV_NAME}
+      d2lbook clear
       d2lbook build outputcheck tabcheck
       """
 

--- a/static/build.yml
+++ b/static/build.yml
@@ -5,9 +5,9 @@ dependencies:
     - ..  # d2l
     - git+https://github.com/d2l-ai/d2l-book
     - mxnet-cu101==1.7.0
-    - torch==1.8.1+cu101
+    - torch==1.9.0+cu101
     - -f https://download.pytorch.org/whl/torch_stable.html
-    - torchvision==0.9.1+cu101
+    - torchvision==0.10.0+cu101
     - -f https://download.pytorch.org/whl/torch_stable.html
     - tensorflow==2.3.1
     - tensorflow-probability==0.11.1


### PR DESCRIPTION
*Description of changes:*
Recently PyTorch released new stable versions. We should bump our dependencies and check if the CI runs green with the new version. I'll remove `d2lbook clear` once the complete build works in the CI.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
