### PR TITLE
Rollback numpy to 1.21.5

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,7 @@ stage("Build and Publish") {
 
       sh label: "Sanity Check", script: """set -ex
       conda activate ${ENV_NAME}
+      d2lbook clear
       d2lbook build outputcheck tabcheck
       """
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,6 @@ stage("Build and Publish") {
 
       sh label: "Sanity Check", script: """set -ex
       conda activate ${ENV_NAME}
-      d2lbook clear
       d2lbook build outputcheck tabcheck
       """
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import d2l
 
 requirements = [
     'jupyter==1.0.0',
-    'numpy==1.22.2',
+    'numpy==1.21.5',
     'matplotlib==3.4',
     'requests==2.25.1',
     'pandas==1.2.4'


### PR DESCRIPTION
colab doesn't support python 3.8 and numpy 1.22 is only python3.8+ supported.
Hence the need to pin numpy below 1.22

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
