### PR TITLE
Mention explicitly where internal states are used in train_2d

### DIFF
--- a/chapter_optimization/gd.md
+++ b/chapter_optimization/gd.md
@@ -150,7 +150,7 @@ To begin with, we need two more helper functions. The first uses an update funct
 #@tab all
 def train_2d(trainer, steps=20, f_grad=None):  #@save
     """Optimize a 2D objective function with a customized trainer."""
-    # `s1` and `s2` are internal state variables that will be used later
+    # `s1` and `s2` are internal state variables that will be used in Momentum, adagrad, RMSProp
     x1, x2, s1, s2 = -5, -2, 0, 0
     results = [(x1, x2)]
     for i in range(steps):

--- a/chapter_optimization/gd.md
+++ b/chapter_optimization/gd.md
@@ -150,7 +150,7 @@ To begin with, we need two more helper functions. The first uses an update funct
 #@tab all
 def train_2d(trainer, steps=20, f_grad=None):  #@save
     """Optimize a 2D objective function with a customized trainer."""
-    # `s1` and `s2` are internal state variables that will be used in Momentum, adagrad, RMSProp
+    # `s1` and `s2` are internal state variables that will be used later
     x1, x2, s1, s2 = -5, -2, 0, 0
     results = [(x1, x2)]
     for i in range(steps):


### PR DESCRIPTION
*Description of changes:*

This PR fixes https://github.com/d2l-ai/d2l-en/issues/2022, by mentioning explicitly where the internal states in `train_2d` are used. 

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.