### PR TITLE
[PyTorch] Kaggle Dog Explicitly move to cpu before plotting

### DIFF
--- a/chapter_computer-vision/kaggle-dog.md
+++ b/chapter_computer-vision/kaggle-dog.md
@@ -416,7 +416,7 @@ def train(net, train_iter, valid_iter, num_epochs, lr, wd, devices, lr_period,
         measures = f'train loss {metric[0] / metric[1]:.3f}'
         if valid_iter is not None:
             valid_loss = evaluate_loss(valid_iter, net, devices)
-            animator.add(epoch + 1, (None, valid_loss.detach()))
+            animator.add(epoch + 1, (None, valid_loss.detach().cpu()))
         scheduler.step()
     if valid_iter is not None:
         measures += f', valid loss {valid_loss:.3f}'


### PR DESCRIPTION
Fix TypeError: can’t convert CUDA tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.

Please DO NOT MERGE this yet.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
