### PR TITLE
Fix sneaky Unicode symbols in math

### DIFF
--- a/chapter_appendix-mathematics-for-deep-learning/information-theory.md
+++ b/chapter_appendix-mathematics-for-deep-learning/information-theory.md
@@ -180,7 +180,7 @@ For the following discussion, we always use $(X, Y)$ as a pair of random variabl
 
 Similar to entropy of a single random variable :eqref:`eq_ent_def`, we define the *joint entropy* $H(X, Y)$ of a pair random variables $(X, Y)$ as
 
-$$H(X, Y) = −E_{(x, y) \sim P} [\log p_{X, Y}(x, y)]. $$
+$$H(X, Y) = -E_{(x, y) \sim P} [\log p_{X, Y}(x, y)]. $$
 :eqlabel:`eq_joint_ent_def`
 
 Precisely, on the one hand, if $(X, Y)$ is a pair of discrete random variables, then
@@ -304,7 +304,7 @@ Given the previous setting of random variables $(X, Y)$, you may wonder: "Now th
 Rather than diving straight into the formal definition, let's practice our intuition by first trying to derive an expression for the mutual information entirely based on terms we have constructed before.  We wish to find the information shared between two random variables.  One way we could try to do this is to start with all the information contained in both $X$ and $Y$ together, and then we take off the parts that are not shared.  The information contained in both $X$ and $Y$ together is written as $H(X, Y)$.  We want to subtract from this the information contained in $X$ but not in $Y$, and the information contained in $Y$ but not in $X$.  As we saw in the previous section, this is given by $H(X \mid Y)$ and $H(Y \mid X)$ respectively.  Thus, we have that the mutual information should be
 
 $$
-I(X, Y) = H(X, Y) - H(Y \mid X) − H(X \mid Y).
+I(X, Y) = H(X, Y) - H(Y \mid X) - H(X \mid Y).
 $$
 
 Indeed, this is a valid definition for the mutual information.  If we expand out the definitions of these terms and combine them, a little algebra shows that this is the same as
@@ -315,9 +315,9 @@ $$I(X, Y) = E_{x} E_{y} \left\{ p_{X, Y}(x, y) \log\frac{p_{X, Y}(x, y)}{p_X(x) 
 
 We can summarize all of these relationships in image :numref:`fig_mutual_information`.  It is an excellent test of intuition to see why the following statements are all also equivalent to $I(X, Y)$.
 
-* $H(X) − H(X \mid Y)$
-* $H(Y) − H(Y \mid X)$
-* $H(X) + H(Y) − H(X, Y)$
+* $H(X) - H(X \mid Y)$
+* $H(Y) - H(Y \mid X)$
+* $H(X) + H(Y) - H(X, Y)$
 
 ![Mutual information's relationship with joint entropy and conditional entropy.](../img/mutual-information.svg)
 :label:`fig_mutual_information`

--- a/chapter_computer-vision/fcn.md
+++ b/chapter_computer-vision/fcn.md
@@ -171,7 +171,7 @@ of the upsampled output image.
 In order to calculate the pixel of the output image
 at coordinate $(x, y)$, 
 first map $(x, y)$ to coordinate $(x', y')$ on the input image, for example, according to the ratio of the input size to the output size. 
-Note that the mapped $x′$ and $y′$ are real numbers. 
+Note that the mapped $x'$ and $y'$ are real numbers. 
 Then, find the four pixels closest to coordinate
 $(x', y')$ on the input image. 
 Finally, the pixel of the output image at coordinate $(x, y)$ is calculated based on these four closest pixels

--- a/chapter_natural-language-processing-pretraining/word2vec.md
+++ b/chapter_natural-language-processing-pretraining/word2vec.md
@@ -19,7 +19,7 @@ the basic knowledge of natural language processing.
 We used one-hot vectors to represent words (characters are words) in :numref:`sec_rnn_scratch`.
 Suppose that the number of different words in the dictionary (the dictionary size) is $N$,
 and each word corresponds to
-a different integer (index) from $0$ to $N−1$.
+a different integer (index) from $0$ to $N-1$.
 To obtain the one-hot vector representation
 for any word with index $i$,
 we create a length-$N$ vector with all 0s


### PR DESCRIPTION
*Description of changes:*

The document has a few "sneaky Unicode symbols" that look like their proper counterpart, but in fact are not.

The symbols were causing LaTeX errors while trying out EPUB rendering (d2l-ai/d2l-book#37)
