### PR TITLE
Move GitHub stars to the top of the homepage

### DIFF
--- a/static/frontpage/frontpage.html
+++ b/static/frontpage/frontpage.html
@@ -184,7 +184,8 @@ a {
     <h2>Dive into Deep Learning</h2>
     <p><b>Interactive</b> deep learning book with code, math, and discussions <br><br>
         Implemented with <b>NumPy/MXNet</b>, <b>PyTorch</b>, and <b>TensorFlow</b><br><br>
-        Adopted at 300 universities from 55 countries
+        Adopted at 300 universities from 55 countries<br><br>
+        <a class="github-button" href="https://github.com/d2l-ai/d2l-en" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star d2l-ai/d2l-en on GitHub">Star</a>
     </p>
   </div>
 </div>
@@ -313,8 +314,6 @@ a {
   <div class = "author-group-title mdl-cell mdl-cell--12-col mdl-cell--top">
     <h3> We thank all the <a href="https://github.com/d2l-ai/d2l-en/graphs/contributors">community contributors</a><br>for making this open source book better for everyone.</h3>
     <h4><a href="https://github.com/d2l-ai/d2l-en#contribute-learn-how">Contribute to the book.</a></h4>
-    <a class="github-button" href="https://github.com/d2l-ai/d2l-en" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star d2l-ai/d2l-en on GitHub">Star</a>
-    <a class="github-button" href="https://github.com/d2l-ai/d2l-en/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork d2l-ai/d2l-en on GitHub">Fork</a>
   </div>
 </div>
 


### PR DESCRIPTION
Move GitHub stars to the top of the homepage

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
