### PR TITLE
[PyTorch] Use d2l.randn in W_hh param

### DIFF
--- a/chapter_recurrent-neural-networks/rnn-scratch.md
+++ b/chapter_recurrent-neural-networks/rnn-scratch.md
@@ -65,7 +65,7 @@ class RNNScratch(d2l.Module):  #@save
             self.W_xh = nn.Parameter(
                 d2l.randn(num_inputs, num_hiddens) * sigma)
             self.W_hh = nn.Parameter(
-                d2l.rand(num_hiddens, num_hiddens) * sigma)
+                d2l.randn(num_hiddens, num_hiddens) * sigma)
             self.b_h = nn.Parameter(d2l.zeros(num_hiddens))
         if tab.selected('tensorflow'):
             self.W_xh = tf.Variable(d2l.normal(

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -626,7 +626,7 @@ class RNNScratch(d2l.Module):
         self.W_xh = nn.Parameter(
             d2l.randn(num_inputs, num_hiddens) * sigma)
         self.W_hh = nn.Parameter(
-            d2l.rand(num_hiddens, num_hiddens) * sigma)
+            d2l.randn(num_hiddens, num_hiddens) * sigma)
         self.b_h = nn.Parameter(d2l.zeros(num_hiddens))
 
     def forward(self, inputs, state=None):


### PR DESCRIPTION
*Description of changes:*
Fix for the inconsistency introduced in #1897 while initializing parameter `W_hh`, it should use random normal distribution (`torch.randn`) instead of random uniform distribution (`torch.rand`).

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
