### PR TITLE
fix: Typos in Linear Neural Networks

### DIFF
--- a/chapter_linear-networks/image-classification-dataset.md
+++ b/chapter_linear-networks/image-classification-dataset.md
@@ -45,7 +45,7 @@ d2l.use_svg_display()
 
 ## Reading the Dataset
 
-We can [**download and read the Fashion-MNIST dataset into memory via the build-in functions in the framework.**]
+We can [**download and read the Fashion-MNIST dataset into memory via the built-in functions in the framework.**]
 
 ```{.python .input}
 class FashionMNIST(d2l.DataModule):  #@save

--- a/chapter_linear-networks/linear-regression.md
+++ b/chapter_linear-networks/linear-regression.md
@@ -275,7 +275,7 @@ They can be tuned automatically by a number of techniques, such as Bayesian Opti
 typically assessed on a separate *validation dataset* (or *validation set*).
 
 After training for some predetermined number of iterations
-(or until some other stopping criteria(s) are met),
+(or until some other stopping criterion is met),
 we record the estimated model parameters,
 denoted $\hat{\mathbf{w}}, \hat{b}$.
 Note that even if our function is truly linear and noiseless,

--- a/chapter_linear-networks/linear-regression.md
+++ b/chapter_linear-networks/linear-regression.md
@@ -275,7 +275,7 @@ They can be tuned automatically by a number of techniques, such as Bayesian Opti
 typically assessed on a separate *validation dataset* (or *validation set*).
 
 After training for some predetermined number of iterations
-(or until some other stopping criteria are met),
+(or until some other stopping criteria(s) are met),
 we record the estimated model parameters,
 denoted $\hat{\mathbf{w}}, \hat{b}$.
 Note that even if our function is truly linear and noiseless,

--- a/chapter_linear-networks/softmax-regression.md
+++ b/chapter_linear-networks/softmax-regression.md
@@ -59,7 +59,7 @@ But general classification problems do not come with natural orderings among the
 Fortunately, statisticians long ago invented a simple way
 to represent categorical data: the *one-hot encoding*.
 A one-hot encoding is a vector with as many components as we have categories.
-The component corresponding to particular instance's category is set to 1
+The component corresponding to a particular instance's category is set to 1
 and all other components are set to 0.
 In our case, a label $y$ would be a three-dimensional vector,
 with $(1, 0, 0)$ corresponding to "cat", $(0, 1, 0)$ to "chicken",
@@ -162,7 +162,7 @@ To interpret our outputs as probabilities,
 we must guarantee that (even on new data),
 they will be nonnegative and sum up to 1.
 Moreover, we need a training objective that encourages
-the model to estimate faithfully probabilities.
+the model to faithfully estimate probabilities.
 Of all instances when a classifier outputs 0.5,
 we hope that half of those examples
 will actually belong to the predicted class.

--- a/chapter_linear-networks/softmax-regression.md
+++ b/chapter_linear-networks/softmax-regression.md
@@ -162,7 +162,7 @@ To interpret our outputs as probabilities,
 we must guarantee that (even on new data),
 they will be nonnegative and sum up to 1.
 Moreover, we need a training objective that encourages
-the model to faithfully estimate probabilities.
+the model to estimate probabilities faithfully.
 Of all instances when a classifier outputs 0.5,
 we hope that half of those examples
 will actually belong to the predicted class.


### PR DESCRIPTION
*Description of changes:*
- Fixes typos/grammars

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
