### PR TITLE
Display the normal distribution image using d2l.plt

### DIFF
--- a/chapter_linear-networks/linear-regression.md
+++ b/chapter_linear-networks/linear-regression.md
@@ -528,6 +528,7 @@ params = [(0, 1), (0, 2), (3, 1)]
 d2l.plot(x, [normal(x, mu, sigma) for mu, sigma in params], xlabel='x',
          ylabel='p(x)', figsize=(4.5, 2.5),
          legend=[f'mean {mu}, std {sigma}' for mu, sigma in params])
+d2l.plt.show()
 ```
 
 Note that changing the mean corresponds


### PR DESCRIPTION
The original version code can run smoothly; however, it doesn't display the result image of the normal distribution.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
