### PR TITLE
Remove unnecessary self.b and self.n

### DIFF
--- a/chapter_recurrent-neural-networks/language-model.md
+++ b/chapter_recurrent-neural-networks/language-model.md
@@ -274,8 +274,8 @@ we will randomly sample
 pairs of input sequences and target sequences
 in minibatches.
 The following data loader randomly generates a minibatch from the dataset each time.
-The argument `batch_size` specifies the number of subsequence examples (`self.b`) in each minibatch
-and `num_steps` is the subsequence length in tokens (`self.n`).
+The argument `batch_size` specifies the number of subsequence examples in each minibatch
+and `num_steps` is the subsequence length in tokens.
 
 ```{.python .input  n=6}
 %%tab all


### PR DESCRIPTION
*Description of changes:*
The names `self.b` and `self.n` are never used again in the chapter 9 (from 9.1 to 9.7). They seem entirely unrelated to the code or the text and confuse the readers. When I saw the two variables here for the first time, I was like "did I miss something? what do they mean?". 

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
