### PR TITLE
Release v0.17.5 

### DIFF
--- a/chapter_appendix-mathematics-for-deep-learning/integral-calculus.md
+++ b/chapter_appendix-mathematics-for-deep-learning/integral-calculus.md
@@ -352,7 +352,7 @@ z = np.exp(- x**2 - y**2)
 
 # Plot function
 ax = d2l.plt.figure().add_subplot(111, projection='3d')
-ax.plot_wireframe(x, y, z)
+ax.plot_wireframe(x.asnumpy(), y.asnumpy(), z.asnumpy())
 d2l.plt.xlabel('x')
 d2l.plt.ylabel('y')
 d2l.plt.xticks([-2, -1, 0, 1, 2])

--- a/chapter_appendix-mathematics-for-deep-learning/multivariable-calculus.md
+++ b/chapter_appendix-mathematics-for-deep-learning/multivariable-calculus.md
@@ -553,8 +553,10 @@ w = np.exp(-1)*(-1 - (x + 1) + (x + 1)**2 + y**2)
 
 # Plot function
 ax = d2l.plt.figure().add_subplot(111, projection='3d')
-ax.plot_wireframe(x, y, z, **{'rstride': 10, 'cstride': 10})
-ax.plot_wireframe(x, y, w, **{'rstride': 10, 'cstride': 10}, color='purple')
+ax.plot_wireframe(x.asnumpy(), y.asnumpy(), z.asnumpy(),
+                  **{'rstride': 10, 'cstride': 10})
+ax.plot_wireframe(x.asnumpy(), y.asnumpy(), w.asnumpy(),
+                  **{'rstride': 10, 'cstride': 10}, color='purple')
 d2l.plt.xlabel('x')
 d2l.plt.ylabel('y')
 d2l.set_figsize()

--- a/chapter_linear-networks/linear-regression.md
+++ b/chapter_linear-networks/linear-regression.md
@@ -342,7 +342,7 @@ rather than writing costly for-loops in Python.**)
 %matplotlib inline
 from d2l import mxnet as d2l
 import math
-import numpy as np
+from mxnet import np
 import time
 ```
 
@@ -481,7 +481,19 @@ def normal(x, mu, sigma):
 We can now (**visualize the normal distributions**).
 
 ```{.python .input}
-#@tab all
+#@tab mxnet
+# Use numpy again for visualization
+x = np.arange(-7, 7, 0.01)
+
+# Mean and standard deviation pairs
+params = [(0, 1), (0, 2), (3, 1)]
+d2l.plot(x.asnumpy(), [normal(x, mu, sigma).asnumpy() for mu, sigma in params], xlabel='x',
+         ylabel='p(x)', figsize=(4.5, 2.5),
+         legend=[f'mean {mu}, std {sigma}' for mu, sigma in params])
+```
+
+```{.python .input}
+#@tab pytorch, tensorflow
 # Use numpy again for visualization
 x = np.arange(-7, 7, 0.01)
 

--- a/chapter_multilayer-perceptrons/kaggle-house-price.md
+++ b/chapter_multilayer-perceptrons/kaggle-house-price.md
@@ -629,7 +629,7 @@ will simplify uploading the results to Kaggle.
 
 ```{.python .input}
 #@tab all
-def train_and_pred(train_features, test_feature, train_labels, test_data,
+def train_and_pred(train_features, test_features, train_labels, test_data,
                    num_epochs, lr, weight_decay, batch_size):
     net = get_net()
     train_ls, _ = train(net, train_features, train_labels, None, None,

--- a/chapter_optimization/optimization-intro.md
+++ b/chapter_optimization/optimization-intro.md
@@ -150,7 +150,24 @@ annotate('saddle point', (0, -0.2), (-0.52, -5.0))
 Saddle points in higher dimensions are even more insidious, as the example below shows. Consider the function $f(x, y) = x^2 - y^2$. It has its saddle point at $(0, 0)$. This is a maximum with respect to $y$ and a minimum with respect to $x$. Moreover, it *looks* like a saddle, which is where this mathematical property got its name.
 
 ```{.python .input}
-#@tab all
+#@tab mxnet
+x, y = d2l.meshgrid(
+    d2l.linspace(-1.0, 1.0, 101), d2l.linspace(-1.0, 1.0, 101))
+z = x**2 - y**2
+ax = d2l.plt.figure().add_subplot(111, projection='3d')
+ax.plot_wireframe(x.asnumpy(), y.asnumpy(), z.asnumpy(),
+                  **{'rstride': 10, 'cstride': 10})
+ax.plot([0], [0], [0], 'rx')
+ticks = [-1, 0, 1]
+d2l.plt.xticks(ticks)
+d2l.plt.yticks(ticks)
+ax.set_zticks(ticks)
+d2l.plt.xlabel('x')
+d2l.plt.ylabel('y');
+```
+
+```{.python .input}
+#@tab pytorch, tensorflow
 x, y = d2l.meshgrid(
     d2l.linspace(-1.0, 1.0, 101), d2l.linspace(-1.0, 1.0, 101))
 z = x**2 - y**2

