### PR TITLE
Depend on matplotlib-inline instead of ipython to avoid colab warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 import d2l
 
 requirements = [
-    'ipython>=7.23',
+    'matplotlib-inline',
     'jupyter',
     'numpy',
     'matplotlib',

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@ from setuptools import setup, find_packages
 import d2l
 
 requirements = [
-    'matplotlib-inline',
     'jupyter',
     'numpy',
     'matplotlib',
+    'matplotlib-inline',
     'requests',
     'pandas',
     'gym'


### PR DESCRIPTION
colab warns when using ipython>1.0.0, hence avoid depending on newer version of ipython. Instead directly depend on matplotlib-inline to fix #2250 

<img width="1784" alt="image (5)" src="https://user-images.githubusercontent.com/23621655/187294085-06be30e2-f285-47b9-a67f-b11641bbbea2.png">
