### PR TITLE
Update machine-translation-and-dataset.md

### DIFF
--- a/chapter_recurrent-modern/machine-translation-and-dataset.md
+++ b/chapter_recurrent-modern/machine-translation-and-dataset.md
@@ -105,7 +105,8 @@ d2l.DATA_HUB['fra-eng'] = (d2l.DATA_URL + 'fra-eng.zip',
 def read_data_nmt():
     """Load the English-French dataset."""
     data_dir = d2l.download_extract('fra-eng')
-    with open(os.path.join(data_dir, 'fra.txt'), 'r') as f:
+    with open(os.path.join(data_dir, 'fra.txt'), 'r',
+              encoding='utf-8') as f:
         return f.read()
 
 raw_text = read_data_nmt()


### PR DESCRIPTION
if not set the encoding, a 'gbk' codec can't decode byte 0x93 error may appear on the win10 computer
