### PR TITLE
Fix typo

### DIFF
--- a/chapter_linear-regression/linear-regression-scratch.md
+++ b/chapter_linear-regression/linear-regression-scratch.md
@@ -100,7 +100,7 @@ $\mathbf{Xw}$ is a vector and $b$ is a scalar.
 Due to the broadcasting mechanism 
 (see :numref:`subsec_broadcasting`),
 when we add a vector and a scalar,
-the scalar is added to each component of the matrix.
+the scalar is added to each component of the vector.
 The resulting `forward` function 
 is registered as a method in the `LinearRegressionScratch` class
 via `add_to_class` (introduced in :numref:`oo-design-utilities`).

--- a/chapter_linear-regression/linear-regression-scratch.md
+++ b/chapter_linear-regression/linear-regression-scratch.md
@@ -91,15 +91,15 @@ class LinearRegressionScratch(d2l.Module):  #@save
 
 Next, we must [**define our model,
 relating its input and parameters to its output.**]
-For our linear model we simply take the matrix-vector product
+For our linear model we simply take the matrix-matrix product
 of the input features $\mathbf{X}$ 
 and the model weights $\mathbf{w}$,
 and add the offset $b$ to each example.
-$\mathbf{Xw}$ is a vector and $b$ is a scalar.
+$\mathbf{Xw}$ is a matrix and $b$ is a scalar.
 Due to the broadcasting mechanism 
 (see :numref:`subsec_broadcasting`),
-when we add a vector and a scalar,
-the scalar is added to each component of the vector.
+when we add a matrix and a scalar,
+the scalar is added to each component of the matrix.
 The resulting `forward` function 
 is registered as a method in the `LinearRegressionScratch` class
 via `add_to_class` (introduced in :numref:`oo-design-utilities`).

--- a/chapter_linear-regression/linear-regression-scratch.md
+++ b/chapter_linear-regression/linear-regression-scratch.md
@@ -91,7 +91,8 @@ class LinearRegressionScratch(d2l.Module):  #@save
 
 Next, we must [**define our model,
 relating its input and parameters to its output.**]
-For our linear model we simply take the matrix-matrix product
+Using the same notation in :eqref:`eq_linreg-y-vec`,
+for our linear model we simply take the matrix-vector product
 of the input features $\mathbf{X}$ 
 and the model weights $\mathbf{w}$,
 and add the offset $b$ to each example.

--- a/chapter_linear-regression/linear-regression-scratch.md
+++ b/chapter_linear-regression/linear-regression-scratch.md
@@ -99,7 +99,7 @@ and add the offset $b$ to each example.
 $\mathbf{Xw}$ is a vector and $b$ is a scalar.
 Due to the broadcasting mechanism 
 (see :numref:`subsec_broadcasting`),
-when we add a matrix and a scalar,
+when we add a vector and a scalar,
 the scalar is added to each component of the matrix.
 The resulting `forward` function 
 is registered as a method in the `LinearRegressionScratch` class

--- a/chapter_linear-regression/linear-regression-scratch.md
+++ b/chapter_linear-regression/linear-regression-scratch.md
@@ -96,7 +96,7 @@ for our linear model we simply take the matrix-vector product
 of the input features $\mathbf{X}$ 
 and the model weights $\mathbf{w}$,
 and add the offset $b$ to each example.
-$\mathbf{Xw}$ is a matrix and $b$ is a scalar.
+$\mathbf{Xw}$ is a vector and $b$ is a scalar.
 Due to the broadcasting mechanism 
 (see :numref:`subsec_broadcasting`),
 when we add a matrix and a scalar,


### PR DESCRIPTION
Here both X and w are matrix. As defined in the code, w's shape is (num_inputs, 1). Xw is a matrix-matrix product, instead of a matrix-vector product.  

For d2l.matmul(X, self.w), a matrix-vector product returns a 1-d vector, while a matrix-matrix product returns a multi-dimension matrix.  Thus it is important to fix the typo because it is confusing.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
