### PR TITLE
Fix ipython deprecation warning

### DIFF
--- a/chapter_preface/index.md
+++ b/chapter_preface/index.md
@@ -346,6 +346,7 @@ from collections import defaultdict
 from IPython import display
 import math
 from matplotlib import pyplot as plt
+from matplotlib_inline import backend_inline
 import os
 import pandas as pd
 import random

--- a/chapter_preliminaries/calculus.md
+++ b/chapter_preliminaries/calculus.md
@@ -92,7 +92,7 @@ Let's develop some intuition with an example.
 ```{.python .input}
 %matplotlib inline
 from d2l import mxnet as d2l
-from IPython import display
+from matplotlib_inline import backend_inline
 from mxnet import np, npx
 npx.set_np()
 
@@ -104,7 +104,7 @@ def f(x):
 #@tab pytorch
 %matplotlib inline
 from d2l import torch as d2l
-from IPython import display
+from matplotlib_inline import backend_inline
 import numpy as np
 
 def f(x):
@@ -115,7 +115,7 @@ def f(x):
 #@tab tensorflow
 %matplotlib inline
 from d2l import tensorflow as d2l
-from IPython import display
+from matplotlib_inline import backend_inline
 import numpy as np
 
 def f(x):
@@ -182,7 +182,7 @@ e.g., via `d2l.use_svg_display()`.
 #@tab all
 def use_svg_display():  #@save
     """Use the svg format to display a plot in Jupyter."""
-    display.set_matplotlib_formats('svg')
+    backend_inline.set_matplotlib_formats('svg')
 ```
 
 Conveniently, we can set figure sizes with `set_figsize`. 
@@ -402,7 +402,7 @@ throughout this book will require calculating the gradient.
 1. Given a function $f(x)$ that is invertible, 
    compute the derivative of its inverse $f^{-1}(x)$. 
    Here we have that $f^{-1}(f(x)) = x$ and conversely $f(f^{-1}(y)) = y$. 
-   Hint: use these properties in your derivation. 
+   Hint: use these properties in your derivation.
 
 :begin_tab:`mxnet`
 [Discussions](https://discuss.d2l.ai/t/32)

--- a/d2l/mxnet.py
+++ b/d2l/mxnet.py
@@ -52,6 +52,7 @@ import pandas as pd
 import requests
 from IPython import display
 from matplotlib import pyplot as plt
+from matplotlib_inline import backend_inline
 
 d2l = sys.modules[__name__]
 
@@ -62,7 +63,7 @@ def use_svg_display():
     """Use the svg format to display a plot in Jupyter.
 
     Defined in :numref:`sec_calculus`"""
-    display.set_matplotlib_formats('svg')
+    backend_inline.set_matplotlib_formats('svg')
 
 def set_figsize(figsize=(3.5, 2.5)):
     """Set the figure size for matplotlib.

--- a/d2l/tensorflow.py
+++ b/d2l/tensorflow.py
@@ -47,6 +47,7 @@ import pandas as pd
 import requests
 from IPython import display
 from matplotlib import pyplot as plt
+from matplotlib_inline import backend_inline
 
 d2l = sys.modules[__name__]
 
@@ -57,7 +58,7 @@ def use_svg_display():
     """Use the svg format to display a plot in Jupyter.
 
     Defined in :numref:`sec_calculus`"""
-    display.set_matplotlib_formats('svg')
+    backend_inline.set_matplotlib_formats('svg')
 
 def set_figsize(figsize=(3.5, 2.5)):
     """Set the figure size for matplotlib.
@@ -192,7 +193,7 @@ class Module(d2l.nn_Module, d2l.HyperParameters):
     def forward(self, X):
         assert hasattr(self, 'net'), 'Neural network is defined'
         return self.net(X)
-      
+
     def call(self, X, *args, **kwargs):
         if kwargs and "training" in kwargs:
             self.training = kwargs['training']

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -53,6 +53,7 @@ import pandas as pd
 import requests
 from IPython import display
 from matplotlib import pyplot as plt
+from matplotlib_inline import backend_inline
 
 d2l = sys.modules[__name__]
 
@@ -69,7 +70,7 @@ def use_svg_display():
     """Use the svg format to display a plot in Jupyter.
 
     Defined in :numref:`sec_calculus`"""
-    display.set_matplotlib_formats('svg')
+    backend_inline.set_matplotlib_formats('svg')
 
 def set_figsize(figsize=(3.5, 2.5)):
     """Set the figure size for matplotlib.


### PR DESCRIPTION
*Description of changes:*
This PR fixes the deprecation warning with `set_matplotlib_formats`.

<img width="983" alt="Screenshot 2022-03-15 at 1 43 31 AM" src="https://user-images.githubusercontent.com/23621655/158284495-b6c2df4c-597d-49aa-85ba-0c562495198f.png">


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
