### PR TITLE
Remove redundant comment for pytorch code

### DIFF
--- a/chapter_natural-language-processing-applications/sentiment-analysis-rnn.md
+++ b/chapter_natural-language-processing-applications/sentiment-analysis-rnn.md
@@ -130,13 +130,10 @@ class BiRNN(nn.Module):
         # steps. The shape of `outputs` is (no. of time steps, batch size,
         # 2 * no. of hidden units)
         outputs, _ = self.encoder(embeddings)
-        # Concatenate the hidden states of the initial time step and final
-        # time step to use as input of the fully connected layer. Its
-        # shape is (batch size, 4 * no. of hidden units)
-        encoding = torch.cat((outputs[0], outputs[-1]), dim=1)
         # Concatenate the hidden states at the initial and final time steps as
         # the input of the fully connected layer. Its shape is (batch size,
         # 4 * no. of hidden units)
+        encoding = torch.cat((outputs[0], outputs[-1]), dim=1) 
         outs = self.decoder(encoding)
         return outs
 ```


### PR DESCRIPTION
There are almost same comment in the pytorch code to explain why do we need to do
```
encoding = torch.cat((outputs[0], outputs[-1]), dim=1)
```

I try to remove one of the comments and select the latter one to make it consistent with the mxnet version.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
