### PR TITLE
replace .size with .size() in (preliminaries/linear_algebra.md)

### DIFF
--- a/chapter_preliminaries/linear-algebra.md
+++ b/chapter_preliminaries/linear-algebra.md
@@ -580,7 +580,7 @@ In code, we could just call the function for calculating the mean
 on tensors of arbitrary shape.
 
 ```{.python .input}
-A.mean(), A.sum() / A.size
+A.mean(), A.sum() / A.size()
 ```
 
 ```{.python .input}


### PR DESCRIPTION
Not changing this will result in: 
A.sum() being divided by the function A.size => invalid, throws error.
whereas we want A.sum() divided by the integer A.size()

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
