### PR TITLE
ViTBlock implementation match schema

### DIFF
--- a/chapter_attention-mechanisms-and-transformers/vision-transformer.md
+++ b/chapter_attention-mechanisms-and-transformers/vision-transformer.md
@@ -145,9 +145,8 @@ class ViTBlock(nn.Module):
         self.mlp = ViTMLP(mlp_num_hiddens, num_hiddens, dropout)
 
     def forward(self, X, valid_lens=None):
-        X = self.ln1(X)
-        return X + self.mlp(self.ln2(
-            X + self.attention(X, X, X, valid_lens)))
+        sum1 = X + self.attention(*([self.ln1(X)]*3), valid_lens)
+        return sum1 + self.mlp(self.ln2(sum1))
 ```
 
 Same as in :numref:`subsec_transformer-encoder`,

--- a/chapter_attention-mechanisms-and-transformers/vision-transformer.md
+++ b/chapter_attention-mechanisms-and-transformers/vision-transformer.md
@@ -146,7 +146,7 @@ class ViTBlock(nn.Module):
 
     def forward(self, X, valid_lens=None):
         X = X + self.attention(*([self.ln1(X)] * 3), valid_lens)
-        return sum1 + self.mlp(self.ln2(sum1))
+        return X + self.mlp(self.ln2(X))
 ```
 
 Same as in :numref:`subsec_transformer-encoder`,

--- a/chapter_attention-mechanisms-and-transformers/vision-transformer.md
+++ b/chapter_attention-mechanisms-and-transformers/vision-transformer.md
@@ -145,7 +145,7 @@ class ViTBlock(nn.Module):
         self.mlp = ViTMLP(mlp_num_hiddens, num_hiddens, dropout)
 
     def forward(self, X, valid_lens=None):
-        sum1 = X + self.attention(*([self.ln1(X)]*3), valid_lens)
+        X = X + self.attention(*([self.ln1(X)] * 3), valid_lens)
         return sum1 + self.mlp(self.ln2(sum1))
 ```
 


### PR DESCRIPTION
Since the schema presented at the top of the section is in agreement with the schema presented in the original paper (https://arxiv.org/abs/2010.11929), I therefore take this schema as the first reference to match the implementation with it. More specifically, I modify the implementation of the forward function of the ViTBlock object that I consider not to match the schema.

**By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.**