### PR TITLE
JAX: Fix num_gpus calculation on systems with GPUs

### DIFF
--- a/chapter_builders-guide/use-gpu.md
+++ b/chapter_builders-guide/use-gpu.md
@@ -189,7 +189,10 @@ def num_gpus():  #@save
     if tab.selected('tensorflow'):
         return len(tf.config.experimental.list_physical_devices('GPU'))
     if tab.selected('jax'):
-        return jax.device_count() - 1  # Exclude CPU device
+        try:
+            return jax.device_count('gpu')
+        except:
+            return 0  # No GPU backend found
 
 num_gpus()
 ```

--- a/d2l/jax.py
+++ b/d2l/jax.py
@@ -563,7 +563,10 @@ def gpu(i=0):
 
 def num_gpus():
     """Defined in :numref:`sec_use_gpu`"""
-    return jax.device_count() - 1  # Exclude CPU device
+    try:
+        return jax.device_count('gpu')
+    except:
+        return 0  # No GPU backend found
 
 def try_gpu(i=0):
     """Return gpu(i) if exists, otherwise return cpu().


### PR DESCRIPTION
`jax.device_count() - 1` to exclude CPU seems incorrect since JAX defines the default device backend as GPU in a machine with GPUs. But then, on machines without GPUs it just returns one since the default device backend is CPU.

Hence we need to use `jax.device_count('gpu')`, which raises runtime error on a system without GPUs. Thus the `try-except` statement.
