### PR TITLE
Typos in chapter_linear-classification/softmax-regression.md

### DIFF
--- a/chapter_linear-classification/softmax-regression.md
+++ b/chapter_linear-classification/softmax-regression.md
@@ -184,7 +184,7 @@ where $\epsilon_i \sim \mathcal{N}(0, \sigma^2)$.
 This is the so-called [probit model](https://en.wikipedia.org/wiki/Probit_model),
 first introduced by :citet:`Fechner.1860`.
 While appealing, it doesn't work quite as well
-or lead to a particularly nice optimization problem,
+nor lead to a particularly nice optimization problem,
 when compared to the softmax.
 
 Another way to accomplish this goal
@@ -242,7 +242,7 @@ problems in deep learning.
 To improve computational efficiency,
 we vectorize calculations in minibatches of data.
 Assume that we are given a minibatch $\mathbf{X} \in \mathbb{R}^{n \times d}$
-of $n$ features with dimensionality (number of inputs) $d$.
+of $n$ inputs with dimensionality (number of features) $d$.
 Moreover, assume that we have $q$ categories in the output.
 Then the weights satisfy $\mathbf{W} \in \mathbb{R}^{d \times q}$
 and the bias satisfies $\mathbf{b} \in \mathbb{R}^{1\times q}$.

--- a/chapter_linear-classification/softmax-regression.md
+++ b/chapter_linear-classification/softmax-regression.md
@@ -242,7 +242,7 @@ problems in deep learning.
 To improve computational efficiency,
 we vectorize calculations in minibatches of data.
 Assume that we are given a minibatch $\mathbf{X} \in \mathbb{R}^{n \times d}$
-of $n$ inputs with dimensionality (number of features) $d$.
+of $n$ examples with dimensionality (number of inputs) $d$.
 Moreover, assume that we have $q$ categories in the output.
 Then the weights satisfy $\mathbf{W} \in \mathbb{R}^{d \times q}$
 and the bias satisfies $\mathbf{b} \in \mathbb{R}^{1\times q}$.


### PR DESCRIPTION
I spot the following oddities

---

*[...] While appealing, it doesn't work quite as well or lead to a particularly nice optimization problem, when compared to the softmax [...]*

Based on the semantic, I think the intent was to say that neither of the two (works well and nice optimisation) are satisfied.
But I read it as the 2nd property is still valid...I mean (maybe it's me) but I read an implied "either" (i.e., either bla-bla-bla OR bla-bla-bla)
Adding _nor_ solve possible misinterpretations
*While appealing, it doesn't work quite as well __nor__ lead to a particularly nice optimization problem, when compared to the softmax.*

---

*[...] Assume that we are given a minibatch $\mathbf{X} \in \mathbb{R}^{n \times d}$ of $n$ features with dimensionality (number of inputs) $d$ [...]*

From Eq 4.1.6, n is the number of input samples not features, so it should be

*Assume that we are given a minibatch $\mathbf{X} \in \mathbb{R}^{n \times d}$ +of $n$ __inputs__ each with dimensionality (number of __features__) $d$.*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
