### PR TITLE
Typo line 15

### DIFF
--- a/chapter_natural-language-processing-applications/finetuning-bert.md
+++ b/chapter_natural-language-processing-applications/finetuning-bert.md
@@ -12,7 +12,7 @@ In :numref:`sec_bert`,
 we introduced a pretraining model, BERT,
 that requires minimal architecture changes
 for a wide range of natural language processing tasks.
-One one hand,
+On the one hand,
 at the time of its proposal,
 BERT improved the state of the art on various natural language processing tasks.
 On the other hand,


### PR DESCRIPTION
Hi, there is a typo at line 15: "One one hand". 
I checked the Collins dictionary, and it says that "On the one hand" works well here instead of "One one hand": https://www.collinsdictionary.com/us/dictionary/english/on-the-one-hand
Thanks!

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
