### PR TITLE
update set_matplotlib_formats() as it deprecated since ipython v 7.23

### DIFF
--- a/chapter_preliminaries/calculus.md
+++ b/chapter_preliminaries/calculus.md
@@ -92,7 +92,7 @@ Let's develop some intuition with an example.
 ```{.python .input}
 %matplotlib inline
 from d2l import mxnet as d2l
-from IPython import display
+import matplotlib_inline.backend_inline
 from mxnet import np, npx
 npx.set_np()
 
@@ -104,7 +104,7 @@ def f(x):
 #@tab pytorch
 %matplotlib inline
 from d2l import torch as d2l
-from IPython import display
+import matplotlib_inline.backend_inline
 import numpy as np
 
 def f(x):
@@ -115,7 +115,7 @@ def f(x):
 #@tab tensorflow
 %matplotlib inline
 from d2l import tensorflow as d2l
-from IPython import display
+import matplotlib_inline.backend_inline
 import numpy as np
 
 def f(x):
@@ -182,7 +182,7 @@ e.g., via `d2l.use_svg_display()`.
 #@tab all
 def use_svg_display():  #@save
     """Use the svg format to display a plot in Jupyter."""
-    display.set_matplotlib_formats('svg')
+    matplotlib_inline.backend_inline.set_matplotlib_formats('svg')
 ```
 
 Conveniently, we can set figure sizes with `set_figsize`. 

--- a/d2l/mxnet.py
+++ b/d2l/mxnet.py
@@ -22,6 +22,7 @@ import pandas as pd
 import requests
 from IPython import display
 from matplotlib import pyplot as plt
+import matplotlib_inline.backend_inline
 
 from mxnet import autograd, context, gluon, image, init, np, npx
 from mxnet.gluon import nn, rnn

--- a/d2l/tensorflow.py
+++ b/d2l/tensorflow.py
@@ -18,6 +18,7 @@ import pandas as pd
 import requests
 from IPython import display
 from matplotlib import pyplot as plt
+import matplotlib_inline.backend_inline
 
 import numpy as np
 import tensorflow as tf

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -18,6 +18,7 @@ import pandas as pd
 import requests
 from IPython import display
 from matplotlib import pyplot as plt
+import matplotlib_inline.backend_inline
 
 import numpy as np
 import torch


### PR DESCRIPTION
set_matplotlib_formats() deprecated since Ipython v 7.23. 

`/tmp/ipykernel_210/3293544180.py:3: DeprecationWarning: `set_matplotlib_formats` is deprecated since IPython 7.23, directly use `matplotlib_inline.backend_inline.set_matplotlib_formats()`
  display.set_matplotlib_formats('svg')`

<img width="1067" alt="2021-10-07 00_36_00-Settings" src="https://user-images.githubusercontent.com/7364193/136476572-d2cb9361-5430-4524-8102-7e49f8d1bcc8.png">


https://ipython.readthedocs.io/en/stable/api/generated/IPython.display.html#IPython.display.set_matplotlib_formats