### PR TITLE
Fixed typo

### DIFF
--- a/chapter_builders-guide/model-construction.md
+++ b/chapter_builders-guide/model-construction.md
@@ -340,7 +340,7 @@ at how the `Sequential` class works.
 Recall that `Sequential` was designed
 to daisy-chain other modules together.
 To build our own simplified `MySequential`,
-we just need to define two key function:
+we just need to define two key functions:
 1. A function to append modules one by one to a list.
 2. A forward propagation function to pass an input through the chain of modules, in the same order as they were appended.
 


### PR DESCRIPTION
"we just need to define two key function" -> "we just need to define two key functions"

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
