### PR TITLE
Bump version to alpha1.post0

### DIFF
--- a/chapter_installation/index.md
+++ b/chapter_installation/index.md
@@ -148,7 +148,7 @@ frequently used functions and classes
 found throughout this book:
 
 ```bash
-pip install d2l==1.0.0a1
+pip install d2l==1.0.0a1.post0
 ```
 
 

--- a/config.ini
+++ b/config.ini
@@ -12,7 +12,7 @@ author = Aston Zhang, Zachary C. Lipton, Mu Li, and Alexander J. Smola
 
 copyright = 2022, All authors. Licensed under CC-BY-SA-4.0 and MIT-0.
 
-release = 1.0.0-alpha1
+release = 1.0.0-alpha1.post0
 
 
 

--- a/d2l/__init__.py
+++ b/d2l/__init__.py
@@ -8,4 +8,4 @@ from d2l import tensorflow as d2l  # Use TensorFlow as the backend
 
 """
 
-__version__ = "1.0.0-alpha1"
+__version__ = "1.0.0-alpha1.post0"


### PR DESCRIPTION
Prepare for `d2l==1.0.0a1.post0` release with minor fixes applied after #2278 #2279.

Only merge after Release PR #2281 passes CI.