### PR TITLE
Feat: Add dynamic preview/stable version tab; Fix preview pdf links

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ stage("Build and Publish") {
 
       sh label:"Build HTML", script:"""set -ex
       conda activate ${ENV_NAME}
-      ./static/build_html.sh
+      ./static/build_html.sh ${env.BRANCH_NAME} ${JOB_NAME}
       """
 
       sh label:"Build PDF", script:"""set -ex

--- a/config.ini
+++ b/config.ini
@@ -39,8 +39,10 @@ tabs = pytorch, mxnet, tensorflow
 # items: name, URL, and a fontawesome icon
 # (https://fontawesome.com/icons?d=gallery). Items are separated by commas.
 # PDF, http://numpy.d2l.ai/d2l-en.pdf, fas fa-file-pdf,
-header_links = PyTorch, https://d2l.ai/d2l-en.pdf, fas fa-file-pdf,
-               MXNet, https://d2l.ai/d2l-en-mxnet.pdf, fas fa-file-pdf,
+# Links within hashes are replaced dynamically in static/build_html.sh
+header_links = ###_ALTERNATE_VERSION_###, ###_ALTERNATE_VERSION_BASE_LINK_###, fas fa-book,
+               PyTorch, ###_CURRENT_VERSION_BASE_LINK_###/d2l-en.pdf, fas fa-file-pdf,
+               MXNet, ###_CURRENT_VERSION_BASE_LINK_###/d2l-en-mxnet.pdf, fas fa-file-pdf,
                Notebooks, https://d2l.ai/d2l-en.zip, fab fa-python,
                Courses, https://courses.d2l.ai, fas fa-user-graduate,
                GitHub, https://github.com/d2l-ai/d2l-en, fab fa-github,

--- a/static/build_html.sh
+++ b/static/build_html.sh
@@ -2,6 +2,33 @@
 
 set -e
 
+# Read arguments
+BRANCH_NAME=$1
+JOB_NAME=$2
+
+STABLE_BASE_PATH="https://d2l.ai"
+PREVIEW_BASE_PATH="http://preview.d2l.ai/$JOB_NAME"
+
+# Generate Headers
+if [[ "$BRANCH_NAME" == "release" ]]; then
+    echo "Use release headers"
+    alternate_text="Preview Version"
+    alternate_base=$PREVIEW_BASE_PATH
+    current_base=$STABLE_BASE_PATH
+else
+    echo "Use ${JOB_NAME} headers"
+    alternate_text="Stable Version"
+    alternate_base=$STABLE_BASE_PATH
+    current_base=$PREVIEW_BASE_PATH
+fi
+
+
+# Replace placeholders in ../config.ini
+sed -i -e "s@###_ALTERNATE_VERSION_###@$alternate_text@g" ./config.ini
+sed -i -e "s@###_ALTERNATE_VERSION_BASE_LINK_###@$alternate_base@g" ./config.ini
+sed -i -e "s@###_CURRENT_VERSION_BASE_LINK_###@$current_base@g" ./config.ini
+
+
 rm -rf _build/rst _build/html
 d2lbook build rst --tab all
 cp static/frontpage/frontpage.html _build/rst_all/


### PR DESCRIPTION
Add feature to switch between preview and stable version through a new header tab. Also, preview version pdf links are now fixed, earlier they pointed to the stable release version pdfs.

Header links are now generated dynamically at runtime using the branch information to decide the content.
