### PR TITLE
Fix typo in kernel name

### DIFF
--- a/chapter_attention-mechanisms/index.md
+++ b/chapter_attention-mechanisms/index.md
@@ -26,7 +26,7 @@ explaining how attention is deployed in a visual scene.
 Inspired by the attention cues in this framework,
 we will design models
 that leverage such attention cues.
-Notably, the Nadaraya-Waston kernel regression
+Notably, the Nadaraya-Watson kernel regression
 in 1964 is a simple demonstration of machine learning with *attention mechanisms*.
 
 Next, we will go on to introduce attention functions


### PR DESCRIPTION
*Description of changes:*
Fixing a small typo in the Nadaraya-Watson kernel name.
See [1].

[1] Watson, Geoffrey S. “Smooth Regression Analysis.” Sankhyā: The Indian Journal of Statistics, Series A (1961-2002), vol. 26, no. 4, Springer, 1964, pp. 359–72, http://www.jstor.org/stable/25049340.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
