### PR TITLE
JAX: Setup D2L JAX API & Add chapter linear regression 

### DIFF
--- a/chapter_appendix-tools-for-deep-learning/utils.md
+++ b/chapter_appendix-tools-for-deep-learning/utils.md
@@ -409,22 +409,7 @@ def evaluate_accuracy(net, data_iter):  #@save
 ```
 
 ```{.python .input}
-%%tab pytorch, mxnet, tensorflow
-
-def linreg(X, w, b):  #@save
-    """The linear regression model."""
-    return d2l.matmul(X, w) + b
-
-def squared_loss(y_hat, y):  #@save
-    """Squared loss."""
-    return (y_hat - d2l.reshape(y, y_hat.shape)) ** 2 / 2
-
-def get_fashion_mnist_labels(labels):  #@save
-    """Return text labels for the Fashion-MNIST dataset."""
-    text_labels = ['t-shirt', 'trouser', 'pullover', 'dress', 'coat',
-                   'sandal', 'shirt', 'sneaker', 'bag', 'ankle boot']
-    return [text_labels[int(i)] for i in labels]
-
+%%tab all
 def show_images(imgs, num_rows, num_cols, titles=None, scale=1.5):  #@save
     """Plot a list of images."""
     figsize = (num_cols * scale, num_rows * scale)
@@ -441,6 +426,24 @@ def show_images(imgs, num_rows, num_cols, titles=None, scale=1.5):  #@save
         if titles:
             ax.set_title(titles[i])
     return axes
+```
+
+```{.python .input}
+%%tab pytorch, mxnet, tensorflow
+
+def linreg(X, w, b):  #@save
+    """The linear regression model."""
+    return d2l.matmul(X, w) + b
+
+def squared_loss(y_hat, y):  #@save
+    """Squared loss."""
+    return (y_hat - d2l.reshape(y, y_hat.shape)) ** 2 / 2
+
+def get_fashion_mnist_labels(labels):  #@save
+    """Return text labels for the Fashion-MNIST dataset."""
+    text_labels = ['t-shirt', 'trouser', 'pullover', 'dress', 'coat',
+                   'sandal', 'shirt', 'sneaker', 'bag', 'ankle boot']
+    return [text_labels[int(i)] for i in labels]
 
 #@tab pytorch, mxnet, tensorflow
 class Animator:  #@save

--- a/chapter_appendix-tools-for-deep-learning/utils.md
+++ b/chapter_appendix-tools-for-deep-learning/utils.md
@@ -1,6 +1,6 @@
 ```{.python .input}
 %load_ext d2lbook.tab
-tab.interact_select(['mxnet', 'pytorch', 'tensorflow'])
+tab.interact_select(['mxnet', 'pytorch', 'tensorflow', 'jax'])
 ```
 
 # Utility Functions and Classes
@@ -37,6 +37,15 @@ from IPython import display
 import collections
 from d2l import tensorflow as d2l
 import tensorflow as tf
+```
+
+```{.python .input}
+%%tab jax
+import inspect
+from IPython import display
+import collections
+from d2l import jax as d2l
+import jax
 ```
 
 Hyperparameters.
@@ -400,7 +409,7 @@ def evaluate_accuracy(net, data_iter):  #@save
 ```
 
 ```{.python .input}
-%%tab all
+%%tab pytorch, mxnet, tensorflow
 
 def linreg(X, w, b):  #@save
     """The linear regression model."""
@@ -433,7 +442,7 @@ def show_images(imgs, num_rows, num_cols, titles=None, scale=1.5):  #@save
             ax.set_title(titles[i])
     return axes
 
-#@tab all
+#@tab pytorch, mxnet, tensorflow
 class Animator:  #@save
     """For plotting data in animation."""
     def __init__(self, xlabel=None, ylabel=None, legend=None, xlim=None,
@@ -473,8 +482,8 @@ class Animator:  #@save
         self.config_axes()
         display.display(self.fig)
         display.clear_output(wait=True)
-        
-#@tab all
+
+#@tab pytorch, mxnet, tensorflow
 class Accumulator:  #@save
     """For accumulating sums over `n` variables."""
     def __init__(self, n):
@@ -487,10 +496,10 @@ class Accumulator:  #@save
         self.data = [0.0] * len(self.data)
 
     def __getitem__(self, idx):
-        return self.data[idx]        
-    
-    
-#@tab all
+        return self.data[idx]
+
+
+#@tab pytorch, mxnet, tensorflow
 def accuracy(y_hat, y):  #@save
     """Compute the number of correct predictions."""
     if len(y_hat.shape) > 1 and y_hat.shape[1] > 1:
@@ -500,7 +509,7 @@ def accuracy(y_hat, y):  #@save
 ```
 
 ```{.python .input}
-%%tab all
+%%tab pytorch, mxnet, tensorflow
 
 import os
 import requests
@@ -548,7 +557,7 @@ def extract(filename, folder=None):  #@save
 ```
 
 ```{.python .input}
-%%tab all
+%%tab pytorch, mxnet, tensorflow
 
 def download_extract(name, folder=None):  #@save
     """Download and extract a zip/tar file."""
@@ -636,7 +645,7 @@ def grad_clipping(grads, theta):  #@save
 More for the attention chapter.
 
 ```{.python .input}
-%%tab all
+%%tab pytorch, mxnet, tensorflow
 #@save
 d2l.DATA_HUB['fra-eng'] = (d2l.DATA_URL + 'fra-eng.zip',
                            '94646ad1522d915e7b0f9296181140edcf86a4f5')

--- a/chapter_builders-guide/use-gpu.md
+++ b/chapter_builders-guide/use-gpu.md
@@ -1,6 +1,6 @@
 ```{.python .input}
 %load_ext d2lbook.tab
-tab.interact_select(['mxnet', 'pytorch', 'tensorflow'])
+tab.interact_select(['mxnet', 'pytorch', 'tensorflow', 'jax'])
 ```
 
 # GPUs
@@ -145,6 +145,14 @@ import tensorflow as tf
 ```
 
 ```{.python .input}
+%%tab jax
+from d2l import jax as d2l
+import jax
+import jax.numpy as jnp
+from flax import linen as nn
+```
+
+```{.python .input}
 %%tab all
 def cpu():  #@save
     if tab.selected('mxnet'):
@@ -153,6 +161,8 @@ def cpu():  #@save
         return torch.device('cpu')
     if tab.selected('tensorflow'):
         return tf.device('/CPU:0')
+    if tab.selected('jax'):
+        return jax.devices('cpu')[0]
 
 def gpu(i=0):  #@save
     if tab.selected('mxnet'):
@@ -161,6 +171,8 @@ def gpu(i=0):  #@save
         return torch.device(f'cuda:{i}')
     if tab.selected('tensorflow'):
         return tf.device(f'/GPU:{i}')
+    if tab.selected('jax'):
+        return jax.devices('gpu')[i]
 
 cpu(), gpu(), gpu(1)
 ```
@@ -176,6 +188,8 @@ def num_gpus():  #@save
         return torch.cuda.device_count()
     if tab.selected('tensorflow'):
         return len(tf.config.experimental.list_physical_devices('GPU'))
+    if tab.selected('jax'):
+        return jax.device_count('gpu')
 
 num_gpus()
 ```
@@ -184,7 +198,7 @@ Now we [**define two convenient functions that allow us
 to run code even if the requested GPUs do not exist.**]
 
 ```{.python .input}
-%%tab all
+%%tab pytorch, mxnet, tensorflow
 def try_gpu(i=0):  #@save
     """Return gpu(i) if exists, otherwise return cpu()."""
     if num_gpus() >= i + 1:
@@ -200,8 +214,28 @@ try_gpu(), try_gpu(10), try_all_gpus()
 
 ## Tensors and GPUs
 
+:begin_tab:`pytorch`
 By default, tensors are created on the CPU.
 We can [**query the device where the tensor is located.**]
+:end_tab:
+
+:begin_tab:`mxnet`
+By default, tensors are created on the CPU.
+We can [**query the device where the tensor is located.**]
+:end_tab:
+
+:begin_tab:`tensorflow`
+By default, tensors are created on the CPU.
+We can [**query the device where the tensor is located.**]
+:end_tab:
+
+:begin_tab:`jax`
+By default, tensors are created on the GPU/TPU if they are available,
+else CPU is used if not available.
+We can [**query the device where the tensor is located.**]
+:end_tab:
+
+
 
 ```{.python .input}
 %%tab mxnet
@@ -219,6 +253,12 @@ x.device
 %%tab tensorflow
 x = tf.constant([1, 2, 3])
 x.device
+```
+
+```{.python .input}
+%%tab jax
+x = jnp.array([1, 2, 3])
+x.device()
 ```
 
 It is important to note that whenever we want
@@ -258,6 +298,13 @@ with try_gpu():
 X
 ```
 
