### PR TITLE
JAX: Add 6.4 Lazy Initialization

### DIFF
--- a/chapter_builders-guide/lazy-init.md
+++ b/chapter_builders-guide/lazy-init.md
@@ -95,8 +95,8 @@ We confirm by attempting to access the parameters below.
 
 :begin_tab:`jax`
 As mentioned previously, parameters and the network definition are decoupled
-in Jax and Flax, the user handles both manually. Flax models are stateless
-hence there is no parameters attribute.
+in Jax and Flax, and the user handles both manually. Flax models are stateless
+hence there is no `parameters` attribute.
 :end_tab:
 
 ```{.python .input}
@@ -204,7 +204,7 @@ It will be used later when default random initializations are not desired.
 :end_tab:
 
 :begin_tab:`jax`
-Parameter Initialization in Flax is always done manually and handled by the
+Parameter initialization in Flax is always done manually and handled by the
 user. The following method sets a PRNG Key and passes in a dummy input to
 initialize the model parameters and return the parameters.
 We have been using it under the hood in the previous sections as well.

--- a/chapter_builders-guide/lazy-init.md
+++ b/chapter_builders-guide/lazy-init.md
@@ -94,7 +94,7 @@ We confirm by attempting to access the parameters below.
 :end_tab:
 
 :begin_tab:`jax`
-As mentioned previously, parameters and the network definition are decoupled
+As mentioned in :numref:`subsec_param-access`, parameters and the network definition are decoupled
 in Jax and Flax, and the user handles both manually. Flax models are stateless
 hence there is no `parameters` attribute.
 :end_tab:

--- a/chapter_builders-guide/lazy-init.md
+++ b/chapter_builders-guide/lazy-init.md
@@ -41,7 +41,7 @@ To begin, let's instantiate an MLP.
 
 ```{.python .input}
 %load_ext d2lbook.tab
-tab.interact_select(['mxnet', 'pytorch', 'tensorflow'])
+tab.interact_select(['mxnet', 'pytorch', 'tensorflow', 'jax'])
 ```
 
 ```{.python .input}
@@ -74,11 +74,30 @@ net = tf.keras.models.Sequential([
 ])
 ```
 
+```{.python .input}
+%%tab jax
+from d2l import jax as d2l
+from flax import linen as nn
+import jax
+from jax import numpy as jnp
+
+net = nn.Sequential([nn.Dense(256), nn.relu, nn.Dense(10)])
+```
+
 At this point, the network cannot possibly know
 the dimensions of the input layer's weights
 because the input dimension remains unknown.
+
+:begin_tab:`mxnet, pytorch, tensorflow`
 Consequently the framework has not yet initialized any parameters.
 We confirm by attempting to access the parameters below.
+:end_tab:
+
+:begin_tab:`jax`
+As mentioned previously, parameters and the network definition are decoupled
+in Jax and Flax, the user handles both manually. Flax models are stateless
+hence there is no parameters attribute.
+:end_tab:
 
 ```{.python .input}
 %%tab mxnet
@@ -155,6 +174,12 @@ net(X)
 [w.shape for w in net.get_weights()]
 ```
 
+```{.python .input}
+%%tab jax
+params = net.init(jax.random.PRNGKey(d2l.get_seed()), jnp.zeros((2, 20)))
+jax.tree_util.tree_map(lambda x: x.shape, params).tree_flatten()
+```
+
 As soon as we know the input dimensionality,
 20,
 the framework can identify the shape of the first layer's weight matrix by plugging in the value of 20.
@@ -178,6 +203,13 @@ and subsequently initializes the parameters.
 It will be used later when default random initializations are not desired.
 :end_tab:
 
+:begin_tab:`jax`
+Parameter Initialization in Flax is always done manually and handled by the
+user. The following method sets a PRNG Key and passes in a dummy input to
+initialize the model parameters and return the parameters.
+We have been using it under the hood in the previous sections as well.
+:end_tab:
+
 ```{.python .input}
 %%tab pytorch
 @d2l.add_to_class(d2l.Module)  #@save
@@ -185,6 +217,18 @@ def apply_init(self, inputs, init=None):
     self.forward(*inputs)
     if init is not None:
         self.net.apply(init)
+```
+
+```{.python .input}
+%%tab jax
+@d2l.add_to_class(d2l.Module)  #@save
+def apply_init(self, dummy_input, **kwargs):
+    if kwargs and 'key' in kwargs and (kwargs['key'] is not None):
+        self.key = kwargs['key']
+    else:
+        self.key = jax.random.PRNGKey(d2l.get_seed())
+    params = self.init(self.key, dummy_input)
+    return params
 ```
 
 ## Summary

--- a/chapter_builders-guide/parameters.md
+++ b/chapter_builders-guide/parameters.md
@@ -76,6 +76,7 @@ net(X).shape
 ```
 
 ## [**Parameter Access**]
+:label:`subsec_param-access`
 
 Let's start with how to access parameters
 from the models that you already know.

--- a/chapter_linear-regression/oo-design.md
+++ b/chapter_linear-regression/oo-design.md
@@ -268,6 +268,10 @@ class Module(d2l.nn_Module, d2l.HyperParameters):  #@save
         def validation_step(self, params, batch):
             l = self.loss(params, *batch[:-1], batch[-1])
             self.plot('loss', l, train=False)
+        
+        def apply_init(self, dummy_input, **kwargs):
+            """To be defined later in :numref:`sec_lazy_init`"""
+            raise NotImplementedError
 
     def configure_optimizers(self):
         raise NotImplementedError
@@ -350,23 +354,14 @@ class Trainer(d2l.HyperParameters):  #@save
                 self.fit_epoch()
 
     if tab.selected('jax'):
-        def apply_init(self, **kwargs):
-            if kwargs and 'key' in kwargs and (kwargs['key'] is not None):
-                self.key = kwargs['key']
-            else:
-                self.key = jax.random.PRNGKey(d2l.get_seed())
-            input_shape = next(iter(self.train_dataloader))[0].shape
-            dummy_input = jnp.zeros(input_shape)
-            params = self.model.init(self.key, dummy_input)
-            return params
-
         def fit(self, model, data, key=None):
             self.prepare_data(data)
             self.prepare_model(model)
             self.optim = model.configure_optimizers()
+            dummy_input = next(iter(self.train_dataloader))[0]
             # Flax uses optax under the hood for a single state obj TrainState
             self.state = TrainState.create(apply_fn=model.apply,
-                                           params=self.apply_init(key=key),
+                                           params=model.apply_init(dummy_input, key=key),
                                            tx=model.configure_optimizers())
             self.epoch = 0
             self.train_batch_idx = 0


### PR DESCRIPTION
This PR adds the section on lazy initialization for JAX. I've also taken this opportunity to refactor the method `apply_init` and move it to a more suitable class i.e `d2l.Module` instead of `d2l.Trainer`. Even though this method is a must for any Flax/Jax implementation, since the user has to handle the param inits, I've postponed it's implementation to a more suitable section i.e Lazy Init (similar to how it is done in PyTorch). But please note that we still make use of this function even before section 6.4.

This is like how we define `save_hyperparameters` only in section [20.7. Utility Functions and Classes](https://d2l.ai/chapter_appendix-tools-for-deep-learning/utils.html), but we start using it as soon as section [3.2. Object-Oriented Design for Implementation](https://d2l.ai/chapter_linear-regression/oo-design.html).

Also I think it would be best to rerun all the JAX notebooks with this change just to make sure that this change in API doesn't break anything. I'll wait to rerun CI (with cache cleaned) on this, after merging the other chapter 6 PRs that are open atm.