### PR TITLE
Delete an outdated paragraph in use-gpu.md

### DIFF
--- a/chapter_builders-guide/use-gpu.md
+++ b/chapter_builders-guide/use-gpu.md
@@ -78,17 +78,6 @@ we can minimize the time spent
 transferring data between devices.
 For example, when training neural networks on a server with a GPU,
 we typically prefer for the model's parameters to live on the GPU.
-
-Next, we need to confirm that
-the GPU version of PyTorch is installed.
-If a CPU version of PyTorch is already installed,
-we need to uninstall it first.
-For example, use the `pip uninstall torch` command,
-then install the corresponding PyTorch version
-according to your CUDA version.
-Assuming you have CUDA 10.0 installed,
-you can install the PyTorch version
-that supports CUDA 10.0 via `pip install torch-cu100`.
 :end_tab:
 
 To run the programs in this section,


### PR DESCRIPTION
Delete an outdated paragraph about installing `torch-cu100`.

Selecting PyTorch 1.11, Linux, Conda, Python on the [PyTorch official site](https://pytorch.org/):
For only CPU, installation command is
`conda install pytorch torchvision torchaudio cpuonly -c pytorch`
For CUDA 11.3, installation command is
`conda install pytorch torchvision torchaudio cudatoolkit=11.3 -c pytorch`

Currently, the majority install PyTorch CPU + GPU without any guidance. Thus maybe we don't need to mention it specifically.
Meanwhile, I noticed this paragraph had already been removed in [d2l-zh/chapter_deep-learning-computation/use-gpu.md](https://github.com/krahets/d2l-zh/blob/master/chapter_deep-learning-computation/use-gpu.md).

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