+```{.python .input}
+%%tab jax
+# By default jax puts arrays to GPUs or TPUs if available
+X = jax.device_put(jnp.ones((2, 3), try_gpu())
+X
+```
+
 Assuming that you have at least two GPUs, the following code will (**create a random tensor on the second GPU.**)
 
 ```{.python .input}
@@ -276,6 +323,13 @@ Y
 %%tab tensorflow
 with try_gpu(1):
     Y = tf.random.uniform((2, 3))
+Y
+```
+
+```{.python .input}
+%%tab jax
+Y = jax.device_put(jax.random.uniform(jax.random.PRNGKey(0), (2, 3)),
+                   try_gpu(1))
 Y
 ```
 
@@ -318,6 +372,13 @@ print(X)
 print(Z)
 ```
 
+```{.python .input}
+%%tab tensorflow
+Z = jax.device_put(X, try_gpu(1))
+print(X)
+print(Z)
+```
+
 Now that [**the data is on the same GPU
 (both `Z` and `Y` are),
 we can add them up.**]
@@ -355,6 +416,12 @@ What happens if we still call `Z2 = Z` under the same device scope?
 It will return `Z` instead of making a copy and allocating new memory.
 :end_tab:
 
+:begin_tab:`jax`
+Imagine that your variable `Z` already lives on your second GPU.
+What happens if we still call `Z2 = Z` under the same device scope?
+It will return `Z` instead of making a copy and allocating new memory.
+:end_tab:
+
 ```{.python .input}
 %%tab mxnet
 Z.as_in_ctx(try_gpu(1)) is Z
@@ -369,6 +436,12 @@ Z.cuda(1) is Z
 %%tab tensorflow
 with try_gpu(1):
     Z2 = Z
+Z2 is Z
+```
+
+```{.python .input}
+%%tab jax
+Z2 = jax.device_put(Z, try_gpu(1))
 Z2 is Z
 ```
 
@@ -434,6 +507,15 @@ with strategy.scope():
         tf.keras.layers.Dense(1)])
 ```
 
+```{.python .input}
+%%tab jax
+net = nn.Sequential([nn.Dense(1)])
+
+key1, key2 = jax.random.split(jax.random.PRNGKey(0))
+x = jax.random.normal(key1, (10,)) # Dummy input
+params = net.init(key2, x) # Initialization call
+```
+
 We will see many more examples of
 how to run models on GPUs in the following chapters,
 simply since they will become somewhat more computationally intensive.
@@ -441,8 +523,13 @@ simply since they will become somewhat more computationally intensive.
 When the input is a tensor on the GPU, the model will calculate the result on the same GPU.
 
 ```{.python .input}
-%%tab all
+%%tab mxnet, pytorch, tensorflow
 net(X)
+```
+
+```{.python .input}
+%%tab jax
+net.apply(params, x)
 ```
 
 Let's (**confirm that the model parameters are stored on the same GPU.**)
@@ -460,6 +547,11 @@ net[0].weight.data.device
 ```{.python .input}
 %%tab tensorflow
 net.layers[0].weights[0].device, net.layers[0].weights[1].device
+```
+
+```{.python .input}
+%%tab jax
+print(jax.tree_util.tree_map(lambda x: x.device(), params))
 ```
 
 Let the trainer support GPU.
