### PR TITLE
Fix the problem where tqdm bar flushes d2l.Animator

### DIFF
--- a/d2l/mxnet.py
+++ b/d2l/mxnet.py
@@ -273,6 +273,7 @@ class Animator:
 
     def add(self, x, y):
         # Add multiple data points into the figure
+        display.clear_output(wait=True)
         if not hasattr(y, "__len__"):
             y = [y]
         n = len(y)
@@ -291,7 +292,6 @@ class Animator:
             self.axes[0].plot(x, y, fmt)
         self.config_axes()
         display.display(self.fig)
-        display.clear_output(wait=True)
 
 
 # Defined in file: ./chapter_linear-networks/softmax-regression-scratch.md

--- a/d2l/tensorflow.py
+++ b/d2l/tensorflow.py
@@ -284,6 +284,7 @@ class Animator:
 
     def add(self, x, y):
         # Add multiple data points into the figure
+        display.clear_output(wait=True)
         if not hasattr(y, "__len__"):
             y = [y]
         n = len(y)
@@ -302,7 +303,6 @@ class Animator:
             self.axes[0].plot(x, y, fmt)
         self.config_axes()
         display.display(self.fig)
-        display.clear_output(wait=True)
 
 
 # Defined in file: ./chapter_linear-networks/softmax-regression-scratch.md

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -303,6 +303,7 @@ class Animator:
 
     def add(self, x, y):
         # Add multiple data points into the figure
+        display.clear_output(wait=True)
         if not hasattr(y, "__len__"):
             y = [y]
         n = len(y)
@@ -321,7 +322,6 @@ class Animator:
             self.axes[0].plot(x, y, fmt)
         self.config_axes()
         display.display(self.fig)
-        display.clear_output(wait=True)
 
 
 # Defined in file: ./chapter_linear-networks/softmax-regression-scratch.md


### PR DESCRIPTION
*Description of changes:*
Hi Professors and developers,

I'm an incoming graduate student at University of Michigan, currently learning Dive into Deep Learning online on Bilibili. When I was trying to combine tqdm progress bar and d2l.Animator, I found that the progress bar constantly flushes out the matplotlib figure, making them impossible to be used together.

Here's a video explaining the hassle and how to fix it:
https://www.bilibili.com/video/BV12P4y147ye/
Sorry but it's in Chinese, I can make another English version if needed.
(Now there's a minimal piece of code below the reproduce the problem.)


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
