### PR TITLE
BLD: Bump python support version 3.9

### DIFF
--- a/INFO.md
+++ b/INFO.md
@@ -3,11 +3,11 @@
 ## Installation for Developers
 
 ```
-wget https://repo.anaconda.com/miniconda/Miniconda3-py38_4.12.0-Linux-x86_64.sh  # For py3.9, wget https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-Linux-x86_64.sh
-sh Miniconda3-py38_4.12.0-Linux-x86_64.sh -b  # For py3.9: sh Miniconda3-py39_4.12.0-Linux-x86_64.sh -b
+wget https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-Linux-x86_64.sh  # For py3.8, wget  https://repo.anaconda.com/miniconda/Miniconda3-py38_4.12.0-Linux-x86_64.sh
+sh Miniconda3-py39_4.12.0-Linux-x86_64.sh -b  # For py3.8: sh Miniconda3-py38_4.12.0-Linux-x86_64.sh -b
 ~/miniconda3/bin/conda init
 . ~/.bashrc
-conda create --name d2l python=3.8 -y  # For py3.9: conda create --name d2l python=3.9 -y
+conda create --name d2l python=3.9 -y  # For py3.8: conda create --name d2l python=3.8 -y
 conda activate d2l
 pip install torch torchvision
 pip install d2l==1.0.0a0

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,7 @@ stage("Build and Publish") {
 
       sh label: "Sanity Check", script: """set -ex
       conda activate ${ENV_NAME}
+      d2lbook clear
       d2lbook build outputcheck tabcheck
       """
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,6 @@ stage("Build and Publish") {
 
       sh label: "Sanity Check", script: """set -ex
       conda activate ${ENV_NAME}
-      d2lbook clear
       d2lbook build outputcheck tabcheck
       """
 

--- a/chapter_installation/index.md
+++ b/chapter_installation/index.md
@@ -17,7 +17,7 @@ if your machine already has conda installed.
 Visit the Miniconda website and determine
 the appropriate version for your system
 based on your Python 3.x version and machine architecture.
-Suppose that your Python version is 3.8
+Suppose that your Python version is 3.9
 (our tested version).
 If you are using macOS,
 you would download the bash script
@@ -27,7 +27,10 @@ and execute the installation as follows:
 
 ```bash
 # The file name is subject to changes
-sh Miniconda3-py38_4.10.3-MacOSX-x86_64.sh -b
+# Intel Macs
+sh Miniconda3-py39_4.12.0-MacOSX-x86_64.sh -b
+# M1 Macs
+sh Miniconda3-py39_4.12.0-MacOSX-arm64.sh -b
 ```
 
 
@@ -38,7 +41,7 @@ and execute the following at the download location:
 
 ```bash
 # The file name is subject to changes
-sh Miniconda3-py38_4.10.3-Linux-x86_64.sh -b
+sh Miniconda3-py39_4.12.0-Linux-x86_64.sh -b
 ```
 
 
@@ -54,7 +57,7 @@ You should be able to create
 a new environment as follows:
 
 ```bash
-conda create --name d2l python=3.8 -y
+conda create --name d2l python=3.9 -y
 ```
 
 
@@ -89,20 +92,20 @@ To install a GPU-enabled version of MXNet,
 we need to find out what version of CUDA you have installed.
 You can check this by running `nvcc --version`
 or `cat /usr/local/cuda/version.txt`.
-Assume that you have installed CUDA 10.1,
+Assume that you have installed CUDA 10.2,
 then execute the following command:
 
 ```bash
 # For macOS and Linux users
-pip install mxnet-cu101==1.7.0
+pip install mxnet-cu102==1.7.0
 
 # For Windows users
-pip install mxnet-cu101==1.7.0 -f https://dist.mxnet.io/python
+pip install mxnet-cu102==1.7.0 -f https://dist.mxnet.io/python
 ```
 
 
-You may change the last digits according to your CUDA version, e.g., `cu100` for
-CUDA 10.0 and `cu90` for CUDA 9.0.
+You may change the last digits according to your CUDA version, e.g., `cu101` for
+CUDA 10.1 and `cu90` for CUDA 9.0.
 
 
 If your machine has no NVIDIA GPUs

--- a/static/build.yml
+++ b/static/build.yml
@@ -1,5 +1,5 @@
 dependencies:
-  - python=3.8
+  - python=3.9
   - pip
   - pip:
     - ..  # d2l


### PR DESCRIPTION
This PR tests all the notebooks and frameworks for Python 3.9 support.
