### PR TITLE
[PyTorch] Use reduction=none for train_epoch_ch3

### DIFF
--- a/chapter_linear-networks/softmax-regression-concise.md
+++ b/chapter_linear-networks/softmax-regression-concise.md
@@ -158,7 +158,7 @@ loss = gluon.loss.SoftmaxCrossEntropyLoss()
 
 ```{.python .input}
 #@tab pytorch
-loss = nn.CrossEntropyLoss()
+loss = nn.CrossEntropyLoss(reduction='none')
 ```
 
 ```{.python .input}

--- a/chapter_linear-networks/softmax-regression-scratch.md
+++ b/chapter_linear-networks/softmax-regression-scratch.md
@@ -402,7 +402,7 @@ def train_epoch_ch3(net, train_iter, loss, updater):  #@save
         if isinstance(updater, torch.optim.Optimizer):
             # Using PyTorch in-built optimizer & loss criterion
             updater.zero_grad()
-            l.sum().backward()
+            l.mean().backward()
             updater.step()
         else:
             # Using custom built optimizer & loss criterion

--- a/chapter_multilayer-perceptrons/dropout.md
+++ b/chapter_multilayer-perceptrons/dropout.md
@@ -440,7 +440,7 @@ d2l.train_ch3(net, train_iter, test_iter, loss, num_epochs,
 ```{.python .input}
 #@tab pytorch
 num_epochs, lr, batch_size = 10, 0.5, 256
-loss = nn.CrossEntropyLoss()
+loss = nn.CrossEntropyLoss(reduction='none')
 train_iter, test_iter = d2l.load_data_fashion_mnist(batch_size)
 trainer = torch.optim.SGD(net.parameters(), lr=lr)
 d2l.train_ch3(net, train_iter, test_iter, loss, num_epochs, trainer)

--- a/chapter_multilayer-perceptrons/mlp-concise.md
+++ b/chapter_multilayer-perceptrons/mlp-concise.md
@@ -81,7 +81,7 @@ trainer = gluon.Trainer(net.collect_params(), 'sgd', {'learning_rate': lr})
 ```{.python .input}
 #@tab pytorch
 batch_size, lr, num_epochs = 256, 0.1, 10
-loss = nn.CrossEntropyLoss()
+loss = nn.CrossEntropyLoss(reduction='none')
 trainer = torch.optim.SGD(net.parameters(), lr=lr)
 ```
 

--- a/chapter_multilayer-perceptrons/mlp-scratch.md
+++ b/chapter_multilayer-perceptrons/mlp-scratch.md
@@ -175,7 +175,7 @@ loss = gluon.loss.SoftmaxCrossEntropyLoss()
 
 ```{.python .input}
 #@tab pytorch
-loss = nn.CrossEntropyLoss()
+loss = nn.CrossEntropyLoss(reduction='none')
 ```
 
 ```{.python .input}

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -293,7 +293,7 @@ def train_epoch_ch3(net, train_iter, loss, updater):
         if isinstance(updater, torch.optim.Optimizer):
             # Using PyTorch in-built optimizer & loss criterion
             updater.zero_grad()
-            l.sum().backward()
+            l.mean().backward()
             updater.step()
         else:
             # Using custom built optimizer & loss criterion


### PR DESCRIPTION
*Description of changes:*
Fixes loss not showing up in the following sections:
* https://d2l.ai/chapter_linear-networks/softmax-regression-concise.html
* https://d2l.ai/chapter_multilayer-perceptrons/mlp-scratch.html
* https://d2l.ai/chapter_multilayer-perceptrons/mlp-concise.html
* https://d2l.ai/chapter_multilayer-perceptrons/dropout.html

I'll look at other sections that might be affected. Note that `l.mean()` is required otherwise when using `l.sum()` with PyTorch CrossEntropy (with no reduction) the loss overshoots. This change will not affect any other notebooks because `d2l.train_ch3` is only used in these notebooks, so it won't break any other section.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
