### PR TITLE
Fixed typo

### DIFF
--- a/chapter_builders-guide/model-construction.md
+++ b/chapter_builders-guide/model-construction.md
@@ -75,7 +75,7 @@ and still implement complex neural networks.
 :label:`fig_blocks`
 
 
-From a programing standpoint, a module is represented by a *class*.
+From a programming standpoint, a module is represented by a *class*.
 Any subclass of it must define a forward propagation function
 that transforms its input into output
 and must store any necessary parameters.


### PR DESCRIPTION
"programing" -> "programming"

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
