### PR TITLE
Bug fixing for forward pass in PyTorch BERT

### DIFF
--- a/chapter_natural-language-processing-pretraining/bert.md
+++ b/chapter_natural-language-processing-pretraining/bert.md
@@ -241,7 +241,7 @@ class BERTEncoder(nn.Module):
         # Shape of `X` remains unchanged in the following code snippet:
         # (batch size, max sequence length, `num_hiddens`)
         X = self.token_embedding(tokens) + self.segment_embedding(segments)
-        X = X + self.pos_embedding.data[:, :X.shape[1], :]
+        X = X + self.pos_embedding[:, :X.shape[1], :]
         for blk in self.blks:
             X = blk(X, valid_lens)
         return X

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -2121,7 +2121,7 @@ class BERTEncoder(nn.Module):
         # Shape of `X` remains unchanged in the following code snippet:
         # (batch size, max sequence length, `num_hiddens`)
         X = self.token_embedding(tokens) + self.segment_embedding(segments)
-        X = X + self.pos_embedding.data[:, :X.shape[1], :]
+        X = X + self.pos_embedding[:, :X.shape[1], :]
         for blk in self.blks:
             X = blk(X, valid_lens)
         return X


### PR DESCRIPTION
*Description of changes:*

The original forward with positional embedding use `.data`, which is detached from the computation graph. Instead, we should directly use `pos_embedding` in forward.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
