### PR TITLE
Update tensor indexing

### DIFF
--- a/chapter_recurrent-neural-networks/language-model.md
+++ b/chapter_recurrent-neural-networks/language-model.md
@@ -265,7 +265,7 @@ def __init__(self, batch_size, num_steps, num_train=10000, num_val=5000):
     self.save_hyperparameters()
     corpus, self.vocab = self.build(self._download())
     array = d2l.tensor([corpus[i:i+num_steps+1] 
-                        for i in range(len(corpus) - num_steps)])
+                        for i in range(len(corpus)-num_steps)])
     self.X, self.Y = array[:,:-1], array[:,1:]
 ```
 

--- a/chapter_recurrent-neural-networks/language-model.md
+++ b/chapter_recurrent-neural-networks/language-model.md
@@ -264,7 +264,7 @@ def __init__(self, batch_size, num_steps, num_train=10000, num_val=5000):
     super(d2l.TimeMachine, self).__init__()
     self.save_hyperparameters()
     corpus, self.vocab = self.build(self._download())
-    array = d2l.tensor([corpus[i : i + num_steps + 1] 
+    array = d2l.tensor([corpus[i:i+num_steps+1] 
                         for i in range(len(corpus) - num_steps)])
     self.X, self.Y = array[:,:-1], array[:,1:]
 ```

--- a/chapter_recurrent-neural-networks/language-model.md
+++ b/chapter_recurrent-neural-networks/language-model.md
@@ -264,8 +264,8 @@ def __init__(self, batch_size, num_steps, num_train=10000, num_val=5000):
     super(d2l.TimeMachine, self).__init__()
     self.save_hyperparameters()
     corpus, self.vocab = self.build(self._download())
-    array = d2l.tensor([corpus[i:i+num_steps+1] 
-                        for i in range(0, len(corpus)-num_steps-1)])
+    array = d2l.tensor([corpus[i : i + num_steps + 1] 
+                        for i in range(len(corpus) - num_steps)])
     self.X, self.Y = array[:,:-1], array[:,1:]
 ```
 


### PR DESCRIPTION
*Description of changes:*
1. Remove the first "0" in the range(), because it is unnecessary. For Python range() Function, the default starting index is 0. See [here](https://www.w3schools.com/python/ref_func_range.asp#:~:text=The%20range()%20function%20returns,stops%20before%20a%20specified%20number.).

2. Remove the last "-1" in the range(), because it is unnecessary. IMO, the intention of "-1" here is to prevent `i + num_steps + 1` from going out of range. Without the "-1", the code will still prevent that because the second parameter of range() is a position to stop and is not included in the iteration. i.e. the iteration stops at the index right before the second parameter. 
See [here](https://www.w3schools.com/python/ref_func_range.asp#:~:text=The%20range()%20function%20returns,stops%20before%20a%20specified%20number.) as well.
I can give a quick example to show why the removal of the last "-1" is correct. Let me know if you need it. 

3. Minor formatting to add more space to make the line more readable. 

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
