### PR TITLE
TF `try_gpu` string output fix

### DIFF
--- a/d2l/tensorflow.py
+++ b/d2l/tensorflow.py
@@ -14,12 +14,13 @@ import tarfile
 import time
 import zipfile
 from collections import defaultdict
+
+import numpy as np
 import pandas as pd
 import requests
 from IPython import display
 from matplotlib import pyplot as plt
 
-import numpy as np
 import tensorflow as tf
 
 d2l = sys.modules[__name__]
@@ -43,6 +44,7 @@ import tarfile
 import time
 import zipfile
 from collections import defaultdict
+
 import pandas as pd
 import requests
 from IPython import display
@@ -51,7 +53,9 @@ from matplotlib import pyplot as plt
 d2l = sys.modules[__name__]
 
 import numpy as np
+
 import tensorflow as tf
+
 
 def use_svg_display():
     """Use the svg format to display a plot in Jupyter.
@@ -464,15 +468,16 @@ class Classifier(d2l.Module):
 
 def cpu():
     """Defined in :numref:`sec_use_gpu`"""
-    return tf.device('/CPU:0')
+    return tf.config.get_visible_devices("CPU")
 
 def gpu(i=0):
     """Defined in :numref:`sec_use_gpu`"""
-    return tf.device(f'/GPU:{i}')
+    visible_devices = tf.config.get_visible_devices("GPU")
+    return visible_devices[i]
 
 def num_gpus():
     """Defined in :numref:`sec_use_gpu`"""
-    return len(tf.config.experimental.list_physical_devices('GPU'))
+    return len(tf.config.get_visible_devices('GPU'))
 
 def try_gpu(i=0):
     """Return gpu(i) if exists, otherwise return cpu().


### PR DESCRIPTION
*Description of changes:*

This pull requrest only affects the string output that is generated after training. For example, the following old output

```
x tokens/sec on <tensorflow.python.eager.context._EagerDeviceContext object at 0x7ff8005deb00>
```
becomes
```
x tokens/sec on PhysicalDevice(name='/physical_device:GPU:0', device_type='GPU')
```
A similar change occurs for multiple GPUs and CPU. It doesn't affect the training process. At present, to the best of my knowledge, all TF code in D2L book uses only 1 GPU even when multiple GPUs are available. Using multiple GPUs in TF requires instantiating the model, loss function, etc. inside a strategy scope. Doing so might require changing the current TF code structure significantly from MXNet or PyTorch. But that's a discussion for another time. The current PR is not even remotely related to that.  


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
