### PR TITLE
Include reference to total derivate in bptt.md

### DIFF
--- a/chapter_recurrent-neural-networks/bptt.md
+++ b/chapter_recurrent-neural-networks/bptt.md
@@ -112,7 +112,7 @@ in :eqref:`eq_bptt_ht_ot`,
 $h_t$ depends on both $h_{t-1}$ and $w_h$,
 where computation of $h_{t-1}$
 also depends on $w_h$.
-Thus,
+Thus, evaluating the total derivate of $h_t$ with respect to $w_h$
 using the chain rule yields
 
 $$\frac{\partial h_t}{\partial w_h}= \frac{\partial f(x_{t},h_{t-1},w_h)}{\partial w_h} +\frac{\partial f(x_{t},h_{t-1},w_h)}{\partial h_{t-1}} \frac{\partial h_{t-1}}{\partial w_h}.$$


### PR DESCRIPTION
Equation (8.7.4) or line 118 is confusing at the moment because the left hand side and the first term on the right are exactly the same. The correct way would probably to change the notation completely to total derivatives (i.e. $\frac{d h_t}{d w_h}$) but I understand that this might be confusing for some readers as well and you don't want to confuse with too much different notation. Therefore, I think a good compromise would be to at least explicitly mention that the reason for the sum in equation (8.7.4) is the presence of the total derivative to give a potentially confused reader a hint what to google for.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
