### PR TITLE
JAX: Add dropout.md

### DIFF
--- a/chapter_builders-guide/lazy-init.md
+++ b/chapter_builders-guide/lazy-init.md
@@ -226,7 +226,8 @@ def apply_init(self, dummy_input, **kwargs):
     if kwargs and 'key' in kwargs and (kwargs['key'] is not None):
         self.key = kwargs['key']
     else:
-        self.key = jax.random.PRNGKey(d2l.get_seed())
+        # Dropout key is only used for models with dropout layers
+        self.key = {'params': d2l.get_key(), 'dropout': d2l.get_key()}
     params = self.init(self.key, dummy_input)
     return params
 ```

--- a/chapter_linear-classification/softmax-regression-concise.md
+++ b/chapter_linear-classification/softmax-regression-concise.md
@@ -190,8 +190,8 @@ def loss(self, Y_hat, Y, averaged=True):
 ```{.python .input}
 %%tab jax
 @d2l.add_to_class(d2l.Classifier)  #@save
-def loss(self, params, X, Y, averaged=True):
-    Y_hat = self.apply(params, X)
+def loss(self, params, X, Y, averaged=True, rngs=None):
+    Y_hat = self.apply(params, X, rngs=rngs)
     Y_hat = d2l.reshape(Y_hat, (-1, Y_hat.shape[-1]))
     fn = optax.softmax_cross_entropy_with_integer_labels
     return fn(Y_hat, Y).mean() if averaged else fn(Y_hat, Y)

--- a/chapter_linear-regression/oo-design.md
+++ b/chapter_linear-regression/oo-design.md
@@ -196,7 +196,6 @@ class Module(d2l.nn_Module, d2l.HyperParameters):  #@save
         # Use default_factory to make sure new plots are generated on each run
         board: ProgressBoard = field(default_factory=lambda: ProgressBoard(),
                                      init=False)
-        training: bool = field(default=None, init=False)
 
     def loss(self, y_hat, y):
         raise NotImplementedError

--- a/chapter_multilayer-perceptrons/dropout.md
+++ b/chapter_multilayer-perceptrons/dropout.md
@@ -201,9 +201,7 @@ from flax import linen as nn
 import jax
 from jax import numpy as jnp
 
-get_key = lambda: jax.random.PRNGKey(d2l.get_seed())  #@save
-
-def dropout_layer(X, dropout, key=get_key()):
+def dropout_layer(X, dropout, key=d2l.get_key()):
     assert 0 <= dropout <= 1
     if dropout == 1: return jnp.zeros_like(X)
     mask = jax.random.uniform(key, X.shape) > dropout
@@ -427,7 +425,7 @@ class DropoutMLP(d2l.Classifier):
         return nn.Dense(self.num_outputs)(x)
 
 @d2l.add_to_class(DropoutMLP)
-def loss(self, params, X, Y, averaged=True, rngs={'dropout': get_key()}):
+def loss(self, params, X, Y, averaged=True, rngs={'dropout': d2l.get_key()}):
     return super(DropoutMLP, self).loss(params, X, Y, averaged, rngs)
 ```
 
@@ -436,10 +434,7 @@ Next, we [**train the model**].
 ```{.python .input}
 %%tab all
 model = DropoutMLP(**hparams)
-if tab.selected('pytorch', 'mxnet', 'tensorflow'):
-    trainer.fit(model, data)
-if tab.selected('jax'):
-    trainer.fit(model, data, key={'params': get_key(), 'dropout': get_key()})
+trainer.fit(model, data)
 ```
 
 ## Summary

--- a/chapter_multilayer-perceptrons/dropout.md
+++ b/chapter_multilayer-perceptrons/dropout.md
@@ -1,6 +1,6 @@
 ```{.python .input}
 %load_ext d2lbook.tab
-tab.interact_select(['mxnet', 'pytorch', 'tensorflow'])
+tab.interact_select(['mxnet', 'pytorch', 'tensorflow', 'jax'])
 ```
 
 # Dropout
@@ -194,6 +194,22 @@ def dropout_layer(X, dropout):
     return tf.cast(mask, dtype=tf.float32) * X / (1.0 - dropout)
 ```
 
