### PR TITLE
Fix error in the description of Laplace smoothing

### DIFF
--- a/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
+++ b/chapter_appendix-mathematics-for-deep-learning/naive-bayes.md
@@ -235,13 +235,13 @@ P_y = n_y / tf.reduce_sum(n_y)
 P_y
 ```
 
-Now on to slightly more difficult things $P_{xy}$. Since we picked black and white images, $p(x_i  \mid  y)$ denotes the probability that pixel $i$ is switched on for class $y$. Just like before we can go and count the number of times $n_{iy}$ such that an event occurs and divide it by the total number of occurrences of $y$, i.e., $n_y$. But there is something slightly troubling: certain pixels may never be black (e.g., for well cropped images the corner pixels might always be white). A convenient way for statisticians to deal with this problem is to add pseudo counts to all occurrences. Hence, rather than $n_{iy}$ we use $n_{iy}+1$ and instead of $n_y$ we use $n_{y} + 1$. This is also called *Laplace Smoothing*.  It may seem ad-hoc, however it may be well motivated from a Bayesian point-of-view.
+Now on to slightly more difficult things $P_{xy}$. Since we picked black and white images, $p(x_i  \mid  y)$ denotes the probability that pixel $i$ is switched on for class $y$. Just like before we can go and count the number of times $n_{iy}$ such that an event occurs and divide it by the total number of occurrences of $y$, i.e., $n_y$. But there is something slightly troubling: certain pixels may never be black (e.g., for well cropped images the corner pixels might always be white). A convenient way for statisticians to deal with this problem is to add pseudo counts to all occurrences. Hence, rather than $n_{iy}$ we use $n_{iy}+1$ and instead of $n_y$ we use $n_{y}+2$ (since there are two possible values pixel $i$ can take - it can either be black or white). This is also called *Laplace Smoothing*.  It may seem ad-hoc, however it can be motivated from a Bayesian point-of-view by a Beta-binomial model.
 
 ```{.python .input}
 n_x = np.zeros((10, 28, 28))
 for y in range(10):
     n_x[y] = np.array(X.asnumpy()[Y.asnumpy() == y].sum(axis=0))
-P_xy = (n_x + 1) / (n_y + 1).reshape(10, 1, 1)
+P_xy = (n_x + 1) / (n_y + 2).reshape(10, 1, 1)
 
 d2l.show_images(P_xy, 2, 5);
 ```
@@ -251,7 +251,7 @@ d2l.show_images(P_xy, 2, 5);
 n_x = torch.zeros((10, 28, 28))
 for y in range(10):
     n_x[y] = torch.tensor(X.numpy()[Y.numpy() == y].sum(axis=0))
-P_xy = (n_x + 1) / (n_y + 1).reshape(10, 1, 1)
+P_xy = (n_x + 1) / (n_y + 2).reshape(10, 1, 1)
 
 d2l.show_images(P_xy, 2, 5);
 ```
@@ -262,7 +262,7 @@ n_x = tf.Variable(tf.zeros((10, 28, 28)))
 for y in range(10):
     n_x[y].assign(tf.cast(tf.reduce_sum(
         X.numpy()[Y.numpy() == y], axis=0), tf.float32))
-P_xy = (n_x + 1) / tf.reshape((n_y + 1), (10, 1, 1))
+P_xy = (n_x + 1) / tf.reshape((n_y + 2), (10, 1, 1))
 
 d2l.show_images(P_xy, 2, 5);
 ```


### PR DESCRIPTION
*Description of changes:*
Improves the description of Laplace smoothing in the section about naive Bayes classification. This should also fix #1726.

See also:
https://en.wikipedia.org/wiki/Additive_smoothing
https://stats.stackexchange.com/questions/384894/what-is-the-interpretation-for-the-priors-in-the-derivation-of-laplace-smoothing

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
