### PR TITLE
Fix #2250 colab missing `matplotlib_inline`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup, find_packages
 import d2l
 
 requirements = [
+    'ipython>=7.23',
     'jupyter',
     'numpy',
     'matplotlib',


### PR DESCRIPTION
This will fix #2250 without adding any new dependency in d2l package. `jupyter` already indirectly installs `ipython`, but now we force ipython to be at a minimum version 7.23 (released in 2019). This v7.23 release [added](https://github.com/ipython/ipython/issues/12918) the `matplotlib_inline` dependency to ipython, so it will automatically fix the missing dep package issue.


@astonzhang let's make a patch release and for `d2l` since this has affected all our notebooks in colab with their recent change.