--- a/chapter_preface/index.md
+++ b/chapter_preface/index.md
@@ -345,6 +345,7 @@ from collections import defaultdict
 from IPython import display
 import math
 from matplotlib import pyplot as plt
+from matplotlib_inline import backend_inline
 import os
 import pandas as pd
 import random

--- a/chapter_preliminaries/calculus.md
+++ b/chapter_preliminaries/calculus.md
@@ -78,7 +78,7 @@ let us experiment with an example.
 ```{.python .input}
 %matplotlib inline
 from d2l import mxnet as d2l
-from IPython import display
+from matplotlib_inline import backend_inline
 from mxnet import np, npx
 npx.set_np()
 
@@ -90,7 +90,7 @@ def f(x):
 #@tab pytorch
 %matplotlib inline
 from d2l import torch as d2l
-from IPython import display
+from matplotlib_inline import backend_inline
 import numpy as np
 
 def f(x):
@@ -101,7 +101,7 @@ def f(x):
 #@tab tensorflow
 %matplotlib inline
 from d2l import tensorflow as d2l
-from IPython import display
+from matplotlib_inline import backend_inline
 import numpy as np
 
 def f(x):
@@ -180,7 +180,7 @@ so later they can be directly invoked (e.g., `d2l.use_svg_display()`) without be
 #@tab all
 def use_svg_display():  #@save
     """Use the svg format to display a plot in Jupyter."""
-    display.set_matplotlib_formats('svg')
+    backend_inline.set_matplotlib_formats('svg')
 ```
 
 We define the `set_figsize` function to specify the figure sizes. Note that here we directly use `d2l.plt` since the import statement `from matplotlib import pyplot as plt` has been marked for being saved in the `d2l` package in the preface.

--- a/chapter_recommender-systems/movielens.md
+++ b/chapter_recommender-systems/movielens.md
@@ -22,7 +22,7 @@ Then, we download the MovieLens 100k dataset and load the interactions as `DataF
 ```{.python .input  n=2}
 #@save
 d2l.DATA_HUB['ml-100k'] = (
-    'http://files.grouplens.org/datasets/movielens/ml-100k.zip',
+    'https://files.grouplens.org/datasets/movielens/ml-100k.zip',
     'cd4dcac4241c8a4ad7badc7ca635da8a69dddb83')
 
 #@save

--- a/d2l/mxnet.py
+++ b/d2l/mxnet.py
@@ -5,29 +5,6 @@ USE_TENSORFLOW = False
 DATA_HUB = dict()
 DATA_URL = 'http://d2l-data.s3-accelerate.amazonaws.com/'
 
-import collections
-import hashlib
-import inspect
-import math
-import os
-import random
-import re
-import shutil
-import sys
-import tarfile
-import time
-import zipfile
-from collections import defaultdict
-import pandas as pd
-import requests
-from IPython import display
-from matplotlib import pyplot as plt
-
-from mxnet import autograd, context, gluon, image, init, np, npx
-from mxnet.gluon import nn, rnn
-from mxnet.gluon.data.vision import transforms
-
-d2l = sys.modules[__name__]
 nn_Module = nn.Block
 
 #################   WARNING   ################

--- a/d2l/mxnet.py
+++ b/d2l/mxnet.py
@@ -2562,7 +2562,7 @@ def predict_snli(net, vocab, premise, hypothesis):
             else 'neutral'
 
 d2l.DATA_HUB['ml-100k'] = (
-    'http://files.grouplens.org/datasets/movielens/ml-100k.zip',
+    'https://files.grouplens.org/datasets/movielens/ml-100k.zip',
     'cd4dcac4241c8a4ad7badc7ca635da8a69dddb83')
 
 def read_data_ml100k():

--- a/d2l/mxnet.py
+++ b/d2l/mxnet.py
@@ -51,6 +51,7 @@ import pandas as pd
 import requests
 from IPython import display
 from matplotlib import pyplot as plt
+from matplotlib_inline import backend_inline
 
 d2l = sys.modules[__name__]
 
@@ -61,7 +62,7 @@ def use_svg_display():
     """Use the svg format to display a plot in Jupyter.
 
     Defined in :numref:`sec_calculus`"""
