### PR TITLE
Changed Max Global Pooling to Average Global Pooling

### DIFF
--- a/chapter_convolutional-modern/densenet.md
+++ b/chapter_convolutional-modern/densenet.md
@@ -340,7 +340,7 @@ net.add(nn.BatchNorm(),
 net = nn.Sequential(
     b1, *blks,
     nn.BatchNorm2d(num_channels), nn.ReLU(),
-    nn.AdaptiveMaxPool2d((1, 1)),
+    nn.AdaptiveAvgPool2d((1, 1)),
     nn.Flatten(),
     nn.Linear(num_channels, 10))
 ```


### PR DESCRIPTION
In the original paper, before the final fully-connected layer Average Global Pooling was used, not Max Global Pooling (this has only not been implemented for PyTorch). I've made the correction to reflect the correct architecture.


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
