### PR TITLE
[PyTorch] hotfix r0.17.2

### DIFF
--- a/chapter_computer-vision/fine-tuning.md
+++ b/chapter_computer-vision/fine-tuning.md
@@ -362,7 +362,7 @@ hotdog_w.shape
 ```{.python .input}
 #@tab pytorch
 weight = pretrained_net.fc.weight
-hotdog_w = torch.split(weight.data, 1, dim=0)[713]
+hotdog_w = torch.split(weight.data, 1, dim=0)[934]
 hotdog_w.shape
 ```
 

--- a/chapter_multilayer-perceptrons/underfit-overfit.md
+++ b/chapter_multilayer-perceptrons/underfit-overfit.md
@@ -535,7 +535,7 @@ def train(train_features, test_features, train_labels, test_labels,
                                 batch_size)
     test_iter = d2l.load_array((test_features, test_labels.reshape(-1,1)),
                                batch_size, is_train=False)
-    trainer = torch.optim.SGD(net.parameters(), lr=0.001)
+    trainer = torch.optim.SGD(net.parameters(), lr=0.01)
     animator = d2l.Animator(xlabel='epoch', ylabel='loss', yscale='log',
                             xlim=[1, num_epochs], ylim=[1e-3, 1e2],
                             legend=['train', 'test'])

--- a/chapter_multilayer-perceptrons/weight-decay.md
+++ b/chapter_multilayer-perceptrons/weight-decay.md
@@ -465,7 +465,7 @@ def train_concise(wd):
         for X, y in train_iter:
             trainer.zero_grad()
             l = loss(net(X), y)
-            l.sum().backward()
+            l.mean().backward()
             trainer.step()
         if (epoch + 1) % 5 == 0:
             animator.add(epoch + 1, (d2l.evaluate_loss(net, train_iter, loss),

--- a/chapter_optimization/minibatch-sgd.md
+++ b/chapter_optimization/minibatch-sgd.md
@@ -488,7 +488,7 @@ def train_concise_ch11(trainer_fn, hyperparams, data_iter, num_epochs=4):
             if n % 200 == 0:
                 timer.stop()
                 animator.add(n/X.shape[0]/len(data_iter),
-                             (d2l.evaluate_loss(net, data_iter, loss),))
+                             (d2l.evaluate_loss(net, data_iter, loss) / 2,))
                 timer.start()
     print(f'loss: {animator.Y[0][-1]:.3f}, {timer.avg():.3f} sec/epoch')
 ```
@@ -520,7 +520,7 @@ def train_concise_ch11(trainer_fn, hyperparams, data_iter, num_epochs=2):
                 timer.stop()
                 p = n/X.shape[0]
                 q = p/tf.data.experimental.cardinality(data_iter).numpy()
-                r = (d2l.evaluate_loss(net, data_iter, loss),)
+                r = (d2l.evaluate_loss(net, data_iter, loss) / 2,)
                 animator.add(q, r)
                 timer.start()
     print(f'loss: {animator.Y[0][-1]:.3f}, {timer.avg():.3f} sec/epoch')
@@ -537,7 +537,7 @@ train_concise_ch11('sgd', {'learning_rate': 0.05}, data_iter)
 #@tab pytorch
 data_iter, _ = get_data_ch11(10)
 trainer = torch.optim.SGD
-train_concise_ch11(trainer, {'lr': 0.05}, data_iter)
+train_concise_ch11(trainer, {'lr': 0.01}, data_iter)
 ```
 
 ```{.python .input}

--- a/d2l/tensorflow.py
+++ b/d2l/tensorflow.py
@@ -1420,7 +1420,7 @@ def train_concise_ch11(trainer_fn, hyperparams, data_iter, num_epochs=2):
                 timer.stop()
                 p = n/X.shape[0]
                 q = p/tf.data.experimental.cardinality(data_iter).numpy()
-                r = (d2l.evaluate_loss(net, data_iter, loss),)
+                r = (d2l.evaluate_loss(net, data_iter, loss) / 2,)
                 animator.add(q, r)
                 timer.start()
     print(f'loss: {animator.Y[0][-1]:.3f}, {timer.avg():.3f} sec/epoch')

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -1494,7 +1494,7 @@ def train_concise_ch11(trainer_fn, hyperparams, data_iter, num_epochs=4):
             if n % 200 == 0:
                 timer.stop()
                 animator.add(n/X.shape[0]/len(data_iter),
-                             (d2l.evaluate_loss(net, data_iter, loss),))
+                             (d2l.evaluate_loss(net, data_iter, loss) / 2,))
                 timer.start()
     print(f'loss: {animator.Y[0][-1]:.3f}, {timer.avg():.3f} sec/epoch')
 


### PR DESCRIPTION
*Description of changes:*
The following sections are fixed:

* The hotdog class in imagenet is number [934](https://gist.github.com/yrevar/942d3a0ac09ec9e5eb3a#file-imagenet1000_clsidx_to_labels-txt-L935) instead of 713.
* 1/2 is added back in mseloss for chapter_optimization in `train_concise_ch11` because the plots won't show since without the 1/2 the loss gets doubled and the ylim of the training curve has been fixed between 0.22 and 0.35. Without the 1/2 factor the loss never shows up on the plots.
* lr=0.01 makes learning smoother in the updated notebooks.
* l.mean() instead of l.sum() (in the weight-decay section) is more stable, producing the expected plots.


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
