### PR TITLE
Update transformer.md

### DIFF
--- a/chapter_attention-and-transformers/transformer.md
+++ b/chapter_attention-and-transformers/transformer.md
@@ -690,7 +690,7 @@ class TransformerDecoderBlock(nn.Module):
         if state[2][self.i] is None:
             key_values = X
         else:
-            key_values = torch.cat((state[2][self.i], X), axis=1)
+            key_values = torch.cat((state[2][self.i], X), dim=1)
         state[2][self.i] = key_values
         if self.training:
             batch_size, num_steps, _ = X.shape


### PR DESCRIPTION
*Description of changes:*
fix a typo in pytorch implementation about _TransformerDecoderBlock_
torch.cat() takes 2 parameters, the second one's name is "dim", not "axis".
see [pytorch docs about torch.cat()](https://pytorch.org/docs/stable/generated/torch.cat.html)


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.