### PR TITLE
[CI] Upgrade Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ stage("Build and Publish") {
   def TARGET_BRANCH = env.CHANGE_TARGET ? env.CHANGE_TARGET : env.BRANCH_NAME
   // such as d2l-en-master
   def TASK = REPO_NAME + '-' + TARGET_BRANCH
-  node {
+  node('d2l-slave') {
     ws("workspace/${TASK}") {
       checkout scm
       // conda environment
@@ -16,7 +16,6 @@ stage("Build and Publish") {
       sh label: "Build Environment", script: """set -ex
       conda env update -n ${ENV_NAME} -f static/build.yml
       conda activate ${ENV_NAME}
-      pip uninstall -y d2lbook
       pip install git+https://github.com/d2l-ai/d2l-book
       pip list
       nvidia-smi

--- a/chapter_linear-networks/linear-regression.md
+++ b/chapter_linear-networks/linear-regression.md
@@ -390,7 +390,7 @@ rather than writing costly for-loops in Python.**)
 %matplotlib inline
 from d2l import mxnet as d2l
 import math
-from mxnet import np
+import numpy as np
 import time
 ```
 

--- a/chapter_linear-networks/oo-design.md
+++ b/chapter_linear-networks/oo-design.md
@@ -177,10 +177,10 @@ class Module(d2l.nn_Module, d2l.HyperParameters):  #@save
         return self.net(X)
 
     if tab.selected('tensorflow'):
-        def call(self, X, *args, training=None):
-            if training is not None:
-                self.training = training
-            return self.forward(X, *args)
+        def call(self, X, *args, **kwargs):
+        if kwargs and "training" in kwargs:
+            self.training = kwargs['training']
+        return self.forward(X, *args)
 
     def plot(self, key, value, train):
         """Plot a point in animation."""

--- a/d2l/tensorflow.py
+++ b/d2l/tensorflow.py
@@ -193,9 +193,9 @@ class Module(d2l.nn_Module, d2l.HyperParameters):
         assert hasattr(self, 'net'), 'Neural network is defined'
         return self.net(X)
 
-    def call(self, X, *args, training=None):
-        if training is not None:
-            self.training = training
+    def call(self,X, *args, **kwargs):
+        if kwargs and "training" in kwargs:
+            self.training = kwargs['training']
         return self.forward(X, *args)
 
     def plot(self, key, value, train):

--- a/d2l/tensorflow.py
+++ b/d2l/tensorflow.py
@@ -193,7 +193,7 @@ class Module(d2l.nn_Module, d2l.HyperParameters):
         assert hasattr(self, 'net'), 'Neural network is defined'
         return self.net(X)
 
-    def call(self,X, *args, **kwargs):
+    def call(self, X, *args, **kwargs):
         if kwargs and "training" in kwargs:
             self.training = kwargs['training']
         return self.forward(X, *args)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import d2l
 requirements = [
     'jupyter',
     'numpy',
-    'matplotlib',
+    'matplotlib==3.4',
     'requests',
     'pandas',
     'gym'

--- a/static/build.yml
+++ b/static/build.yml
@@ -4,10 +4,10 @@ dependencies:
   - pip:
     - ..  # d2l
     - git+https://github.com/d2l-ai/d2l-book
-    - mxnet-cu101==1.7.0
-    - torch==1.8.1+cu101
+    - mxnet-cu102==1.7.0
+    - torch==1.8.1+cu102
     - -f https://download.pytorch.org/whl/torch_stable.html
-    - torchvision==0.9.1+cu101
+    - torchvision==0.9.1+cu102
     - -f https://download.pytorch.org/whl/torch_stable.html
-    - tensorflow==2.3.1
-    - tensorflow-probability==0.11.1
+    - tensorflow==2.8.0
+    - tensorflow-probability==0.16.0

--- a/static/build.yml
+++ b/static/build.yml
@@ -3,7 +3,6 @@ dependencies:
   - pip
   - pip:
     - ..  # d2l
-    - git+https://github.com/d2l-ai/d2l-book
     - mxnet-cu102==1.7.0
     - torch==1.8.1+cu102
     - -f https://download.pytorch.org/whl/torch_stable.html


### PR DESCRIPTION
This PR updates the infrastructure for d2l CI. 

1. Use a new master-slave approach for the Jenkins and the build servers.
2. Remove unnecessary installation of d2lbook in `static/build.yml`
3. Bump to `tensorflow==2.8.0` and `tensorflow-probability==0.16.0` (Based on CUDA 11.2)
4. Update `torch` and `mxnet` cuda version. (Based on CUDA 10.2)
5. Pin `matplotlib==3.4.0` ; this is required to fix #2046
6. Fix `tensorflow==2.8.0` bug in seq2seq; Thanks @cheungdaven 
7. Fix linear regression plotting bug in `mxnet` with `numpy>=1.20`. Fixes issue number one mentioned in #2044 

Changes made behind the scene:
The slave node now has multiple CUDA versions (10.2 and 11.2) for use with different frameworks.
`LD_LIBRARY_PATH` sets both of them in order and each library installs the framework accordingly.

@astonzhang I suggest making a merge commit instead of squashing since we have multiple unrelated changes in this single PR and in case we need to revert only a particular change then we can easily do that.