### PR TITLE
fix function predict_seq2seq

### DIFF
--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -3046,7 +3046,7 @@ def predict_seq2seq(net, src_sentence, src_vocab, tgt_vocab, num_steps,
         pred = dec_X.squeeze(dim=0).type(torch.int32).item()
         # Save attention weights (to be covered later)
         if save_attention_weights:
-            attention_weight_seq.append(net.decoder.attention_weights)
+            attention_weight_seq.append(net.decoder.attention_weights())
         # Once the end-of-sequence token is predicted, the generation of the
         # output sequence is complete
         if pred == tgt_vocab['<eos>']:


### PR DESCRIPTION
`net.decoder.attention_weights` should be `net.decoder.attention_weights()`, attention_weights is a function, we should call it here, otherwise attention_weight_seq will be a list of functions, rather than a list of attention_weights. and when we exec `attention_weights = torch.cat([step[0][0][0] for step in dec_attention_weight_seq],0).reshape((1, 1, -1, num_steps))` later, an error will  occur: 'method' object is not subscriptable.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
