### PR TITLE
Fixed FutureWarning (Dropping of nuisance columns in DataFrame reductions (with 'numeric_only=None') is deprecated; in a future version this will raise TypeError.  Select only valid columns before calling the reduction.)

### DIFF
--- a/chapter_preliminaries/pandas.md
+++ b/chapter_preliminaries/pandas.md
@@ -106,7 +106,7 @@ the mean value of the corresponding column**].
 
 ```{.python .input}
 #@tab all
-inputs = inputs.fillna(inputs.mean())
+inputs['NumRooms'] = inputs['NumRooms'].fillna(inputs['NumRooms'].mean())
 print(inputs)
 ```
 


### PR DESCRIPTION
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
