### PR TITLE
Modify the weights in compute_loss

### DIFF
--- a/chapter_computer-vision/neural-style.md
+++ b/chapter_computer-vision/neural-style.md
@@ -380,7 +380,7 @@ and noise reduction on the synthesized image.
 
 ```{.python .input}
 #@tab all
-content_weight, style_weight, tv_weight = 1, 1e3, 10
+content_weight, style_weight, tv_weight = 1, 1e4, 10
 
 def compute_loss(X, contents_Y_hat, styles_Y_hat, contents_Y, styles_Y_gram):
     # Calculate the content, style, and total variance losses respectively
@@ -390,7 +390,7 @@ def compute_loss(X, contents_Y_hat, styles_Y_hat, contents_Y, styles_Y_gram):
         styles_Y_hat, styles_Y_gram)]
     tv_l = tv_loss(X) * tv_weight
     # Add up all the losses
-    l = sum(10 * styles_l + contents_l + [tv_l])
+    l = sum(styles_l + contents_l + [tv_l])
     return contents_l, styles_l, tv_l, l
 ```
 


### PR DESCRIPTION
*Description of changes:*

In [neural style](https://github.com/d2l-ai/d2l-en/blob/master/chapter_computer-vision/neural-style.md) the losses are added by `l = sum(10 * styles_l + contents_l + [tv_l])`, but the text does not seem to provide any justification about why an additional multiplication of `10` is applied to `styles_l`. I checked the Eq. 7 in [original paper](https://arxiv.org/pdf/1508.06576.pdf), the [implementation in keras](https://github.com/keras-team/keras-io/blob/f7da9514bec1b1be335c5610fbe4b31eb4c71de0/examples/generative/neural_style_transfer.py#L214) and [implementation in tensorflow](https://github.com/tensorflow/docs/blob/master/site/en/tutorials/generative/style_transfer.ipynb), but could not find why an additional multiplication should be applied to style loss either. Perhaps it is less confusing to just increase the `style_weight` by 10 times.

The plot for original loss plots `styles_l` but in fact `10 * styles_l` is used, and thus the styles_l loss in the plot is smaller:
![image](https://user-images.githubusercontent.com/8708551/151384126-df5e3b05-a96e-483c-8d92-4c4dac4a650f.png)

The updated version directly plots the actual `styles_l`:
![image](https://user-images.githubusercontent.com/8708551/151384544-4181f0d5-c568-4f5f-876f-d91b0f7d692e.png)

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
