### PR TITLE
Update text-preprocessing.md

### DIFF
--- a/chapter_recurrent-neural-networks/text-preprocessing.md
+++ b/chapter_recurrent-neural-networks/text-preprocessing.md
@@ -73,7 +73,7 @@ print(lines[10])
 
 The following `tokenize` function
 takes a list (`lines`) as the input,
-where each list is a text sequence (e.g., a text line).
+where each element is a text sequence (e.g., a text line).
 Each text sequence is split into a list of tokens.
 A *token* is the basic unit in text.
 In the end,


### PR DESCRIPTION
change list to element, semantic problem

*Description of changes:*
I think there should be element instead of list. Because list doesn't make any sense and in that list (lines), elements are also not lists (they are strings). 
I changed this line:
The following tokenize function takes a list (lines) as the input, where each **_list_** is a text sequence (e.g., a text line).
to this:
The following tokenize function takes a list (lines) as the input, where each **_element_** is a text sequence (e.g., a text line).


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
