### PR TITLE
JAX: Switch to tfds dataloading for performance

### DIFF
--- a/chapter_linear-classification/image-classification-dataset.md
+++ b/chapter_linear-classification/image-classification-dataset.md
@@ -60,8 +60,8 @@ import jax
 from jax import numpy as jnp
 import numpy as np
 import time
-import tensorflow as tf  # Used for dataloading
-import tensorflow_datasets as tfds  # Used for dataloading
+import tensorflow as tf
+import tensorflow_datasets as tfds
 
 d2l.use_svg_display()
 ```

--- a/chapter_linear-classification/image-classification-dataset.md
+++ b/chapter_linear-classification/image-classification-dataset.md
@@ -60,8 +60,8 @@ import jax
 from jax import numpy as jnp
 import numpy as np
 import time
-import torch
-import torchvision
+import tensorflow as tf  # Used for dataloading
+import tensorflow_datasets as tfds  # Used for dataloading
 
 d2l.use_svg_display()
 ```
@@ -99,41 +99,12 @@ class FashionMNIST(d2l.DataModule):  #@save
 ```
 
 ```{.python .input}
-%%tab tensorflow
+%%tab tensorflow, jax
 class FashionMNIST(d2l.DataModule):  #@save
     def __init__(self, batch_size=64, resize=(28, 28)):
         super().__init__()
         self.save_hyperparameters()
         self.train, self.val = tf.keras.datasets.fashion_mnist.load_data()
-```
-
-```{.python .input}
-%%tab jax
-class ToArray:  #@save
-    """Convert a PIL Image to numpy.ndarray."""
-    def __init__(self):
-        pass
-
-    def __call__(self, pic):
-        img = np.asarray(pic) / 255  # Convert PIL to ndarray & normalize
-        # Use channel last format
-        img = img.reshape(img.shape[0], img.shape[1], len(pic.getbands()))
-        return img
-```
-
-```{.python .input}
-%%tab jax
-class FashionMNIST(d2l.DataModule):  #@save
-    def __init__(self, batch_size=64, resize=(28, 28)):
-        super().__init__()
-        self.save_hyperparameters()
-        trans = torchvision.transforms.Compose(
-                                    [torchvision.transforms.Resize(resize),
-                                     ToArray()])
-        self.train = torchvision.datasets.FashionMNIST(
-            root=self.root, train=True, transform=trans, download=True)
-        self.val = torchvision.datasets.FashionMNIST(
-            root=self.root, train=False, transform=trans, download=True)
 ```
 
 Fashion-MNIST consists of images from 10 categories, each represented
@@ -143,13 +114,13 @@ Consequently the training set and the test set
 contain 60,000 and 10,000 images, respectively.
 
 ```{.python .input}
-%%tab mxnet, pytorch, jax
+%%tab mxnet, pytorch
 data = FashionMNIST(resize=(32, 32))
 len(data.train), len(data.val)
 ```
 
 ```{.python .input}
-%%tab tensorflow
+%%tab tensorflow, jax
 data = FashionMNIST(resize=(32, 32))
 len(data.train[0]), len(data.val[0])
 ```
@@ -204,7 +175,7 @@ def get_dataloader(self, train):
 ```
 
 ```{.python .input}
-%%tab tensorflow
+%%tab tensorflow, jax
 @d2l.add_to_class(FashionMNIST)  #@save
 def get_dataloader(self, train):
     data = self.train if train else self.val
@@ -212,25 +183,13 @@ def get_dataloader(self, train):
                             tf.cast(y, dtype='int32'))
     resize_fn = lambda X, y: (tf.image.resize_with_pad(X, *self.resize), y)
     shuffle_buf = len(data[0]) if train else 1
-    return tf.data.Dataset.from_tensor_slices(process(*data)).batch(
-        self.batch_size).map(resize_fn).shuffle(shuffle_buf)
-```
-
-```{.python .input}
-%%tab jax
-@d2l.add_to_class(FashionMNIST)  #@save
-def get_dataloader(self, train):
-    def jax_collate(batch):
-        if isinstance(batch[0], np.ndarray):
-            return jnp.stack(batch)
-        elif isinstance(batch[0], (tuple, list)):
-            transposed = zip(*batch)
-            return [jax_collate(samples) for samples in transposed]
-        else:
-            return jnp.array(batch)
-    data = self.train if train else self.val
-    return torch.utils.data.DataLoader(data, self.batch_size, shuffle=train,
-                                       collate_fn=jax_collate, num_workers=0)
+    if tab.selected('tensorflow'):
+        return tf.data.Dataset.from_tensor_slices(process(*data)).batch(
+            self.batch_size).map(resize_fn).shuffle(shuffle_buf)
+    if tab.selected('jax'):
+        return tfds.as_numpy(
+            tf.data.Dataset.from_tensor_slices(process(*data)).batch(
+                self.batch_size).map(resize_fn).shuffle(shuffle_buf))
 ```
 
 To see how this works, let's load a minibatch of images by invoking the newly-added `train_dataloader` method. It contains 64 images.
