### PR TITLE
[STY] Fix :label: naming convention

### DIFF
--- a/chapter_recurrent-modern/lstm.md
+++ b/chapter_recurrent-modern/lstm.md
@@ -44,7 +44,7 @@ Just like in GRUs,
 the data feeding into the LSTM gates are
 the input at the current time step and
 the hidden state of the previous time step,
-as illustrated in :numref:`lstm_0`.
+as illustrated in :numref:`fig_lstm_0`.
 They are processed by
 three fully connected layers with a sigmoid activation function to compute the values of
 the input, forget. and output gates.
@@ -52,7 +52,7 @@ As a result, values of the three gates
 are in the range of $(0, 1)$.
 
 ![Computing the input gate, the forget gate, and the output gate in an LSTM model.](../img/lstm-0.svg)
-:label:`lstm_0`
+:label:`fig_lstm_0`
 
 Mathematically,
 suppose that there are $h$ hidden units, the batch size is $n$, and the number of inputs is $d$.
@@ -77,10 +77,10 @@ $$\tilde{\mathbf{C}}_t = \text{tanh}(\mathbf{X}_t \mathbf{W}_{xc} + \mathbf{H}_{
 
 where $\mathbf{W}_{xc} \in \mathbb{R}^{d \times h}$ and $\mathbf{W}_{hc} \in \mathbb{R}^{h \times h}$ are weight parameters and $\mathbf{b}_c \in \mathbb{R}^{1 \times h}$ is a bias parameter.
 
-A quick illustration of the candidate memory cell is shown in :numref:`lstm_1`.
+A quick illustration of the candidate memory cell is shown in :numref:`fig_lstm_1`.
 
 ![Computing the candidate memory cell in an LSTM model.](../img/lstm-1.svg)
-:label:`lstm_1`
+:label:`fig_lstm_1`
 
 ### Memory Cell
 
@@ -94,11 +94,11 @@ If the forget gate is always approximately 1 and the input gate is always approx
 This design is introduced to alleviate the vanishing gradient problem and to better capture
 long range dependencies within sequences.
 
-We thus arrive at the flow diagram in :numref:`lstm_2`.
+We thus arrive at the flow diagram in :numref:`fig_lstm_2`.
 
 ![Computing the memory cell in an LSTM model.](../img/lstm-2.svg)
 
-:label:`lstm_2`
+:label:`fig_lstm_2`
 
 
 ### Hidden State
@@ -113,10 +113,10 @@ Whenever the output gate approximates 1 we effectively pass all memory informati
 
 
 
-:numref:`lstm_3` has a graphical illustration of the data flow.
+:numref:`fig_lstm_3` has a graphical illustration of the data flow.
 
 ![Computing the hidden state in an LSTM model.](../img/lstm-3.svg)
-:label:`lstm_3`
+:label:`fig_lstm_3`
 
 
 


### PR DESCRIPTION
**Fix LSTM figures naming convention.**

Minor issue found while developing the mini compiler for references.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
