### PR TITLE
Jacobian matrix

### DIFF
--- a/chapter_preliminaries/calculus.md
+++ b/chapter_preliminaries/calculus.md
@@ -312,7 +312,7 @@ by $\nabla f(\mathbf{x})$.
 The following rules come in handy 
 for differentiating multivariate functions:
 
-* For all $\mathbf{A} \in \mathbb{R}^{m \times n}$ we have $\nabla_{\mathbf{x}} \mathbf{A} \mathbf{x} = \mathbf{A}^\top$ and $\nabla_{\mathbf{x}} \mathbf{x}^\top \mathbf{A}  = \mathbf{A}$.
+* For all $\mathbf{A} \in \mathbb{R}^{m \times n}$ we have $\nabla_{\mathbf{x}} \mathbf{A} \mathbf{x} = \mathbf{A}$ and $\nabla_{\mathbf{x}} \mathbf{x}^\top \mathbf{A}  = \mathbf{A}$.
 * For square matrices $\mathbf{A} \in \mathbb{R}^{n \times n}$ we have that $\nabla_{\mathbf{x}} \mathbf{x}^\top \mathbf{A} \mathbf{x}  = (\mathbf{A} + \mathbf{A}^\top)\mathbf{x}$ and in particular
 $\nabla_{\mathbf{x}} \|\mathbf{x} \|^2 = \nabla_{\mathbf{x}} \mathbf{x}^\top \mathbf{x} = 2\mathbf{x}$.
 


### PR DESCRIPTION
*Description of changes:*

I'm new to linear algebra so I'm not sure if it's correct, but it seems like the Jacobian matrix for a function $f: \mathbb{R}^n \to \mathbb{R}^m$ should also have dimension $m \times n$. As the product $\mathbf{A} \mathbf{x}$ has such a mapping, its derivative would also have dimensions $m \times n$. Therefore $\nabla_{\mathbf{x}} \mathbf{A} \mathbf{x} = \mathbf{A}$, not $\mathbf{A}^\top$.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