@@ -273,7 +232,7 @@ def visualize(self, batch, nrows=1, ncols=8, labels=[]):
     X, y = batch
     if not labels:
         labels = self.text_labels(y)
-    if tab.selected('mxnet') or tab.selected('pytorch'):
+    if tab.selected('mxnet', 'pytorch'):
         d2l.show_images(X.squeeze(1), nrows, ncols, titles=labels)
     if tab.selected('tensorflow'):
         d2l.show_images(tf.squeeze(X), nrows, ncols, titles=labels)

--- a/chapter_linear-regression/oo-design.md
+++ b/chapter_linear-regression/oo-design.md
@@ -299,11 +299,11 @@ The `DataModule` class is the base class for data. Quite frequently the `__init_
 ```{.python .input}
 %%tab all
 class DataModule(d2l.HyperParameters):  #@save
-    if tab.selected('mxnet', 'pytorch', 'jax'):
+    if tab.selected('mxnet', 'pytorch'):
         def __init__(self, root='../data', num_workers=4):
             self.save_hyperparameters()
 
-    if tab.selected('tensorflow'):
+    if tab.selected('tensorflow', 'jax'):
         def __init__(self, root='../data'):
             self.save_hyperparameters()
 

--- a/chapter_linear-regression/synthetic-regression-data.md
+++ b/chapter_linear-regression/synthetic-regression-data.md
@@ -194,7 +194,7 @@ and let it take care of shuffling examples  efficiently.
 JAX is all about NumPy like API with device acceleration and the functional
 transformations, so at least the current version doesn’t include data loading
 methods. With other  libraries we already have great data loaders out there,
-and JAX suggests using them instead. Here we will grab Tensorflow’s data loader,
+and JAX suggests using them instead. Here we will grab TensorFlow’s data loader,
 and modify it slightly to make it work with JAX.
 :end_tab:
 
@@ -212,8 +212,8 @@ def get_tensorloader(self, tensors, train, indices=slice(0, None)):
         return torch.utils.data.DataLoader(dataset, self.batch_size,
                                            shuffle=train)
     if tab.selected('jax'):
