### PR TITLE
mini typo

### DIFF
--- a/chapter_installation/index.md
+++ b/chapter_installation/index.md
@@ -142,7 +142,7 @@ pip install -U d2l
 ```
 
 
-Once you have completed these installation steps, we can the Jupyter notebook server by running:
+Once you have completed these installation steps, we can start the Jupyter notebook server by running:
 
 ```bash
 jupyter notebook


### PR DESCRIPTION
is the phrase `we can the Jupyter notebook server by running `correct? (grammatically speaking)
shouldn't it contain a verb between `can` and` the`?
Maybe I'm wrong, english is not my mother tongue.


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
