### PR TITLE
Update kaggle-dog.md

### DIFF
--- a/chapter_computer-vision/kaggle-dog.md
+++ b/chapter_computer-vision/kaggle-dog.md
@@ -492,7 +492,7 @@ train(net, train_valid_iter, None, num_epochs, lr, wd, devices, lr_period,
 
 preds = []
 for data, label in test_iter:
-    output = torch.nn.functional.softmax(net(data.to(devices[0])), dim=0)
+    output = torch.nn.functional.softmax(net(data.to(devices[0])), dim=1)
     preds.extend(output.cpu().detach().numpy())
 ids = sorted(os.listdir(
     os.path.join(data_dir, 'train_valid_test', 'test', 'unknown')))


### PR DESCRIPTION
In line 495, softmax should be done on dim=1. Ouput shape of net is (128,120). dim = 0 is the dimension of batchsize. Softmax should be done over dim=1 which is 120 classes.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
