### PR TITLE
time starts without stopping

### DIFF
--- a/chapter_optimization/minibatch-sgd.md
+++ b/chapter_optimization/minibatch-sgd.md
@@ -368,6 +368,8 @@ def train_ch11(trainer_fn, states, hyperparams, data_iter,
                 animator.add(n/X.shape[0]/len(data_iter),
                              (d2l.evaluate_loss(net, data_iter, loss),))
                 timer.start()
+    timer.stop()
+    
     print(f'loss: {animator.Y[0][-1]:.3f}, {timer.avg():.3f} sec/epoch')
     return timer.cumsum(), animator.Y[0]
 ```
@@ -509,6 +511,8 @@ def train_concise_ch11(tr_name, hyperparams, data_iter, num_epochs=2):
                 animator.add(n/X.shape[0]/len(data_iter),
                              (d2l.evaluate_loss(net, data_iter, loss),))
                 timer.start()
+    timer.stop()      
+    
     print(f'loss: {animator.Y[0][-1]:.3f}, {timer.avg():.3f} sec/epoch')
 ```
 


### PR DESCRIPTION
If we call train_ch11 or train_concise_ch11 and the code never fits in the condition (like calling these functions with a batch size of 1500 and only one epoch), no time interval will be stored in the times array of the Timer object and this causes a division by zero in Timer.avg() because this function divides by the length of the times array.