### PR TITLE
Update machine-translation-and-dataset.md

### DIFF
--- a/chapter_recurrent-modern/machine-translation-and-dataset.md
+++ b/chapter_recurrent-modern/machine-translation-and-dataset.md
@@ -105,7 +105,8 @@ d2l.DATA_HUB['fra-eng'] = (d2l.DATA_URL + 'fra-eng.zip',
 def read_data_nmt():
     """Load the English-French dataset."""
     data_dir = d2l.download_extract('fra-eng')
-    with open(os.path.join(data_dir, 'fra.txt'), 'r') as f:
+    with open(os.path.join(data_dir, 'fra.txt'), 'r',
+              encoding='utf-8') as f:
         return f.read()
 
 raw_text = read_data_nmt()


### PR DESCRIPTION
*Description of changes:*
这个问题是因为电脑的编码问题产生的，如果地区和位置设置为中国，默认编码是gbk，此时程序是无法正常运行的，报错如下：

> UnicodeDecodeError: 'gbk' codec can't decode byte 0xaf in position 33: illegal multibyte sequence

需要加上编码格式，之后程序可以正常运行。


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
