### PR TITLE
[PyTorch] Fix module types (LazyLinear -> Linear)

### DIFF
--- a/chapter_builders-guide/init-param.md
+++ b/chapter_builders-guide/init-param.md
@@ -89,7 +89,7 @@ net[0].weight.data()[0]
 ```{.python .input  n=6}
 %%tab pytorch
 def init_normal(module):
-    if type(module) == nn.LazyLinear:
+    if type(module) == nn.Linear:
         nn.init.normal_(module.weight, mean=0, std=0.01)
         nn.init.zeros_(module.bias)
 net.apply(init_normal)
@@ -122,7 +122,7 @@ net[0].weight.data()[0]
 ```{.python .input  n=9}
 %%tab pytorch
 def init_constant(module):
-    if type(module) == nn.LazyLinear:
+    if type(module) == nn.Linear:
         nn.init.constant_(module.weight, 1)
         nn.init.zeros_(module.bias)
 net.apply(init_constant)
@@ -161,10 +161,10 @@ print(net[1].weight.data())
 ```{.python .input  n=12}
 %%tab pytorch
 def init_xavier(module):
-    if type(module) == nn.LazyLinear:
+    if type(module) == nn.Linear:
         nn.init.xavier_uniform_(module.weight)
 def init_42(module):
-    if type(module) == nn.LazyLinear:
+    if type(module) == nn.Linear:
         nn.init.constant_(module.weight, 42)
 
 net[0].apply(init_xavier)
@@ -238,7 +238,7 @@ net[0].weight.data()[:2]
 ```{.python .input  n=15}
 %%tab pytorch
 def my_init(module):
-    if type(module) == nn.LazyLinear:
+    if type(module) == nn.Linear:
         print("Init", *[(name, param.shape)
                         for name, param in module.named_parameters()][0])
         nn.init.uniform_(module.weight, -10, 10)


### PR DESCRIPTION
*Description of changes:*

[In 6.3 Parameter Initialization](http://d2l.ai/chapter_builders-guide/init-param.html), surprisingly `LazyLinear` modules have the type `<class 'torch.nn.modules.linear.Linear'>` during init, so the in-place updates in the PyTorch examples are skipped.

This PR fixes this by making the if statements check for the correct `nn.Linear` type.

Not applied:
```py
def init_constant(module):
    if type(module) == nn.LazyLinear: # this is False
        nn.init.constant_(module.weight, 1)
        nn.init.zeros_(module.bias)
net.apply(init_constant)
net[0].weight.data[0], net[0].bias.data[0]
```
```
(tensor([ 0.1594,  0.9592, -1.4913,  0.8780]), tensor(0.))
```

Applied:
```py
def init_constant(module):
    if type(module) == nn.Linear: # this is True
        nn.init.constant_(module.weight, 1)
        nn.init.zeros_(module.bias)
net.apply(init_constant)
net[0].weight.data[0], net[0].bias.data[0]
```
```
(tensor([1., 1., 1., 1.]), tensor(0.))
```

---

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
