### PR TITLE
Fix typo - Change period to comma in lstm.md

### DIFF
--- a/chapter_recurrent-modern/lstm.md
+++ b/chapter_recurrent-modern/lstm.md
@@ -47,7 +47,7 @@ the hidden state of the previous time step,
 as illustrated in :numref:`fig_lstm_0`.
 They are processed by
 three fully connected layers with a sigmoid activation function to compute the values of
-the input, forget. and output gates.
+the input, forget, and output gates.
 As a result, values of the three gates
 are in the range of $(0, 1)$.
 


### PR DESCRIPTION
*Description of changes:*

Fixing typo - changing period to comma when listing out types of gates

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
