### PR TITLE
Minor spelling fix in heatmap

### DIFF
--- a/chapter_attention-mechanisms/bahdanau-attention.md
+++ b/chapter_attention-mechanisms/bahdanau-attention.md
@@ -425,7 +425,7 @@ d2l.show_heatmaps(
 #@tab tensorflow
 # Plus one to include the end-of-sequence token
 d2l.show_heatmaps(attention_weights[:, :, :, :len(engs[-1].split()) + 1],
-                  xlabel='Key posistions', ylabel='Query posistions')
+                  xlabel='Key positions', ylabel='Query positions')
 ```
 
 ## Summary


### PR DESCRIPTION
Minor spelling fix in heatmap: posistions -> positions

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