-        # Use Tensorflow Datasets & Dataloader
-        # JAX or Flax do not provide any dataloading functionality
+        # Use Tensorflow Datasets & Dataloader. JAX or Flax do not provide
+        # any dataloading functionality
         shuffle_buffer = tensors[0].shape[0] if train else 1
         return tfds.as_numpy(
             tf.data.Dataset.from_tensor_slices(tensors).shuffle(

--- a/chapter_linear-regression/synthetic-regression-data.md
+++ b/chapter_linear-regression/synthetic-regression-data.md
@@ -50,7 +50,8 @@ import jax
 from jax import numpy as jnp
 import numpy as np
 import random
-import torch
+import tensorflow as tf
+import tensorflow_datasets as tfds
 ```
 
 ## Generating the Dataset
@@ -142,7 +143,7 @@ def get_dataloader(self, train):
     else:
         indices = list(range(self.num_train, self.num_train+self.num_val))
     for i in range(0, len(indices), self.batch_size):
-        if tab.selected('mxnet') or tab.selected('pytorch') or tab.selected('jax'):
+        if tab.selected('mxnet', 'pytorch', 'jax'):
             batch_indices = d2l.tensor(indices[i: i+self.batch_size])
             yield self.X[batch_indices], self.y[batch_indices]
         if tab.selected('tensorflow'):
@@ -193,7 +194,7 @@ and let it take care of shuffling examples  efficiently.
 JAX is all about NumPy like API with device acceleration and the functional
 transformations, so at least the current version doesn’t include data loading
 methods. With other  libraries we already have great data loaders out there,
-and JAX suggests using them instead. Here we will grab PyTorch’s data loader,
+and JAX suggests using them instead. Here we will grab Tensorflow’s data loader,
 and modify it slightly to make it work with JAX.
 :end_tab:
 
@@ -211,33 +212,12 @@ def get_tensorloader(self, tensors, train, indices=slice(0, None)):
         return torch.utils.data.DataLoader(dataset, self.batch_size,
                                            shuffle=train)
     if tab.selected('jax'):
-        # Use PyTorch Dataset and Dataloader
+        # Use Tensorflow Datasets & Dataloader
         # JAX or Flax do not provide any dataloading functionality
-
-        def jax_collate(batch):
-            if isinstance(batch[0], np.ndarray):
-                return jnp.stack(batch)
-            elif isinstance(batch[0], (tuple, list)):
-                transposed = zip(*batch)
-                return [jax_collate(samples) for samples in transposed]
-            else:
-                return jnp.array(batch)
-
-        class JaxDataset(torch.utils.data.Dataset):
-            def __init__(self, train, seed=0):
-                super().__init__()
-
-            def __getitem__(self, index):
-                return (np.asarray(tensors[0][index]),
-                        np.asarray(tensors[1][index]))
-
-            def __len__(self):
-                return len(tensors[0])
-
-        dataset = JaxDataset(*tensors)
-        return torch.utils.data.DataLoader(dataset, self.batch_size,
-                                           shuffle=train,
-                                           collate_fn=jax_collate)
+        shuffle_buffer = tensors[0].shape[0] if train else 1
+        return tfds.as_numpy(
+            tf.data.Dataset.from_tensor_slices(tensors).shuffle(
+                buffer_size=shuffle_buffer).batch(self.batch_size))
 
     if tab.selected('tensorflow'):
         shuffle_buffer = tensors[0].shape[0] if train else 1

--- a/chapter_preface/index.md
+++ b/chapter_preface/index.md
@@ -479,8 +479,8 @@ from jax import numpy as jnp
 from jax import grad, vmap
 import numpy as np
 import optax
-import torch  # Used for dataloading
-import torchvision  # Used for dataloading
+import tensorflow as tf  # Used for dataloading
+import tensorflow_datasets as tfds  # Used for dataloading
 ```
 
 ### Target Audience

--- a/chapter_preface/index.md
+++ b/chapter_preface/index.md
@@ -479,8 +479,8 @@ from jax import numpy as jnp
 from jax import grad, vmap
 import numpy as np
 import optax
-import tensorflow as tf  # Used for dataloading
-import tensorflow_datasets as tfds  # Used for dataloading
+import tensorflow as tf
+import tensorflow_datasets as tfds
 ```
 
 ### Target Audience

--- a/d2l/jax.py
+++ b/d2l/jax.py
@@ -44,8 +44,8 @@ import flax
 import jax
 import numpy as np
 import optax
-import tensorflow as tf  # Used for dataloading
-import tensorflow_datasets as tfds  # Used for dataloading
+import tensorflow as tf
+import tensorflow_datasets as tfds
 from flax import linen as nn
 from flax.training.train_state import TrainState
 from jax import grad

--- a/static/build.yml
+++ b/static/build.yml
@@ -10,7 +10,7 @@ dependencies:
     - -f https://download.pytorch.org/whl/torch_stable.html
     - tensorflow==2.9.1
     - tensorflow-probability==0.17.0
-    - tensorflow-datasets
+    - tensorflow-datasets==4.7.0
     - jaxlib
     - "jax[cuda]"
     - -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html

--- a/static/build.yml
+++ b/static/build.yml
@@ -10,6 +10,7 @@ dependencies:
     - -f https://download.pytorch.org/whl/torch_stable.html
     - tensorflow==2.9.1
     - tensorflow-probability==0.17.0
+    - tensorflow-datasets
     - jaxlib
     - "jax[cuda]"
     - -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html


### PR DESCRIPTION
After running the benchmarks for the dataset and data loader performance in JAX, it was pretty evident we needed to switch to tensorflow datasets, especially for example FashionMNIST dataset for JAX is slow when resizing the inputs using torchvision.

Also, according to one of the JAX/Flax team members, [here](https://github.com/google/jax/issues/9190#issuecomment-1013576878):
> Usually we recommend that people use TFDS / tf.data based dataloaders as they're far more CPU efficient for feeding multiple GPUs or TPUs than torch dataloaders with multiprocessing.


Previous timings with PyTorch dataloader compared to tfds timings. (Though it is a bit unfair for torch since earlier we were using jnp.stack for that, which is quite slow. But even after switching to np.stack with torch dataloader it is still slower than tfds as discussed offline).

JAX based on PyTorch Dataloader:
<img width="1063" alt="image" src="https://user-images.githubusercontent.com/23621655/201800818-2b82f277-cd79-4e59-b82a-97ca5b205f8b.png">

JAX based on TFDS Dataloader:
<img width="1063" alt="image" src="https://user-images.githubusercontent.com/23621655/201801869-214a833c-faee-4186-b9e3-df27f4082ab0.png">