### PR TITLE
HotFix Release: Fix #2250 colab missing matplotlib_inline

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup, find_packages
 import d2l
 
 requirements = [
+    'ipython>=7.23',
     'jupyter',
     'numpy',
     'matplotlib',


### PR DESCRIPTION
This PR cherry-picks 7e328317929d01bd4a311fe87e862effc810d9ab to the relese branch, fixing the colab `matplotlib_inline` missing package bug.