+```{.python .input}
+%%tab jax
+from d2l import jax as d2l
+from flax import linen as nn
+import jax
+from jax import numpy as jnp
+
+get_key = lambda: jax.random.PRNGKey(d2l.get_seed())  #@save
+
+def dropout_layer(X, dropout, key=get_key()):
+    assert 0 <= dropout <= 1
+    if dropout == 1: return jnp.zeros_like(X)
+    mask = jax.random.uniform(key, X.shape) > dropout
+    return jnp.asarray(mask, dtype=jnp.float32) * X / (1.0 - dropout)
+```
+
 We can [**test out the `dropout_layer` function on a few examples**].
 In the following lines of code,
 we pass our input `X` through the dropout operation,
@@ -207,6 +223,8 @@ if tab.selected('pytorch'):
     X = torch.arange(16, dtype = torch.float32).reshape((2, 8))
 if tab.selected('tensorflow'):
     X = tf.reshape(tf.range(16, dtype=tf.float32), (2, 8))
+if tab.selected('jax'):
+    X = jnp.arange(16, dtype=jnp.float32).reshape(2, 8)
 print('dropout_p = 0:', dropout_layer(X, 0))
 print('dropout_p = 0.5:', dropout_layer(X, 0.5))
 print('dropout_p = 1:', dropout_layer(X, 1))
@@ -275,12 +293,39 @@ class DropoutMLPScratch(d2l.Classifier):
         self.lin1 = tf.keras.layers.Dense(num_hiddens_1, activation='relu')
         self.lin2 = tf.keras.layers.Dense(num_hiddens_2, activation='relu')
         self.lin3 = tf.keras.layers.Dense(num_outputs)
-        
+
     def forward(self, X):
         H1 = self.lin1(tf.reshape(X, (X.shape[0], -1)))
         if self.training:
             H1 = dropout_layer(H1, self.dropout_1)
         H2 = self.lin2(H1)
+        if self.training:
+            H2 = dropout_layer(H2, self.dropout_2)
+        return self.lin3(H2)
+```
+
+```{.python .input}
+%%tab jax
+class DropoutMLPScratch(d2l.Classifier):
+    num_hiddens_1: int
+    num_hiddens_2: int
+    num_outputs: int
+    dropout_1: float
+    dropout_2: float
+    lr: float
+    training: bool
+
+    def setup(self):
+        self.lin1 = nn.Dense(self.num_hiddens_1)
+        self.lin2 = nn.Dense(self.num_hiddens_2)
+        self.lin3 = nn.Dense(self.num_outputs)
+        self.relu = nn.relu
+
+    def forward(self, X):
+        H1 = self.relu(self.lin1(X.reshape(X.shape[0], -1)))
+        if self.training:
+            H1 = dropout_layer(H1, self.dropout_1)
+        H2 = self.relu(self.lin2(H1))
         if self.training:
             H2 = dropout_layer(H2, self.dropout_2)
         return self.lin3(H2)
@@ -292,8 +337,12 @@ The following is similar to the training of MLPs described previously.
 
 ```{.python .input}
 %%tab all
-hparams = {'num_outputs':10, 'num_hiddens_1':256, 'num_hiddens_2':256, 
-           'dropout_1':0.5, 'dropout_2':0.5, 'lr':0.1}
+if tab.selected('pytorch', 'mxnet', 'tensorflow'):
+    hparams = {'num_outputs':10, 'num_hiddens_1':256, 'num_hiddens_2':256,
+               'dropout_1':0.5, 'dropout_2':0.5, 'lr':0.1}
+if tab.selected('jax'):
+    hparams = {'num_outputs':10, 'num_hiddens_1':256, 'num_hiddens_2':256,
+               'dropout_1':0.5, 'dropout_2':0.5, 'lr':0.1, 'training': True}
 model = DropoutMLPScratch(**hparams)
 data = d2l.FashionMNIST(batch_size=256)
 trainer = d2l.Trainer(max_epochs=10)
@@ -358,12 +407,39 @@ class DropoutMLP(d2l.Classifier):
             tf.keras.layers.Dense(num_outputs)])
 ```
 
