### PR TITLE
Remove unnecessary .reshape()

### DIFF
--- a/chapter_linear-regression/linear-regression-scratch.md
+++ b/chapter_linear-regression/linear-regression-scratch.md
@@ -130,7 +130,7 @@ among all examples in the minibatch.
 %%tab all
 @d2l.add_to_class(LinearRegressionScratch)  #@save
 def loss(self, y_hat, y):
-    l = (y_hat - d2l.reshape(y, y_hat.shape)) ** 2 / 2
+    l = (y_hat - y) ** 2 / 2
     return d2l.reduce_mean(l)
 ```
 


### PR DESCRIPTION
*Description of changes:*
The .reshape() here is unnecessary, because both y_hat and y have the same shape (32, 1). 

The additional .reshape() is confusing to the beginners.  
When I started to read the book, I struggled with this .reshape() and spent a lot of time trying to understand why it is needed. But it is actually not needed. I hope the future beginners do not have to waste their time on this. 

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
