### PR TITLE
fix minor typo: parallellism->parallelism

### DIFF
--- a/chapter_computational-performance/index.md
+++ b/chapter_computational-performance/index.md
@@ -6,7 +6,7 @@ datasets and models are usually large,
 which involves heavy computation.
 Therefore, computational performance matters a lot.
 This chapter will focus on the major factors that affect computational performance:
-imperative programming, symbolic programming, asynchronous computing, automatic parallellism, and multi-GPU computation.
+imperative programming, symbolic programming, asynchronous computing, automatic parallelism, and multi-GPU computation.
 By studying this chapter, you may further improve computational performance of those models implemented in the previous chapters,
 for example, by reducing training time without affecting accuracy.
 


### PR DESCRIPTION
*Description of changes:*
I fixed a minor typo in index of 'Chapter 12. Computational Performance': parallellism->parallelism

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