+```{.python .input}
+%%tab jax
+class DropoutMLP(d2l.Classifier):
+    num_hiddens_1: int
+    num_hiddens_2: int
+    num_outputs: int
+    dropout_1: float
+    dropout_2: float
+    lr: float
+    training: bool
+
+    @nn.compact
+    def __call__(self, X):
+        x = nn.relu(nn.Dense(self.num_hiddens_1)(X.reshape((X.shape[0], -1))))
+        x = nn.Dropout(self.dropout_1, deterministic=not self.training)(x)
+        x = nn.relu(nn.Dense(self.num_hiddens_2)(x))
+        x = nn.Dropout(self.dropout_2, deterministic=not self.training)(x)
+        return nn.Dense(self.num_outputs)(x)
+
+@d2l.add_to_class(DropoutMLP)
+def loss(self, params, X, Y, averaged=True, rngs={'dropout': get_key()}):
+    return super(DropoutMLP, self).loss(params, X, Y, averaged, rngs)
+```
+
 Next, we [**train the model**].
 
 ```{.python .input}
 %%tab all
 model = DropoutMLP(**hparams)
-trainer.fit(model, data)
+if tab.selected('pytorch', 'mxnet', 'tensorflow'):
+    trainer.fit(model, data)
+if tab.selected('jax'):
+    trainer.fit(model, data, key={'params': get_key(), 'dropout': get_key()})
 ```
 
 ## Summary

--- a/d2l/jax.py
+++ b/d2l/jax.py
@@ -184,7 +184,6 @@ class Module(d2l.nn_Module, d2l.HyperParameters):
     # Use default_factory to make sure new plots are generated on each run
     board: ProgressBoard = field(default_factory=lambda: ProgressBoard(),
                                  init=False)
-    training: bool = field(default=None, init=False)
 
     def loss(self, y_hat, y):
         raise NotImplementedError
@@ -520,12 +519,14 @@ class Classifier(d2l.Module):
         compare = d2l.astype(preds == d2l.reshape(Y, -1), d2l.float32)
         return d2l.reduce_mean(compare) if averaged else compare
 
-    def loss(self, params, X, Y, averaged=True):
+    def loss(self, params, X, Y, averaged=True, rngs=None):
         """Defined in :numref:`sec_softmax_concise`"""
-        Y_hat = self.apply(params, X)
+        Y_hat = self.apply(params, X, rngs=rngs)
         Y_hat = d2l.reshape(Y_hat, (-1, Y_hat.shape[-1]))
         fn = optax.softmax_cross_entropy_with_integer_labels
         return fn(Y_hat, Y).mean() if averaged else fn(Y_hat, Y)
+
+get_key = lambda: jax.random.PRNGKey(d2l.get_seed())
 
 def cpu():
     """Defined in :numref:`sec_use_gpu`"""

--- a/d2l/jax.py
+++ b/d2l/jax.py
@@ -8,6 +8,7 @@ from flax import linen as nn
 import random
 
 get_seed = lambda: random.randint(0, 1e6)
+get_key = lambda: jax.random.PRNGKey(get_seed())
 
 nn_Module = nn.Module
 
@@ -525,8 +526,6 @@ class Classifier(d2l.Module):
         Y_hat = d2l.reshape(Y_hat, (-1, Y_hat.shape[-1]))
         fn = optax.softmax_cross_entropy_with_integer_labels
         return fn(Y_hat, Y).mean() if averaged else fn(Y_hat, Y)
-
-get_key = lambda: jax.random.PRNGKey(d2l.get_seed())
 
 def cpu():
     """Defined in :numref:`sec_use_gpu`"""

--- a/d2l/jax.py
+++ b/d2l/jax.py
@@ -242,7 +242,8 @@ class Module(d2l.nn_Module, d2l.HyperParameters):
         if kwargs and 'key' in kwargs and (kwargs['key'] is not None):
             self.key = kwargs['key']
         else:
-            self.key = jax.random.PRNGKey(d2l.get_seed())
+            # Dropout key is only used for models with dropout layers
+            self.key = {'params': d2l.get_key(), 'dropout': d2l.get_key()}
         params = self.init(self.key, dummy_input)
         return params
 


### PR DESCRIPTION
*Description of changes:*
Note that dropout in flax requires passing rngs with a specific 'dropout' key. This is not required otherwise and is set to None by default. This PR handles that. In the future, we can refactor this further to make use of `make_rng` to make sure every dropout layer has a separate generation.

I also save a utility lambda function which can be used in later sections called `get_key`.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