-    display.set_matplotlib_formats('svg')
+    backend_inline.set_matplotlib_formats('svg')
 
 def set_figsize(figsize=(3.5, 2.5)):
     """Set the figure size for matplotlib.

--- a/d2l/mxnet.py
+++ b/d2l/mxnet.py
@@ -5,6 +5,10 @@ USE_TENSORFLOW = False
 DATA_HUB = dict()
 DATA_URL = 'http://d2l-data.s3-accelerate.amazonaws.com/'
 
+from mxnet import autograd, context, gluon, image, init, np, npx
+from mxnet.gluon import nn, rnn
+from mxnet.gluon.data.vision import transforms
+
 nn_Module = nn.Block
 
 #################   WARNING   ################

--- a/d2l/tensorflow.py
+++ b/d2l/tensorflow.py
@@ -1,28 +1,7 @@
 DATA_HUB = dict()
 DATA_URL = 'http://d2l-data.s3-accelerate.amazonaws.com/'
 
-import collections
-import hashlib
-import inspect
-import math
-import os
-import random
-import re
-import shutil
-import sys
-import tarfile
-import time
-import zipfile
-from collections import defaultdict
-import pandas as pd
-import requests
-from IPython import display
-from matplotlib import pyplot as plt
 
-import numpy as np
-import tensorflow as tf
-
-d2l = sys.modules[__name__]
 nn_Module = tf.keras.Model
 
 #################   WARNING   ################

--- a/d2l/tensorflow.py
+++ b/d2l/tensorflow.py
@@ -1,6 +1,8 @@
 DATA_HUB = dict()
 DATA_URL = 'http://d2l-data.s3-accelerate.amazonaws.com/'
 
+import numpy as np
+import tensorflow as tf
 
 nn_Module = tf.keras.Model
 

--- a/d2l/tensorflow.py
+++ b/d2l/tensorflow.py
@@ -46,6 +46,7 @@ import pandas as pd
 import requests
 from IPython import display
 from matplotlib import pyplot as plt
+from matplotlib_inline import backend_inline
 
 d2l = sys.modules[__name__]
 
@@ -56,7 +57,7 @@ def use_svg_display():
     """Use the svg format to display a plot in Jupyter.
 
     Defined in :numref:`sec_calculus`"""
-    display.set_matplotlib_formats('svg')
+    backend_inline.set_matplotlib_formats('svg')
 
 def set_figsize(figsize=(3.5, 2.5)):
     """Set the figure size for matplotlib.

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -1,6 +1,14 @@
 DATA_HUB = dict()
 DATA_URL = 'http://d2l-data.s3-accelerate.amazonaws.com/'
 
+import numpy as np
+import torch
+import torchvision
+from PIL import Image
+from torch import nn
+from torch.nn import functional as F
+from torch.utils import data
+from torchvision import transforms
 
 nn_Module = nn.Module
 

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -52,6 +52,7 @@ import pandas as pd
 import requests
 from IPython import display
 from matplotlib import pyplot as plt
+from matplotlib_inline import backend_inline
 
 d2l = sys.modules[__name__]
 
@@ -68,7 +69,7 @@ def use_svg_display():
     """Use the svg format to display a plot in Jupyter.
 
     Defined in :numref:`sec_calculus`"""
-    display.set_matplotlib_formats('svg')
+    backend_inline.set_matplotlib_formats('svg')
 
 def set_figsize(figsize=(3.5, 2.5)):
     """Set the figure size for matplotlib.

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -1,34 +1,7 @@
 DATA_HUB = dict()
 DATA_URL = 'http://d2l-data.s3-accelerate.amazonaws.com/'
 
-import collections
-import hashlib
-import inspect
-import math
-import os
-import random
-import re
-import shutil
-import sys
-import tarfile
-import time
-import zipfile
-from collections import defaultdict
-import pandas as pd
-import requests
-from IPython import display
-from matplotlib import pyplot as plt
 
-import numpy as np
-import torch
-import torchvision
-from PIL import Image
-from torch import nn
-from torch.nn import functional as F
-from torch.utils import data
-from torchvision import transforms
-
-d2l = sys.modules[__name__]
 nn_Module = nn.Module
 
 #################   WARNING   ################

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import d2l
 
 requirements = [
     'jupyter==1.0.0',
-    'numpy==1.22.2',
+    'numpy==1.21.5',
     'matplotlib==3.4',
     'requests==2.25.1',
     'pandas==1.2.4'

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import d2l
 requirements = [
     'jupyter==1.0.0',
     'numpy==1.21.5',
-    'matplotlib==3.4',
+    'matplotlib==3.5.1',
     'requests==2.25.1',
     'pandas==1.2.4'
 ]

--- a/static/build.yml
+++ b/static/build.yml
@@ -5,9 +5,9 @@ dependencies:
     - ..  # d2l
     - git+https://github.com/d2l-ai/d2l-book
     - mxnet-cu102==1.7.0
-    - torch==1.10.2+cu102
+    - torch==1.11.0+cu102
     - -f https://download.pytorch.org/whl/torch_stable.html
-    - torchvision==0.11.3+cu102
+    - torchvision==0.12.0+cu102
     - -f https://download.pytorch.org/whl/torch_stable.html
     - tensorflow==2.8.0
     - tensorflow-probability==0.16.0


### PR DESCRIPTION
This release adds:
* Fix google colab support: rollback numpy to 1.21.5 to add support for python3.7
* Fix ipython deprecation warning
* Fix broken download link movielens dataset
* Fix matplotlib 3.5 dependency bug and numpy coercion
* Upgraded torch==1.11.0 and torchvision==0.12.0
* Remove redundant d2l lib code

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
