### PR TITLE
convert batchnorm to lazybatchnorm

### DIFF
--- a/chapter_attention-mechanisms/transformer.md
+++ b/chapter_attention-mechanisms/transformer.md
@@ -269,7 +269,7 @@ with autograd.record():
 ```{.python .input}
 %%tab pytorch
 ln = nn.LayerNorm(2)
-bn = nn.BatchNorm1d(2)
+bn = nn.LazyBatchNorm1d()
 X = d2l.tensor([[1, 2], [2, 3]], dtype=torch.float32)
 # Compute mean and variance from X in the training mode
 print('layer norm:', ln(X), '\nbatch norm:', bn(X))


### PR DESCRIPTION
*Description of changes:*

Convert batchnorm to lazybatchnorm (which is for demonstration to compare batchnorm and layernorm). 

Since pytorch has not updated its layernorm to lazylayernorm, we do not need to make any other changes to transformer for the moment.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
