### PR TITLE
Fix a vague sentence in sgd section

### DIFF
--- a/chapter_optimization/gd.md
+++ b/chapter_optimization/gd.md
@@ -150,7 +150,7 @@ To begin with, we need two more helper functions. The first uses an update funct
 #@tab all
 def train_2d(trainer, steps=20, f_grad=None):  #@save
     """Optimize a 2D objective function with a customized trainer."""
-    # `s1` and `s2` are internal state variables that will be used later
+    # `s1` and `s2` are internal state variables that will be used in Momentum, adagrad, RMSProp
     x1, x2, s1, s2 = -5, -2, 0, 0
     results = [(x1, x2)]
     for i in range(steps):

--- a/chapter_optimization/gd.md
+++ b/chapter_optimization/gd.md
@@ -150,7 +150,7 @@ To begin with, we need two more helper functions. The first uses an update funct
 #@tab all
 def train_2d(trainer, steps=20, f_grad=None):  #@save
     """Optimize a 2D objective function with a customized trainer."""
-    # `s1` and `s2` are internal state variables that will be used in Momentum, adagrad, RMSProp
+    # `s1` and `s2` are internal state variables that will be used later
     x1, x2, s1, s2 = -5, -2, 0, 0
     results = [(x1, x2)]
     for i in range(steps):

--- a/chapter_optimization/sgd.md
+++ b/chapter_optimization/sgd.md
@@ -254,7 +254,7 @@ A similar reasoning shows that the probability of picking some sample (i.e., tra
 
 $${n \choose 1} \frac{1}{n} \left(1-\frac{1}{n}\right)^{n-1} = \frac{n}{n-1} \left(1-\frac{1}{n}\right)^{n} \approx e^{-1} \approx 0.37.$$
 
-This leads to an increased variance and decreased data efficiency relative to sampling *without replacement*. Hence, in practice we perform the latter (and this is the default choice throughout this book). Last note that repeated passes through the training dataset traverse it in a *different* random order.
+Sampling with replacement leads to an increased variance and decreased data efficiency relative to sampling *without replacement*. Hence, in practice we perform the latter (and this is the default choice throughout this book). Last note that repeated passes through the training dataset traverse it in a *different* random order.
 
 
 ## Summary


### PR DESCRIPTION
*Description of changes:*

In [sgd](https://github.com/d2l-ai/d2l-en/blob/master/chapter_optimization/sgd.md), it says `This leads to an increased variance and decreased data efficiency relative to sampling without replacement.` The sentence is quite vague since it confuses the reader regarding what `this` means, and it might refer to the preceding content about `picking some sample (i.e., training example) exactly once`. It's more clear to specify what is `this` explicitly. 

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
