### PR TITLE
[homepage] make the first 3 items in toc align right

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -49,6 +49,8 @@ favicon = static/favicon.png
 
 html_logo = static/logo-with-text.png
 
+include_css = static/d2l.css 
+
 
 [pdf]
 

--- a/static/d2l.css
+++ b/static/d2l.css
@@ -1,0 +1,5 @@
+.globaltoc ul:first-of-type li.toctree-l1 .link-wrapper>a {
+    padding-left: 1em;
+    text-align: right;
+    padding-right: 8px;
+}


### PR DESCRIPTION
*Description of changes:*

how it looks like now: 

<img width="252" alt="Screen Shot 2021-07-26 at 3 05 34 PM" src="https://user-images.githubusercontent.com/421857/127065277-72a5c777-ded9-42c1-8631-f6b4c5c24b2f.png">


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
