### PR TITLE
Fix typo in custom-layer.ipynb

### DIFF
--- a/chapter_builders-guide/custom-layer.md
+++ b/chapter_builders-guide/custom-layer.md
@@ -136,7 +136,7 @@ Now let's implement our own version of the  fully connected layer.
 Recall that this layer requires two parameters,
 one to represent the weight and the other for the bias.
 In this implementation, we bake in the ReLU activation as a default.
-This layer requires to input arguments: `in_units` and `units`, which
+This layer requires two input arguments: `in_units` and `units`, which
 denote the number of inputs and outputs, respectively.
 
 ```{.python .input}


### PR DESCRIPTION
*Description of changes:*

Replace `to` with `two` as the text is referring to the number of arguments to the layer

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
