### PR TITLE
[frontpage] change notebook icon to python

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -40,7 +40,7 @@ tabs = mxnet, pytorch, tensorflow
 # PDF, http://numpy.d2l.ai/d2l-en.pdf, fas fa-file-pdf,
 header_links = MXNet, https://d2l.ai/d2l-en.pdf, fas fa-file-pdf,
                PyTorch, https://d2l.ai/d2l-en-pytorch.pdf, fas fa-file-pdf,
-               Notebooks, https://d2l.ai/d2l-en.zip, fas fa-download,
+               Notebooks, https://d2l.ai/d2l-en.zip, fab fa-python,
                Courses, https://courses.d2l.ai, fas fa-user-graduate,
                GitHub, https://github.com/d2l-ai/d2l-en, fab fa-github,
                中文版, https://zh.d2l.ai, fas fa-external-link-alt


### PR DESCRIPTION
*Description of changes:*

change the notebook icon from download to python.

<img width="144" alt="Screen Shot 2021-07-26 at 2 53 24 PM" src="https://user-images.githubusercontent.com/421857/127064094-f67d18ce-4305-44e7-a3a9-baae905b0992.png">

though i didn't find a way to have colored icons... 

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
