### PR TITLE
Fix: Epoch instead of batch

### DIFF
--- a/chapter_convolutional-neural-networks/conv-layer.md
+++ b/chapter_convolutional-neural-networks/conv-layer.md
@@ -300,7 +300,7 @@ for i in range(10):
     # Update the kernel
     conv2d.weight.data()[:] -= lr * conv2d.weight.grad()
     if (i + 1) % 2 == 0:
-        print(f'batch {i + 1}, loss {float(l.sum()):.3f}')
+        print(f'Epoch {i + 1}, loss {float(l.sum()):.3f}')
 ```
 
 ```{.python .input}
@@ -324,7 +324,7 @@ for i in range(10):
     # Update the kernel
     conv2d.weight.data[:] -= lr * conv2d.weight.grad
     if (i + 1) % 2 == 0:
-        print(f'batch {i + 1}, loss {l.sum():.3f}')
+        print(f'Epoch {i + 1}, loss {l.sum():.3f}')
 ```
 
 ```{.python .input}
@@ -352,7 +352,7 @@ for i in range(10):
         weights[0] = conv2d.weights[0] - update
         conv2d.set_weights(weights)
         if (i + 1) % 2 == 0:
-            print(f'batch {i + 1}, loss {tf.reduce_sum(l):.3f}')
+            print(f'Epoch {i + 1}, loss {tf.reduce_sum(l):.3f}')
 ```
 
 Note that the error has dropped to a small value after 10 iterations. Now we will [**take a look at the kernel tensor we learned.**]

--- a/chapter_convolutional-neural-networks/conv-layer.md
+++ b/chapter_convolutional-neural-networks/conv-layer.md
@@ -300,7 +300,7 @@ for i in range(10):
     # Update the kernel
     conv2d.weight.data()[:] -= lr * conv2d.weight.grad()
     if (i + 1) % 2 == 0:
-        print(f'Epoch {i + 1}, loss {float(l.sum()):.3f}')
+        print(f'epoch {i + 1}, loss {float(l.sum()):.3f}')
 ```
 
 ```{.python .input}
@@ -324,7 +324,7 @@ for i in range(10):
     # Update the kernel
     conv2d.weight.data[:] -= lr * conv2d.weight.grad
     if (i + 1) % 2 == 0:
-        print(f'Epoch {i + 1}, loss {l.sum():.3f}')
+        print(f'epoch {i + 1}, loss {l.sum():.3f}')
 ```
 
 ```{.python .input}
@@ -352,7 +352,7 @@ for i in range(10):
         weights[0] = conv2d.weights[0] - update
         conv2d.set_weights(weights)
         if (i + 1) % 2 == 0:
-            print(f'Epoch {i + 1}, loss {tf.reduce_sum(l):.3f}')
+            print(f'epoch {i + 1}, loss {tf.reduce_sum(l):.3f}')
 ```
 
 Note that the error has dropped to a small value after 10 iterations. Now we will [**take a look at the kernel tensor we learned.**]


### PR DESCRIPTION
*Description of changes:*
Since the loop here is over the complete dataset (only one image here) it is actually an Epoch rather than a batch that is traversed.

Initially pointed out in the [discussion forum](https://discuss.d2l.ai/t/convolutions-for-images/66/2). Thanks [Jimmie Munyi](https://discuss.d2l.ai/u/jimmiemunyi).

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