@@ -550,5 +642,3 @@ In short, as long as all data and parameters are on the same device, we can lear
 :begin_tab:`tensorflow`
 [Discussions](https://discuss.d2l.ai/t/270)
 :end_tab:
-
-

--- a/chapter_builders-guide/use-gpu.md
+++ b/chapter_builders-guide/use-gpu.md
@@ -198,7 +198,7 @@ Now we [**define two convenient functions that allow us
 to run code even if the requested GPUs do not exist.**]
 
 ```{.python .input}
-%%tab pytorch, mxnet, tensorflow
+%%tab all
 def try_gpu(i=0):  #@save
     """Return gpu(i) if exists, otherwise return cpu()."""
     if num_gpus() >= i + 1:
@@ -301,7 +301,7 @@ X
 ```{.python .input}
 %%tab jax
 # By default jax puts arrays to GPUs or TPUs if available
-X = jax.device_put(jnp.ones((2, 3), try_gpu())
+X = jax.device_put(jnp.ones((2, 3)), try_gpu())
 X
 ```
 
@@ -373,7 +373,7 @@ print(Z)
 ```
 
 ```{.python .input}
-%%tab tensorflow
+%%tab jax
 Z = jax.device_put(X, try_gpu(1))
 print(X)
 print(Z)

--- a/chapter_builders-guide/use-gpu.md
+++ b/chapter_builders-guide/use-gpu.md
@@ -147,9 +147,9 @@ import tensorflow as tf
 ```{.python .input}
 %%tab jax
 from d2l import jax as d2l
-import jax
-import jax.numpy as jnp
 from flax import linen as nn
+import jax
+from jax import numpy as jnp
 ```
 
 ```{.python .input}
@@ -234,8 +234,6 @@ By default, tensors are created on the GPU/TPU if they are available,
 else CPU is used if not available.
 We can [**query the device where the tensor is located.**]
 :end_tab:
-
-
 
 ```{.python .input}
 %%tab mxnet

--- a/chapter_linear-regression/linear-regression-concise.md
+++ b/chapter_linear-regression/linear-regression-concise.md
@@ -312,10 +312,10 @@ to train our model.
 model = LinearRegression(lr=0.03)
 data = d2l.SyntheticRegressionData(w=d2l.tensor([2, -3.4]), b=4.2)
 trainer = d2l.Trainer(max_epochs=3)
-if tab.selected(jax):
+if tab.selected('jax'):
     key = jax.random.PRNGKey(42)
     trainer.fit(model, data, key)
-else:
+if tab.selected('pytorch', 'mxnet', 'tensorflow'):
     trainer.fit(model, data)
 ```
 

--- a/chapter_linear-regression/linear-regression-concise.md
+++ b/chapter_linear-regression/linear-regression-concise.md
@@ -45,7 +45,7 @@ from mxnet.gluon import nn
 npx.set_np()
 ```
 
-```{.python .input  n=1}
+```{.python .input}
 %%tab pytorch
 from d2l import torch as d2l
 import numpy as np
@@ -53,20 +53,19 @@ import torch
 from torch import nn
 ```
 
-```{.python .input  n=1}
+```{.python .input}
 %%tab tensorflow
 from d2l import tensorflow as d2l
 import numpy as np
 import tensorflow as tf
 ```
 
-```{.python .input  n=1}
+```{.python .input}
 %%tab jax
 from d2l import jax as d2l
+from flax import linen as nn
 import jax
 from jax import numpy as jnp
-from jax import grad
-from flax import linen as nn
 import optax
 ```
 
@@ -165,7 +164,7 @@ class LinearRegression(d2l.Module):  #@save
 
 ```{.python .input}
 %%tab jax
-class LinearRegression(d2l.Module):  # @save
+class LinearRegression(d2l.Module):  #@save
     lr: float
 
     def setup(self):
@@ -174,7 +173,7 @@ class LinearRegression(d2l.Module):  # @save
 
 In the `forward` method, we just invoke the built-in `__call__` function of the predefined layers to compute the outputs.
 
-```{.python .input  n=3}
+```{.python .input}
 %%tab pytorch, mxnet, tensorflow
 @d2l.add_to_class(LinearRegression)  #@save
 def forward(self, X):
@@ -182,10 +181,10 @@ def forward(self, X):
     return self.net(X)
 ```
 
-```{.python .input  n=3}
+```{.python .input}
 %%tab jax
 @d2l.add_to_class(LinearRegression)  #@save
-def __call__(self, X):
+def forward(self, X):
     """The linear regression model."""
     return self.net(X)
 ```
@@ -212,7 +211,7 @@ The `MeanSquaredError` class computes the mean squared error (without the $1/2$ 
 By default it returns the average loss over examples.
 :end_tab:
 
-```{.python .input  n=3}
+```{.python .input}
 %%tab pytorch, mxnet, tensorflow
 @d2l.add_to_class(LinearRegression)  #@save
 def loss(self, y_hat, y):
@@ -227,7 +226,7 @@ def loss(self, y_hat, y):
         return fn(y, y_hat)
 ```
 
-```{.python .input  n=3}
+```{.python .input}
 %%tab jax
 @d2l.add_to_class(LinearRegression)  #@save
 def loss(self, params, X, y):
@@ -275,7 +274,7 @@ and thus Keras supports it alongside a number of
 variations on this algorithm in the `optimizers` module.
 :end_tab:
 
-```{.python .input  n=5}
+```{.python .input}
 %%tab all
 @d2l.add_to_class(LinearRegression)  #@save
 def configure_optimizers(self):
@@ -312,11 +311,7 @@ to train our model.
 model = LinearRegression(lr=0.03)
 data = d2l.SyntheticRegressionData(w=d2l.tensor([2, -3.4]), b=4.2)
 trainer = d2l.Trainer(max_epochs=3)
-if tab.selected('jax'):
-    key = jax.random.PRNGKey(42)
-    trainer.fit(model, data, key)
-if tab.selected('pytorch', 'mxnet', 'tensorflow'):
-    trainer.fit(model, data)
+trainer.fit(model, data)
 ```
 
 Below, we

--- a/chapter_linear-regression/linear-regression-scratch.md
+++ b/chapter_linear-regression/linear-regression-scratch.md
@@ -58,9 +58,9 @@ import tensorflow as tf
 %%tab jax
 %matplotlib inline
 from d2l import jax as d2l
-import jax
-import jax.numpy as jnp
 from flax import linen as nn
+import jax
+from jax import numpy as jnp
 import optax
 ```
 
@@ -101,7 +101,7 @@ class LinearRegressionScratch(d2l.Module):  #@save
 
 ```{.python .input}
 %%tab jax
-class LinearRegressionScratch(d2l.Module):  # @save
+class LinearRegressionScratch(d2l.Module):  #@save
     num_inputs: int
     lr: float
     sigma: float = 0.01
@@ -265,23 +265,24 @@ class SGD(d2l.HyperParameters):  #@save
     def __init__(self, lr):
         """
         Minibatch stochastic gradient descent.
-        The key transformation of Optax is the `GradientTransformation`
-        defined by two functions, the `init` and the `update`.
-        The `init` initializes the state and the `update` transforms
+        The key transformation of Optax is the GradientTransformation
+        defined by two methods, the init and the update.
+        The init initializes the state and the update transforms
         the gradients.
         https://github.com/deepmind/optax/blob/master/optax/_src/transform.py
         """
         self.save_hyperparameters()
 
     def init(self, params):
-        # params not used
+        # Delete unused params
         del params
         return optax.EmptyState
 
     def update(self, updates, state, params=None):
         del params
-        # apply_gradients through flax's train_state is called, which then
-        # calls optax.apply_updates adding the params to the update defined
+        # When state.apply_gradients method is called to update flax's
+        # train_state object, it internally calls optax.apply_updates method
+        # adding the params to the update equation defined below.
         updates = jax.tree_util.tree_map(lambda g: -self.lr * g, updates)
         return updates, state
 
@@ -451,11 +452,7 @@ later.
 model = LinearRegressionScratch(2, lr=0.03)
 data = d2l.SyntheticRegressionData(w=d2l.tensor([2, -3.4]), b=4.2)
 trainer = d2l.Trainer(max_epochs=3)
-if tab.selected('jax'):
-    key = jax.random.PRNGKey(6)
-    trainer.fit(model, data, key)
-if tab.selected('pytorch', 'mxnet', 'tensorflow'):
-    trainer.fit(model, data)
+trainer.fit(model, data)
 ```
 
 Because we synthesized the dataset ourselves,

--- a/chapter_linear-regression/linear-regression-scratch.md
+++ b/chapter_linear-regression/linear-regression-scratch.md
@@ -451,10 +451,10 @@ later.
 model = LinearRegressionScratch(2, lr=0.03)
 data = d2l.SyntheticRegressionData(w=d2l.tensor([2, -3.4]), b=4.2)
 trainer = d2l.Trainer(max_epochs=3)
-if tab.selected(jax):
+if tab.selected('jax'):
     key = jax.random.PRNGKey(6)
     trainer.fit(model, data, key)
-else:
+if tab.selected('pytorch', 'mxnet', 'tensorflow'):
     trainer.fit(model, data)
 ```
 

--- a/chapter_linear-regression/linear-regression.md
+++ b/chapter_linear-regression/linear-regression.md
@@ -1,6 +1,6 @@
 ```{.python .input  n=1}
 %load_ext d2lbook.tab
-tab.interact_select(['mxnet', 'pytorch', 'tensorflow'])
+tab.interact_select(['mxnet', 'pytorch', 'tensorflow', 'jax'])
 ```
 
 # Linear Regression
@@ -415,6 +415,15 @@ import numpy as np
 import time
 ```
 
+```{.python .input}
+%%tab jax
+%matplotlib inline
+from d2l import jax as d2l
+import math
+import jax.numpy as jnp
+import time
+```
+
 To illustrate why this matters so much,
 we can (**consider two methods for adding vectors.**)
 To start, we instantiate two 10,000-dimensional vectors
@@ -448,6 +457,19 @@ c = tf.Variable(d2l.zeros(n))
 t = time.time()
 for i in range(n):
     c[i].assign(a[i] + b[i])
+f'{time.time() - t:.5f} sec'
+```
+
+```{.python .input}
+%%tab jax
+# JAX arrays are immutable, meaning that once
+# created their contents cannot be changed
+# For updating individual elements, JAX provides
+# an indexed update syntax that returns an updated copy
+c = d2l.zeros(n)
+t = time.time()
+for i in range(n):
+    c = c.at[i].set(a[i] + b[i])
 f'{time.time() - t:.5f} sec'
 ```
 
@@ -501,7 +523,10 @@ Below [**we define a function to compute the normal distribution**].
 %%tab all
 def normal(x, mu, sigma):
     p = 1 / math.sqrt(2 * math.pi * sigma**2)
-    return p * np.exp(-0.5 * (x - mu)**2 / sigma**2)
+    if tab.selected('jax'):
+        return p * jnp.exp(-0.5 * (x - mu)**2 / sigma**2)
+    else:
+        return p * np.exp(-0.5 * (x - mu)**2 / sigma**2)
 ```
 
 We can now (**visualize the normal distributions**).
@@ -519,9 +544,13 @@ d2l.plot(x.asnumpy(), [normal(x, mu, sigma).asnumpy() for mu, sigma in params], 
 ```
 
 ```{.python .input  n=8}
-%%tab pytorch, tensorflow
-# Use numpy again for visualization
-x = np.arange(-7, 7, 0.01)
+%%tab pytorch, tensorflow, jax
+if tab.selected('jax'):
+    # Use jax numpy for visualization
+    x = jnp.arange(-7, 7, 0.01)
+else:
+    # Use numpy again for visualization
+    x = np.arange(-7, 7, 0.01)
 
 # Mean and standard deviation pairs
 params = [(0, 1), (0, 2), (3, 1)]

--- a/chapter_linear-regression/linear-regression.md
+++ b/chapter_linear-regression/linear-regression.md
@@ -1,4 +1,4 @@
-```{.python .input  n=1}
+```{.python .input}
 %load_ext d2lbook.tab
 tab.interact_select(['mxnet', 'pytorch', 'tensorflow', 'jax'])
 ```
@@ -386,7 +386,7 @@ Doing this efficiently requires that (**we**) (~~should~~)
 fast linear algebra libraries
 rather than writing costly for-loops in Python.**)
 
-```{.python .input  n=1}
+```{.python .input}
 %%tab mxnet
 %matplotlib inline
 from d2l import mxnet as d2l
@@ -395,7 +395,7 @@ from mxnet import np
 import time
 ```
 
-```{.python .input  n=1}
+```{.python .input}
 %%tab pytorch
 %matplotlib inline
 from d2l import torch as d2l
@@ -431,7 +431,7 @@ containing all ones.
 In one method, we loop over the vectors with a Python for-loop.
 In the other method, we rely on a single call to `+`.
 
-```{.python .input  n=2}
+```{.python .input}
 %%tab all
 n = 10000
 a = d2l.ones(n)
@@ -475,7 +475,7 @@ f'{time.time() - t:.5f} sec'
 
 (**Alternatively, we rely on the reloaded `+` operator to compute the elementwise sum.**)
 
-```{.python .input  n=4}
+```{.python .input}
 %%tab all
 t = time.time()
 d = a + b
@@ -519,19 +519,19 @@ $$p(x) = \frac{1}{\sqrt{2 \pi \sigma^2}} \exp\left(-\frac{1}{2 \sigma^2} (x - \m
 
 Below [**we define a function to compute the normal distribution**].
 
-```{.python .input  n=3}
+```{.python .input}
 %%tab all
 def normal(x, mu, sigma):
     p = 1 / math.sqrt(2 * math.pi * sigma**2)
     if tab.selected('jax'):
         return p * jnp.exp(-0.5 * (x - mu)**2 / sigma**2)
-    else:
+    if tab.selected('pytorch', 'mxnet', 'tensorflow'):
         return p * np.exp(-0.5 * (x - mu)**2 / sigma**2)
 ```
 
 We can now (**visualize the normal distributions**).
 
-```{.python .input  n=8}
+```{.python .input}
 %%tab mxnet
 # Use numpy again for visualization
 x = np.arange(-7, 7, 0.01)
@@ -543,12 +543,12 @@ d2l.plot(x.asnumpy(), [normal(x, mu, sigma).asnumpy() for mu, sigma in params], 
          legend=[f'mean {mu}, std {sigma}' for mu, sigma in params])
 ```
 
-```{.python .input  n=8}
+```{.python .input}
 %%tab pytorch, tensorflow, jax
 if tab.selected('jax'):
     # Use jax numpy for visualization
     x = jnp.arange(-7, 7, 0.01)
-else:
+if tab.selected('pytorch', 'mxnet', 'tensorflow'):
     # Use numpy again for visualization
     x = np.arange(-7, 7, 0.01)
 

--- a/chapter_linear-regression/linear-regression.md
+++ b/chapter_linear-regression/linear-regression.md
@@ -419,8 +419,8 @@ import time
 %%tab jax
 %matplotlib inline
 from d2l import jax as d2l
+from jax import numpy as jnp
 import math
-import jax.numpy as jnp
 import time
 ```
 
@@ -462,9 +462,8 @@ f'{time.time() - t:.5f} sec'
 
 ```{.python .input}
 %%tab jax
-# JAX arrays are immutable, meaning that once
-# created their contents cannot be changed
-# For updating individual elements, JAX provides
+# JAX arrays are immutable, meaning that once created their contents
+# cannot be changed. For updating individual elements, JAX provides
 # an indexed update syntax that returns an updated copy
 c = d2l.zeros(n)
 t = time.time()
@@ -533,7 +532,7 @@ We can now (**visualize the normal distributions**).
 
 ```{.python .input}
 %%tab mxnet
-# Use numpy again for visualization
+# Use NumPy again for visualization
 x = np.arange(-7, 7, 0.01)
 
 # Mean and standard deviation pairs
@@ -546,10 +545,10 @@ d2l.plot(x.asnumpy(), [normal(x, mu, sigma).asnumpy() for mu, sigma in params], 
 ```{.python .input}
 %%tab pytorch, tensorflow, jax
 if tab.selected('jax'):
-    # Use jax numpy for visualization
+    # Use JAX NumPy for visualization
     x = jnp.arange(-7, 7, 0.01)
 if tab.selected('pytorch', 'mxnet', 'tensorflow'):
-    # Use numpy again for visualization
+    # Use NumPy again for visualization
     x = np.arange(-7, 7, 0.01)
 
 # Mean and standard deviation pairs

--- a/chapter_linear-regression/oo-design.md
+++ b/chapter_linear-regression/oo-design.md
@@ -1,6 +1,6 @@
 ```{.python .input  n=1}
 %load_ext d2lbook.tab
-tab.interact_select(['mxnet', 'pytorch', 'tensorflow'])
+tab.interact_select(['mxnet', 'pytorch', 'tensorflow', 'jax'])
 ```
 
 # Object-Oriented Design for Implementation
@@ -64,6 +64,17 @@ import time
 import numpy as np
 from d2l import torch as d2l
 import tensorflow as tf
+```
+
+```{.python .input}
+%%tab jax
+from dataclasses import field
+import time
+import numpy as np
+from d2l import jax as d2l
+import jax
+import jax.numpy as jnp
+from flax.training.train_state import TrainState
 ```
 
 ## Utilities
@@ -162,25 +173,48 @@ Sometimes we put the code to compute the output into a separate `forward` method
 ```{.python .input}
 %%tab all
 class Module(d2l.nn_Module, d2l.HyperParameters):  #@save
-    def __init__(self, plot_train_per_epoch=2, plot_valid_per_epoch=1):
-        super().__init__()
-        self.save_hyperparameters()
-        self.board = ProgressBoard()
+    if tab.selected('pytorch', 'mxnet', 'tensorflow'):
+        def __init__(self, plot_train_per_epoch=2, plot_valid_per_epoch=1):
+            super().__init__()
+            self.save_hyperparameters()
+            self.board = ProgressBoard()
         if tab.selected('tensorflow'):
             self.training = None
+
+    if tab.selected('jax'):
+        # No need for save_hyperparam when using python dataclass
+        # python dataclasses do not work perfectly well with inheritance
+        plot_train_per_epoch: int = field(default=2, init=False)
+        plot_valid_per_epoch: int = field(default=1, init=False)
+        # Use default_factory to make sure new plots are generated on each run
+        board: ProgressBoard = field(default_factory=lambda: ProgressBoard(),
+                                     init=False)
+        training: bool = field(default=None, init=False)
 
     def loss(self, y_hat, y):
         raise NotImplementedError
 
-    def forward(self, X):
-        assert hasattr(self, 'net'), 'Neural network is defined'
-        return self.net(X)
+    if tab.selected('pytorch', 'mxnet', 'tensorflow'):
+        def forward(self, X):
+            assert hasattr(self, 'net'), 'Neural network is defined'
+            return self.net(X)
 
     if tab.selected('tensorflow'):
         def call(self, X, *args, **kwargs):
             if kwargs and "training" in kwargs:
                 self.training = kwargs['training']
             return self.forward(X, *args)
+
+    if tab.selected('jax'):
+        # JAX & Flax don't have a forward method like syntax
+        # Flax uses setup and built-in __call__ magic methods for forward pass
+        # Adding here for consistency
+        def forward(self, X, *args, **kwargs):
+            assert hasattr(self, 'net'), 'Neural network is defined'
+            return self.net(X, *args, **kwargs)
+
+        def __call__(self, X, *args, **kwargs):
+            return self.forward(X, *args, **kwargs)
 
     def plot(self, key, value, train):
         """Plot a point in animation."""
@@ -202,15 +236,31 @@ class Module(d2l.nn_Module, d2l.HyperParameters):  #@save
             self.board.draw(x, d2l.numpy(d2l.to(value, d2l.cpu())),
                             ('train_' if train else 'val_') + key,
                             every_n=int(n))
+        if tab.selected('jax'):
+            self.board.draw(x, d2l.to(value, d2l.cpu()),
+                            ('train_' if train else 'val_') + key,
+                            every_n=int(n))
 
-    def training_step(self, batch):
-        l = self.loss(self(*batch[:-1]), batch[-1])
-        self.plot('loss', l, train=True)
-        return l
+    if tab.selected('pytorch', 'mxnet', 'tensorflow'):
+        def training_step(self, batch):
+            l = self.loss(self(*batch[:-1]), batch[-1])
+            self.plot('loss', l, train=True)
+            return l
 
-    def validation_step(self, batch):
-        l = self.loss(self(*batch[:-1]), batch[-1])
-        self.plot('loss', l, train=False)
+        def validation_step(self, batch):
+            l = self.loss(self(*batch[:-1]), batch[-1])
+            self.plot('loss', l, train=False)
+
+    if tab.selected('jax'):
+        def training_step(self, params, batch):
+            l, grads = jax.value_and_grad(self.loss)(params, *batch[:-1],
+                                                     batch[-1])
+            self.plot("loss", l, train=True)
+            return l, grads
+
+        def validation_step(self, params, batch):
+            l = self.loss(params, *batch[:-1], batch[-1])
+            self.plot("loss", l, train=False)
 
     def configure_optimizers(self):
         raise NotImplementedError
@@ -239,7 +289,7 @@ The `DataModule` class is the base class for data. Quite frequently the `__init_
 ```{.python .input}
 %%tab all
 class DataModule(d2l.HyperParameters):  #@save
-    if tab.selected('mxnet', 'pytorch'):
+    if tab.selected('mxnet', 'pytorch', 'jax'):
         def __init__(self, root='../data', num_workers=4):
             self.save_hyperparameters()
 
@@ -281,15 +331,42 @@ class Trainer(d2l.HyperParameters):  #@save
         model.board.xlim = [0, self.max_epochs]
         self.model = model
 
-    def fit(self, model, data):
-        self.prepare_data(data)
-        self.prepare_model(model)
-        self.optim = model.configure_optimizers()
-        self.epoch = 0
-        self.train_batch_idx = 0
-        self.val_batch_idx = 0
-        for self.epoch in range(self.max_epochs):
-            self.fit_epoch()
+    if tab.selected('pytorch', 'mxnet', 'tensorflow'):
+        def fit(self, model, data):
+            self.prepare_data(data)
+            self.prepare_model(model)
+            self.optim = model.configure_optimizers()
+            self.epoch = 0
+            self.train_batch_idx = 0
+            self.val_batch_idx = 0
+            for self.epoch in range(self.max_epochs):
+                self.fit_epoch()
+
+    if tab.selected('jax'):
+        def apply_init(self, **kwargs):
+            if kwargs and 'key' in kwargs and (kwargs['key'] is not None):
+                self.key = kwargs['key']
+            else:
+                self.key = jax.random.PRNGKey(0)  # Avoid, but use as fallback
+            input_shape = next(iter(self.train_dataloader))[0].shape
+            dummy_input = jnp.zeros(input_shape)
+            params = self.model.init(self.key, dummy_input)
+            return params
+
+        def fit(self, model, data, key=None):
+            self.prepare_data(data)
+            self.prepare_model(model)
+            self.params = self.apply_init(key=key)
+            self.optim = model.configure_optimizers()
+            # Flax uses optax under the hood for a single state obj TrainState
+            self.state = TrainState.create(apply_fn=model.apply,
+                                           params=self.apply_init(key=key),
+                                           tx=model.configure_optimizers())
+            self.epoch = 0
+            self.train_batch_idx = 0
+            self.val_batch_idx = 0
+            for self.epoch in range(self.max_epochs):
+                self.fit_epoch()
 
     def fit_epoch(self):
         raise NotImplementedError

--- a/chapter_linear-regression/oo-design.md
+++ b/chapter_linear-regression/oo-design.md
@@ -74,6 +74,7 @@ import numpy as np
 from d2l import jax as d2l
 import jax
 import jax.numpy as jnp
+from flax import linen as nn
 from flax.training.train_state import TrainState
 ```
 

--- a/chapter_linear-regression/synthetic-regression-data.md
+++ b/chapter_linear-regression/synthetic-regression-data.md
@@ -47,7 +47,7 @@ import random
 %matplotlib inline
 from d2l import jax as d2l
 import jax
-import jax.numpy as jnp
+from jax import numpy as jnp
 import numpy as np
 import random
 ```
@@ -189,12 +189,11 @@ Beyond that, we set `batch_size` in the built-in data loader
 and let it take care of shuffling examples  efficiently.
 
 :begin_tab:`jax`
-JAX is laser-focused on program transformations and
-accelerator-backed NumPy, so it doesn’t include data loading or munging
-in the JAX library. There are already a lot of great data loaders out
-there, and jax suggests using them instead of reinventing anything.
-Here we'll grab PyTorch’s data loader, and modify it slightly to make
-it work with NumPy arrays.
+JAX is all about NumPy like API with device acceleration and the functional
+transformations, so atleast the current version doesn’t include data loading
+methods. With other  libraries we already have great data loaders out there,
+and JAX suggests using them instead. Here we will grab PyTorch’s data loader,
+and modify it slightly to make it work with JAX.
 :end_tab:
 
 ```{.python .input}
@@ -218,7 +217,7 @@ def get_tensorloader(self, tensors, train, indices=slice(0, None)):
         def jax_collate(batch):
             if isinstance(batch[0], np.ndarray):
                 return jnp.stack(batch)
-            elif isinstance(batch[0], (tuple,list)):
+            elif isinstance(batch[0], (tuple, list)):
                 transposed = zip(*batch)
                 return [jax_collate(samples) for samples in transposed]
             else:

--- a/chapter_linear-regression/weight-decay.md
+++ b/chapter_linear-regression/weight-decay.md
@@ -222,7 +222,7 @@ import tensorflow as tf
 %matplotlib inline
 from d2l import jax as d2l
 import jax
-import jax.numpy as jnp
+from jax import numpy as jnp
 import optax
 ```
 
@@ -254,7 +254,7 @@ class Data(d2l.DataModule):
             noise = d2l.normal((n, 1)) * 0.01
         if tab.selected('jax'):
             self.X = jax.random.normal(jax.random.PRNGKey(0), (n, num_inputs))
-            noise = jax.random.normal(jax.random.PRNGKey(0),(n, 1)) * 0.01
+            noise = jax.random.normal(jax.random.PRNGKey(0), (n, 1)) * 0.01
         w, b = d2l.ones((num_inputs, 1)) * 0.01, 0.05
         self.y = d2l.matmul(self.X, w) + b + noise
 
@@ -320,12 +320,10 @@ trainer = d2l.Trainer(max_epochs=10)
 def train_scratch(lambd):    
     model = WeightDecayScratch(num_inputs=200, lambd=lambd, lr=0.01)
     model.board.yscale='log'
+    trainer.fit(model, data)
     if tab.selected('pytorch', 'mxnet', 'tensorflow'):
-        trainer.fit(model, data)
         print('L2 norm of w:', float(l2_penalty(model.w)))
     if tab.selected('jax'):
-        key = jax.random.PRNGKey(24)
-        trainer.fit(model, data, key)
         print('L2 norm of w:',
               float(l2_penalty(trainer.state.params['params']['w'])))
 ```
@@ -448,7 +446,7 @@ class WeightDecay(d2l.LinearRegression):
     wd: int = 0
     
     def configure_optimizers(self):
-        # weight_decay is not available within `optax.sgd`, but
+        # Weight Decay is not available directly within `optax.sgd`, but
         # optax allows chaining several transformations together
         return optax.chain(optax.additive_weight_decay(self.wd),
                            optax.sgd(self.lr))
@@ -466,13 +464,11 @@ and this work becomes more routine.
 %%tab all
 model = WeightDecay(wd=3, lr=0.01)
 model.board.yscale='log'
+trainer.fit(model, data)
 
 if tab.selected('jax'):
-    key = jax.random.PRNGKey(2)
-    trainer.fit(model, data, key)
     print('L2 norm of w:', float(l2_penalty(model.get_w_b(trainer.state)[0])))
 if tab.selected('pytorch', 'mxnet', 'tensorflow'):
-    trainer.fit(model, data)
     print('L2 norm of w:', float(l2_penalty(model.get_w_b()[0])))
 ```
 

--- a/chapter_linear-regression/weight-decay.md
+++ b/chapter_linear-regression/weight-decay.md
@@ -1,6 +1,6 @@
-```{.python .input  n=1}
+```{.python .input}
 %load_ext d2lbook.tab
-tab.interact_select(['mxnet', 'pytorch', 'tensorflow'])
+tab.interact_select(['mxnet', 'pytorch', 'tensorflow', 'jax'])
 ```
 
 # Weight Decay
@@ -193,7 +193,7 @@ still holds true.
 We can illustrate the benefits of weight decay 
 through a simple synthetic example.
 
-```{.python .input  n=2}
+```{.python .input}
 %%tab mxnet
 %matplotlib inline
 from d2l import mxnet as d2l
@@ -202,7 +202,7 @@ from mxnet.gluon import nn
 npx.set_np()
 ```
 
-```{.python .input  n=3}
+```{.python .input}
 %%tab pytorch
 %matplotlib inline
 from d2l import torch as d2l
@@ -210,11 +210,20 @@ import torch
 from torch import nn
 ```
 
-```{.python .input  n=4}
+```{.python .input}
 %%tab tensorflow
 %matplotlib inline
 from d2l import tensorflow as d2l
 import tensorflow as tf
+```
+
+```{.python .input}
+%%tab jax
+%matplotlib inline
+from d2l import jax as d2l
+import jax
+import jax.numpy as jnp
+import optax
 ```
 
 First, we [**generate some data as before**]:
@@ -231,7 +240,7 @@ we can make the effects of overfitting pronounced,
 by increasing the dimensionality of our problem to $d = 200$
 and working with a small training set with only 20 examples.
 
-```{.python .input  n=5}
+```{.python .input}
 %%tab all
 class Data(d2l.DataModule):
     def __init__(self, num_train, num_val, num_inputs, batch_size):
@@ -243,6 +252,9 @@ class Data(d2l.DataModule):
         if tab.selected('tensorflow'):
             self.X = d2l.normal((n, num_inputs))
             noise = d2l.normal((n, 1)) * 0.01
+        if tab.selected('jax'):
+            self.X = jax.random.normal(jax.random.PRNGKey(0), (n, num_inputs))
+            noise = jax.random.normal(jax.random.PRNGKey(0),(n, 1)) * 0.01
         w, b = d2l.ones((num_inputs, 1)) * 0.01, 0.05
         self.y = d2l.matmul(self.X, w) + b + noise
 
@@ -264,7 +276,7 @@ to the original loss function.
 Perhaps the most convenient way to implement this penalty
 is to square all terms in place and sum them up.
 
-```{.python .input  n=6}
+```{.python .input}
 %%tab all
 def l2_penalty(w):
     return d2l.reduce_sum(w**2) / 2
@@ -276,20 +288,31 @@ In the final model,
 the linear regression and the squared loss have not changed since :numref:`sec_linear_scratch`,
 so we will just define a subclass of `d2l.LinearRegressionScratch`. The only change here is that our loss now includes the penalty term.
 
-```{.python .input  n=7}
-%%tab all
+```{.python .input}
+%%tab pytorch, mxnet, tensorflow
 class WeightDecayScratch(d2l.LinearRegressionScratch):
     def __init__(self, num_inputs, lambd, lr, sigma=0.01):
         super().__init__(num_inputs, lr, sigma)
         self.save_hyperparameters()
         
     def loss(self, y_hat, y):
-        return super().loss(y_hat, y) + self.lambd * l2_penalty(self.w)        
+        return (super().loss(y_hat, y) +
+                self.lambd * l2_penalty(self.w))
+```
+
+```{.python .input}
+%%tab jax
+class WeightDecayScratch(d2l.LinearRegressionScratch):
+    lambd: int = 0
+        
+    def loss(self, params, X, y):
+        return (super().loss(params, X, y) +
+                self.lambd * l2_penalty(params['params']['w']))
 ```
 
 The following code fits our model on the training set with 20 examples and evaluates it on the validation set with 100 examples.
 
-```{.python .input  n=8}
+```{.python .input}
 %%tab all
 data = Data(num_train=20, num_val=100, num_inputs=200, batch_size=5)
 trainer = d2l.Trainer(max_epochs=10)
@@ -297,8 +320,14 @@ trainer = d2l.Trainer(max_epochs=10)
 def train_scratch(lambd):    
     model = WeightDecayScratch(num_inputs=200, lambd=lambd, lr=0.01)
     model.board.yscale='log'
-    trainer.fit(model, data)
-    print('L2 norm of w:', float(l2_penalty(model.w)))
+    if tab.selected('pytorch', 'mxnet', 'tensorflow'):
+        trainer.fit(model, data)
+        print('L2 norm of w:', float(l2_penalty(model.w)))
+    if tab.selected('jax'):
+        key = jax.random.PRNGKey(24)
+        trainer.fit(model, data, key)
+        print('L2 norm of w:',
+              float(l2_penalty(trainer.state.params['params']['w'])))
 ```
 
 ### [**Training without Regularization**]
@@ -309,7 +338,7 @@ Note that we overfit badly,
 decreasing the training error but not the
 validation error---a textbook case of overfitting.
 
-```{.python .input  n=9}
+```{.python .input}
 %%tab all
 train_scratch(0)
 ```
@@ -322,7 +351,7 @@ but the validation error decreases.
 This is precisely the effect
 we expect from regularization.
 
-```{.python .input  n=10}
+```{.python .input}
 %%tab all
 train_scratch(3)
 ```
@@ -370,7 +399,7 @@ the weight decay hyperparameter `wd` and apply it to the layer's weights
 through the `kernel_regularizer` argument.
 :end_tab:
 
-```{.python .input  n=11}
+```{.python .input}
 %%tab mxnet
 class WeightDecay(d2l.LinearRegression):
     def __init__(self, wd, lr):
@@ -385,7 +414,7 @@ class WeightDecay(d2l.LinearRegression):
                              {'learning_rate': self.lr, 'wd': self.wd})
 ```
 
-```{.python .input  n=12}
+```{.python .input}
 %%tab pytorch
 class WeightDecay(d2l.LinearRegression):
     def __init__(self, wd, lr):
@@ -398,7 +427,7 @@ class WeightDecay(d2l.LinearRegression):
                                lr=self.lr, weight_decay=self.wd)
 ```
 
-```{.python .input  n=13}
+```{.python .input}
 %%tab tensorflow
 class WeightDecay(d2l.LinearRegression):
     def __init__(self, wd, lr):
@@ -413,6 +442,18 @@ class WeightDecay(d2l.LinearRegression):
         return super().loss(y_hat, y) + self.net.losses
 ```
 
+```{.python .input}
+%%tab jax
+class WeightDecay(d2l.LinearRegression):
+    wd: int = 0
+    
+    def configure_optimizers(self):
+        # weight_decay is not available within `optax.sgd`, but
+        # optax allows chaining several transformations together
+        return optax.chain(optax.additive_weight_decay(self.wd),
+                           optax.sgd(self.lr))
+```
+
 [**The plot looks similar to that when
 we implemented weight decay from scratch**].
 However, this version runs faster
@@ -421,12 +462,18 @@ benefits that will become more
 pronounced as you address larger problems
 and this work becomes more routine.
 
-```{.python .input  n=14}
+```{.python .input}
 %%tab all
 model = WeightDecay(wd=3, lr=0.01)
 model.board.yscale='log'
-trainer.fit(model, data)
-print('L2 norm of w:', float(l2_penalty(model.get_w_b()[0])))
+
+if tab.selected('jax'):
+    key = jax.random.PRNGKey(2)
+    trainer.fit(model, data, key)
+    print('L2 norm of w:', float(l2_penalty(model.get_w_b(trainer.state)[0])))
+if tab.selected('pytorch', 'mxnet', 'tensorflow'):
+    trainer.fit(model, data)
+    print('L2 norm of w:', float(l2_penalty(model.get_w_b()[0])))
 ```
 
 So far, we only touched upon one notion of

--- a/chapter_preface/index.md
+++ b/chapter_preface/index.md
@@ -471,15 +471,16 @@ import tensorflow as tf
 #@tab jax
 #@save
 from dataclasses import field
-import numpy as np
-import jax
-import jax.numpy as jnp
 import flax
-from jax import random
-from jax import grad, vmap
 from flax import linen as nn
 from flax.training.train_state import TrainState
+import jax
+from jax import numpy as jnp
+from jax import grad, vmap
+import numpy as np
 import optax
+import torch  # Used for dataloading
+import torchvision  # Used for dataloading
 ```
 
 ### Target Audience

--- a/chapter_preface/index.md
+++ b/chapter_preface/index.md
@@ -470,6 +470,7 @@ import tensorflow as tf
 ```{.python .input}
 #@tab jax
 #@save
+from dataclasses import field
 import numpy as np
 import jax
 import jax.numpy as jnp
@@ -477,6 +478,8 @@ import flax
 from jax import random
 from jax import grad, vmap
 from flax import linen as nn
+from flax.training.train_state import TrainState
+import optax
 ```
 
 ### Target Audience

--- a/chapter_preliminaries/autograd.md
+++ b/chapter_preliminaries/autograd.md
@@ -80,7 +80,7 @@ x
 
 ```{.python .input}
 %%tab jax
-import jax.numpy as jnp
+from jax import numpy as jnp
 
 x = jnp.arange(4.0)
 x

--- a/chapter_preliminaries/linear-algebra.md
+++ b/chapter_preliminaries/linear-algebra.md
@@ -89,7 +89,7 @@ x + y, x * y, x / y, x**y
 
 ```{.python .input}
 %%tab jax
-import jax.numpy as jnp
+from jax import numpy as jnp
 
 x = jnp.array(3.0)
 y = jnp.array(2.0)

--- a/chapter_preliminaries/ndarray.md
+++ b/chapter_preliminaries/ndarray.md
@@ -81,7 +81,7 @@ import tensorflow as tf
 ```{.python .input}
 %%tab jax
 import jax
-import jax.numpy as jnp
+from jax import numpy as jnp
 ```
 
 [**A tensor represents a (possibly multi-dimensional) array of numerical values.**]

--- a/chapter_preliminaries/pandas.md
+++ b/chapter_preliminaries/pandas.md
@@ -146,7 +146,7 @@ X, y
 
 ```{.python .input}
 %%tab jax
-import jax.numpy as jnp
+from jax import numpy as jnp
 
 X, y = jnp.array(inputs.values), jnp.array(targets.values)
 X, y

--- a/chapter_preliminaries/probability.md
+++ b/chapter_preliminaries/probability.md
@@ -195,7 +195,7 @@ from tensorflow_probability import distributions as tfd
 from d2l import jax as d2l
 import random
 import jax
-import jax.numpy as jnp
+from jax import numpy as jnp
 import numpy as np
 ```
 

--- a/d2l/jax.py
+++ b/d2l/jax.py
@@ -409,6 +409,33 @@ class SGD(d2l.HyperParameters):
     def __call__():
         return optax.GradientTransformation(self.init, self.update)
 
+class LinearRegression(d2l.Module):
+    """Defined in :numref:`sec_linear_concise`"""
+    lr: float
+
+    def setup(self):
+        self.net = nn.Dense(1, kernel_init=nn.initializers.normal(0.01))
+
+    def __call__(self, X):
+        """The linear regression model.
+    
+        Defined in :numref:`sec_linear_concise`"""
+        return self.net(X)
+
+    def loss(self, params, X, y):
+        """Defined in :numref:`sec_linear_concise`"""
+        y_hat = self.apply(params, X)
+        return d2l.reduce_mean(optax.l2_loss(y_hat, y))
+
+    def configure_optimizers(self):
+        """Defined in :numref:`sec_linear_concise`"""
+        return optax.sgd(self.lr)
+
+    def get_w_b(self, state):
+        """Defined in :numref:`sec_linear_concise`"""
+        net = state.params['params']['net']
+        return net['kernel'], net['bias']
+
 def cpu():
     """Defined in :numref:`sec_use_gpu`"""
     return jax.devices('cpu')[0]

--- a/d2l/jax.py
+++ b/d2l/jax.py
@@ -1,3 +1,14 @@
+DATA_HUB = dict()
+DATA_URL = 'http://d2l-data.s3-accelerate.amazonaws.com/'
+
+import jax
+import flax
+import jax.numpy as jnp
+from flax import linen as nn
+
+nn_Module = nn.Module
+
+
 #################   WARNING   ################
 # The below part is generated automatically through:
 #    d2lbook build lib
@@ -24,11 +35,14 @@ from matplotlib_inline import backend_inline
 
 d2l = sys.modules[__name__]
 
+from dataclasses import field
 import flax
 import jax
 import jax.numpy as jnp
 import numpy as np
+import optax
 from flax import linen as nn
+from flax.training.train_state import TrainState
 from jax import grad, random, vmap
 
 def use_svg_display():
@@ -80,6 +94,207 @@ def plot(X, Y=None, xlabel=None, ylabel=None, legend=[], xlim=None,
     for x, y, fmt in zip(X, Y, fmts):
         axes.plot(x,y,fmt) if len(x) else axes.plot(y,fmt)
     set_axes(axes, xlabel, ylabel, xlim, ylim, xscale, yscale, legend)
+
+def add_to_class(Class):
+    """Defined in :numref:`sec_oo-design`"""
+    def wrapper(obj):
+        setattr(Class, obj.__name__, obj)
+    return wrapper
+
+class HyperParameters:
+    def save_hyperparameters(self, ignore=[]):
+        """Defined in :numref:`sec_oo-design`"""
+        raise NotImplemented
+
+    def save_hyperparameters(self, ignore=[]):
+        """Save function arguments into class attributes.
+    
+        Defined in :numref:`sec_utils`"""
+        frame = inspect.currentframe().f_back
+        _, _, _, local_vars = inspect.getargvalues(frame)
+        self.hparams = {k:v for k, v in local_vars.items()
+                        if k not in set(ignore+['self']) and not k.startswith('_')}
+        for k, v in self.hparams.items():
+            setattr(self, k, v)
+
+class ProgressBoard(d2l.HyperParameters):
+    """Plot data points in animation.
+
+    Defined in :numref:`sec_oo-design`"""
+    def __init__(self, xlabel=None, ylabel=None, xlim=None,
+                 ylim=None, xscale='linear', yscale='linear',
+                 ls=['-', '--', '-.', ':'], colors=['C0', 'C1', 'C2', 'C3'],
+                 fig=None, axes=None, figsize=(3.5, 2.5), display=True):
+        self.save_hyperparameters()
+
+    def draw(self, x, y, label, every_n=1):
+        raise NotImplemented
+
+    def draw(self, x, y, label, every_n=1):
+        """Defined in :numref:`sec_utils`"""
+        Point = collections.namedtuple('Point', ['x', 'y'])
+        if not hasattr(self, 'raw_points'):
+            self.raw_points = collections.OrderedDict()
+            self.data = collections.OrderedDict()
+        if label not in self.raw_points:
+            self.raw_points[label] = []
+            self.data[label] = []
+        points = self.raw_points[label]
+        line = self.data[label]
+        points.append(Point(x, y))
+        if len(points) != every_n:
+            return
+        mean = lambda x: sum(x) / len(x)
+        line.append(Point(mean([p.x for p in points]),
+                          mean([p.y for p in points])))
+        points.clear()
+        if not self.display:
+            return
+        d2l.use_svg_display()
+        if self.fig is None:
+            self.fig = d2l.plt.figure(figsize=self.figsize)
+        plt_lines, labels = [], []
+        for (k, v), ls, color in zip(self.data.items(), self.ls, self.colors):
+            plt_lines.append(d2l.plt.plot([p.x for p in v], [p.y for p in v],
+                                          linestyle=ls, color=color)[0])
+            labels.append(k)
+        axes = self.axes if self.axes else d2l.plt.gca()
+        if self.xlim: axes.set_xlim(self.xlim)
+        if self.ylim: axes.set_ylim(self.ylim)
+        if not self.xlabel: self.xlabel = self.x
+        axes.set_xlabel(self.xlabel)
+        axes.set_ylabel(self.ylabel)
+        axes.set_xscale(self.xscale)
+        axes.set_yscale(self.yscale)
+        axes.legend(plt_lines, labels)
+        display.display(self.fig)
+        display.clear_output(wait=True)
+
+class Module(d2l.nn_Module, d2l.HyperParameters):
+    """Defined in :numref:`sec_oo-design`"""
+    # No need for save_hyperparam when using python dataclass
+    # python dataclasses do not work perfectly well with inheritance
+    plot_train_per_epoch: int = field(default=2, init=False)
+    plot_valid_per_epoch: int = field(default=1, init=False)
+    # Use default_factory to make sure new plots are generated on each run
+    board: ProgressBoard = field(default_factory=lambda: ProgressBoard(),
+                                 init=False)
+    training: bool = field(default=None, init=False)
+
+    def loss(self, y_hat, y):
+        raise NotImplementedError
+
+    # JAX & Flax don't have a forward method like syntax
+    # Flax uses setup and built-in __call__ magic methods for forward pass
+    # Adding here for consistency
+    def forward(self, X, *args, **kwargs):
+        assert hasattr(self, 'net'), 'Neural network is defined'
+        return self.net(X, *args, **kwargs)
+
+    def __call__(self, X, *args, **kwargs):
+        return self.forward(X, *args, **kwargs)
+
+    def plot(self, key, value, train):
+        """Plot a point in animation."""
+        assert hasattr(self, 'trainer'), 'Trainer is not inited'
+        self.board.xlabel = 'epoch'
+        if train:
+            x = self.trainer.train_batch_idx / \
+                self.trainer.num_train_batches
+            n = self.trainer.num_train_batches / \
+                self.plot_train_per_epoch
+        else:
+            x = self.trainer.epoch + 1
+            n = self.trainer.num_val_batches / \
+                self.plot_valid_per_epoch
+        self.board.draw(x, d2l.to(value, d2l.cpu()),
+                        ('train_' if train else 'val_') + key,
+                        every_n=int(n))
+
+    def training_step(self, params, batch):
+        l, grads = jax.value_and_grad(self.loss)(params, *batch[:-1],
+                                                 batch[-1])
+        self.plot("loss", l, train=True)
+        return l, grads
+
+    def validation_step(self, params, batch):
+        l = self.loss(params, *batch[:-1], batch[-1])
+        self.plot("loss", l, train=False)
+
+    def configure_optimizers(self):
+        raise NotImplementedError
+
+class DataModule(d2l.HyperParameters):
+    """Defined in :numref:`sec_oo-design`"""
+    def __init__(self, root='../data', num_workers=4):
+        self.save_hyperparameters()
+
+    def get_dataloader(self, train):
+        raise NotImplementedError
+
+    def train_dataloader(self):
+        return self.get_dataloader(train=True)
+
+    def val_dataloader(self):
+        return self.get_dataloader(train=False)
+
+class Trainer(d2l.HyperParameters):
+    """Defined in :numref:`sec_oo-design`"""
+    def __init__(self, max_epochs, num_gpus=0, gradient_clip_val=0):
+        self.save_hyperparameters()
+        assert num_gpus == 0, 'No GPU support yet'
+
+    def prepare_data(self, data):
+        self.train_dataloader = data.train_dataloader()
+        self.val_dataloader = data.val_dataloader()
+        self.num_train_batches = len(self.train_dataloader)
+        self.num_val_batches = (len(self.val_dataloader)
+                                if self.val_dataloader is not None else 0)
+
+    def prepare_model(self, model):
+        model.trainer = self
+        model.board.xlim = [0, self.max_epochs]
+        self.model = model
+
+    def apply_init(self, **kwargs):
+        if kwargs and 'key' in kwargs and (kwargs['key'] is not None):
+            self.key = kwargs['key']
+        else:
+            self.key = jax.random.PRNGKey(0)  # Avoid, but use as fallback
+        input_shape = next(iter(self.train_dataloader))[0].shape
+        dummy_input = jnp.zeros(input_shape)
+        params = self.model.init(self.key, dummy_input)
+        return params
+
+    def fit(self, model, data, key=None):
+        self.prepare_data(data)
+        self.prepare_model(model)
+        self.params = self.apply_init(key=key)
+        self.optim = model.configure_optimizers()
+        # Flax uses optax under the hood for a single state obj TrainState
+        self.state = TrainState.create(apply_fn=model.apply,
+                                       params=self.apply_init(key=key),
+                                       tx=model.configure_optimizers())
+        self.epoch = 0
+        self.train_batch_idx = 0
+        self.val_batch_idx = 0
+        for self.epoch in range(self.max_epochs):
+            self.fit_epoch()
+
+    def fit_epoch(self):
+        raise NotImplementedError
+
+def cpu():
+    """Defined in :numref:`sec_use_gpu`"""
+    return jax.devices('cpu')[0]
+
+def gpu(i=0):
+    """Defined in :numref:`sec_use_gpu`"""
+    return jax.devices('gpu')[i]
+
+def num_gpus():
+    """Defined in :numref:`sec_use_gpu`"""
+    return jax.device_count('gpu')
 
 
 # Alias defined in config.ini

--- a/d2l/mxnet.py
+++ b/d2l/mxnet.py
@@ -2939,6 +2939,25 @@ def evaluate_accuracy(net, data_iter):
         metric.add(accuracy(net(X), y), d2l.size(y))
     return metric[0] / metric[1]
 
+def show_images(imgs, num_rows, num_cols, titles=None, scale=1.5):
+    """Plot a list of images.
+
+    Defined in :numref:`sec_utils`"""
+    figsize = (num_cols * scale, num_rows * scale)
+    _, axes = d2l.plt.subplots(num_rows, num_cols, figsize=figsize)
+    axes = axes.flatten()
+    for i, (ax, img) in enumerate(zip(axes, imgs)):
+        try:
+            img = d2l.numpy(img)
+        except:
+            pass
+        ax.imshow(img)
+        ax.axes.get_xaxis().set_visible(False)
+        ax.axes.get_yaxis().set_visible(False)
+        if titles:
+            ax.set_title(titles[i])
+    return axes
+
 def linreg(X, w, b):
     """The linear regression model.
 
@@ -2958,25 +2977,6 @@ def get_fashion_mnist_labels(labels):
     text_labels = ['t-shirt', 'trouser', 'pullover', 'dress', 'coat',
                    'sandal', 'shirt', 'sneaker', 'bag', 'ankle boot']
     return [text_labels[int(i)] for i in labels]
-
-def show_images(imgs, num_rows, num_cols, titles=None, scale=1.5):
-    """Plot a list of images.
-
-    Defined in :numref:`sec_utils`"""
-    figsize = (num_cols * scale, num_rows * scale)
-    _, axes = d2l.plt.subplots(num_rows, num_cols, figsize=figsize)
-    axes = axes.flatten()
-    for i, (ax, img) in enumerate(zip(axes, imgs)):
-        try:
-            img = d2l.numpy(img)
-        except:
-            pass
-        ax.imshow(img)
-        ax.axes.get_xaxis().set_visible(False)
-        ax.axes.get_yaxis().set_visible(False)
-        if titles:
-            ax.set_title(titles[i])
-    return axes
 
 class Animator:
     """For plotting data in animation."""

--- a/d2l/tensorflow.py
+++ b/d2l/tensorflow.py
@@ -447,7 +447,6 @@ class Classifier(d2l.Module):
 def cpu():
     """Defined in :numref:`sec_use_gpu`"""
     return tf.device('/CPU:0')
-
 def gpu(i=0):
     """Defined in :numref:`sec_use_gpu`"""
     return tf.device(f'/GPU:{i}')

--- a/d2l/tensorflow.py
+++ b/d2l/tensorflow.py
@@ -1534,6 +1534,25 @@ def evaluate_accuracy(net, data_iter):
         metric.add(accuracy(net(X), y), d2l.size(y))
     return metric[0] / metric[1]
 
+def show_images(imgs, num_rows, num_cols, titles=None, scale=1.5):
+    """Plot a list of images.
+
+    Defined in :numref:`sec_utils`"""
+    figsize = (num_cols * scale, num_rows * scale)
+    _, axes = d2l.plt.subplots(num_rows, num_cols, figsize=figsize)
+    axes = axes.flatten()
+    for i, (ax, img) in enumerate(zip(axes, imgs)):
+        try:
+            img = d2l.numpy(img)
+        except:
+            pass
+        ax.imshow(img)
+        ax.axes.get_xaxis().set_visible(False)
+        ax.axes.get_yaxis().set_visible(False)
+        if titles:
+            ax.set_title(titles[i])
+    return axes
+
 def linreg(X, w, b):
     """The linear regression model.
 
@@ -1553,25 +1572,6 @@ def get_fashion_mnist_labels(labels):
     text_labels = ['t-shirt', 'trouser', 'pullover', 'dress', 'coat',
                    'sandal', 'shirt', 'sneaker', 'bag', 'ankle boot']
     return [text_labels[int(i)] for i in labels]
-
-def show_images(imgs, num_rows, num_cols, titles=None, scale=1.5):
-    """Plot a list of images.
-
-    Defined in :numref:`sec_utils`"""
-    figsize = (num_cols * scale, num_rows * scale)
-    _, axes = d2l.plt.subplots(num_rows, num_cols, figsize=figsize)
-    axes = axes.flatten()
-    for i, (ax, img) in enumerate(zip(axes, imgs)):
-        try:
-            img = d2l.numpy(img)
-        except:
-            pass
-        ax.imshow(img)
-        ax.axes.get_xaxis().set_visible(False)
-        ax.axes.get_yaxis().set_visible(False)
-        if titles:
-            ax.set_title(titles[i])
-    return axes
 
 class Animator:
     """For plotting data in animation."""

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -2692,6 +2692,25 @@ def train_ch6(net, train_iter, test_iter, num_epochs, lr, device):
     print(f'{metric[2] * num_epochs / timer.sum():.1f} examples/sec '
           f'on {str(device)}')
 
+def show_images(imgs, num_rows, num_cols, titles=None, scale=1.5):
+    """Plot a list of images.
+
+    Defined in :numref:`sec_utils`"""
+    figsize = (num_cols * scale, num_rows * scale)
+    _, axes = d2l.plt.subplots(num_rows, num_cols, figsize=figsize)
+    axes = axes.flatten()
+    for i, (ax, img) in enumerate(zip(axes, imgs)):
+        try:
+            img = d2l.numpy(img)
+        except:
+            pass
+        ax.imshow(img)
+        ax.axes.get_xaxis().set_visible(False)
+        ax.axes.get_yaxis().set_visible(False)
+        if titles:
+            ax.set_title(titles[i])
+    return axes
+
 def linreg(X, w, b):
     """The linear regression model.
 
@@ -2711,25 +2730,6 @@ def get_fashion_mnist_labels(labels):
     text_labels = ['t-shirt', 'trouser', 'pullover', 'dress', 'coat',
                    'sandal', 'shirt', 'sneaker', 'bag', 'ankle boot']
     return [text_labels[int(i)] for i in labels]
-
-def show_images(imgs, num_rows, num_cols, titles=None, scale=1.5):
-    """Plot a list of images.
-
-    Defined in :numref:`sec_utils`"""
-    figsize = (num_cols * scale, num_rows * scale)
-    _, axes = d2l.plt.subplots(num_rows, num_cols, figsize=figsize)
-    axes = axes.flatten()
-    for i, (ax, img) in enumerate(zip(axes, imgs)):
-        try:
-            img = d2l.numpy(img)
-        except:
-            pass
-        ax.imshow(img)
-        ax.axes.get_xaxis().set_visible(False)
-        ax.axes.get_yaxis().set_visible(False)
-        if titles:
-            ax.set_title(titles[i])
-    return axes
 
 class Animator:
     """For plotting data in animation."""

--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -201,7 +201,6 @@ class Module(d2l.nn_Module, d2l.HyperParameters):
         self.board.draw(x, d2l.numpy(d2l.to(value, d2l.cpu())),
                         ('train_' if train else 'val_') + key,
                         every_n=int(n))
-
     def training_step(self, batch):
         l = self.loss(self(*batch[:-1]), batch[-1])
         self.plot('loss', l, train=True)


### PR DESCRIPTION
This PR sets up the base for rest of the `JAX` port in D2L. The review may not be straight fwd, I'll share a few pointers below that went into the decision making for the design:

1. We decided to use `flax` and `optax` with `JAX` given they are more popular in the community compared to their counterparts.
2. `JAX` is meant to be written in a very functional form, but this is actually the exact opposite of how D2L V1.0 API works. The d2l api relies on OOP which may not be the natural way for writing pure `JAX` but on the up side, for a beginner once they grab the Lightning like D2L API, things get a lot easier.
3. Flax uses Python DataClasses (introduced in py3.7) which help reduce the boilerplate required to instantiate any class with several attribute fields. Since this is fairly new feature, it is probably not very widely adopted. DataClasses are harder to work with when dealing with inheritance (though this should be much better once we switch to py3.10, then we can utilize `kw_only` attr for the data fields)
4. Since JAX arrays are immutable and inplace operations are prohibited (can still do that with `.at`) but JAX ecosystem avoids inplace ops, this can lead to code being slightly more verbose in some places. It is cumbersome at times to deal with (atleast for someone coming from pytorch/numpy world), but it has it's own benefits in terms of JIT compilation.


This PR also includes the alias configuration setup required to de-duplicate code with a common d2l syntax. 

Note: JAX always runs everything on GPUs by default if it detects a GPU device, this might not play well with [how d2lbook detects](https://github.com/d2l-ai/d2l-book/blob/c850397e738045f51204dd42ae737e37883ef54a/d2lbook/resource.py#L30) which notebooks to run on GPUs and which not. We may need to patch that, if that becomes an issue in the future.