### PR TITLE
JAX: Add AlexNet

### DIFF
--- a/chapter_convolutional-modern/alexnet.md
+++ b/chapter_convolutional-modern/alexnet.md
@@ -1,6 +1,6 @@
 ```{.python .input  n=1}
 %load_ext d2lbook.tab
-tab.interact_select(['mxnet', 'pytorch', 'tensorflow'])
+tab.interact_select(['mxnet', 'pytorch', 'tensorflow', 'jax'])
 ```
 
 # Deep Convolutional Neural Networks (AlexNet)
@@ -314,8 +314,16 @@ from d2l import tensorflow as d2l
 import tensorflow as tf
 ```
 
+```{.python .input}
+%%tab jax
+from d2l import jax as d2l
+from flax import linen as nn
+import jax
+from jax import numpy as jnp
+```
+
 ```{.python .input  n=5}
-%%tab all
+%%tab pytorch, mxnet, tensorflow
 class AlexNet(d2l.Classifier):
     def __init__(self, lr=0.1, num_classes=10):
         super().__init__()
@@ -372,6 +380,36 @@ class AlexNet(d2l.Classifier):
                 tf.keras.layers.Dense(num_classes)])
 ```
 
+```{.python .input}
+%%tab jax
+class AlexNet(d2l.Classifier):
+    lr: float = 0.1
+    num_classes: int = 10
+    training: bool = True
+
+    def setup(self):
+        self.net = nn.Sequential([
+            nn.Conv(features=96, kernel_size=(11, 11), strides=(4, 4)),
+            nn.relu,
+            lambda x: nn.max_pool(x, window_shape=(3, 3), strides=(2, 2)),
+            nn.Conv(features=256, kernel_size=(5, 5)),
+            nn.relu,
+            lambda x: nn.max_pool(x, window_shape=(3, 3), strides=(2, 2)),
+            nn.Conv(features=384, kernel_size=(3, 3)), nn.relu,
+            nn.Conv(features=384, kernel_size=(3, 3)), nn.relu,
+            nn.Conv(features=256, kernel_size=(3, 3)), nn.relu,
+            lambda x: nn.max_pool(x, window_shape=(3, 3), strides=(2, 2)),
+            lambda x: x.reshape((x.shape[0], -1)),  # flatten
+            nn.Dense(features=4096),
+            nn.relu,
+            nn.Dropout(0.5, deterministic=not self.training),
+            nn.Dense(features=4096),
+            nn.relu,
+            nn.Dropout(0.5, deterministic=not self.training),
+            nn.Dense(features=self.num_classes)
+        ])
+```
+
 We [**construct a single-channel data example**] with both height and width of 224 (**to observe the output shape of each layer**). It matches the AlexNet architecture in :numref:`fig_alexnet`.
 
 ```{.python .input  n=6}
@@ -382,6 +420,11 @@ AlexNet().layer_summary((1, 1, 224, 224))
 ```{.python .input  n=7}
 %%tab tensorflow
 AlexNet().layer_summary((1, 224, 224, 1))
+```
+
+```{.python .input}
+%%tab jax
+AlexNet(training=False).layer_summary((1, 224, 224, 1), key=d2l.get_key())
 ```
 
 ## Training
@@ -405,7 +448,7 @@ and much slower training due to the deeper and wider network,
 the higher image resolution, and the more costly convolutions.
 
 ```{.python .input  n=8}
-%%tab pytorch, mxnet
+%%tab pytorch, mxnet, jax
 model = AlexNet(lr=0.01)
 data = d2l.FashionMNIST(batch_size=128, resize=(224, 224))
 trainer = d2l.Trainer(max_epochs=10, num_gpus=1)

--- a/chapter_linear-classification/classification.md
+++ b/chapter_linear-classification/classification.md
@@ -132,7 +132,7 @@ def accuracy(self, Y_hat, Y, averaged=True):
 ```{.python .input  n=9}
 %%tab jax
 @d2l.add_to_class(Classifier)  #@save
-@partial(jax.jit, static_argnums=(0,4))
+@partial(jax.jit, static_argnums=(0, 4))
 def accuracy(self, params, X, Y, averaged=True):
     """Compute the number of correct predictions."""
     Y_hat = self.apply(params, X)

--- a/chapter_linear-classification/classification.md
+++ b/chapter_linear-classification/classification.md
@@ -30,7 +30,9 @@ import tensorflow as tf
 ```{.python .input}
 %%tab jax
 from d2l import jax as d2l
+from functools import partial
 from jax import numpy as jnp
+import jax
 import optax
 ```
 
@@ -130,6 +132,7 @@ def accuracy(self, Y_hat, Y, averaged=True):
 ```{.python .input  n=9}
 %%tab jax
 @d2l.add_to_class(Classifier)  #@save
+@partial(jax.jit, static_argnums=(0,4))
 def accuracy(self, params, X, Y, averaged=True):
     """Compute the number of correct predictions."""
     Y_hat = self.apply(params, X)

--- a/chapter_linear-classification/softmax-regression-concise.md
+++ b/chapter_linear-classification/softmax-regression-concise.md
@@ -191,7 +191,7 @@ def loss(self, Y_hat, Y, averaged=True):
 ```{.python .input}
 %%tab jax
 @d2l.add_to_class(d2l.Classifier)  #@save
-@partial(jax.jit, static_argnums=(0,4))
+@partial(jax.jit, static_argnums=(0, 4))
 def loss(self, params, X, Y, averaged=True):
     Y_hat = self.apply(params, X, rngs=None)
     Y_hat = d2l.reshape(Y_hat, (-1, Y_hat.shape[-1]))

--- a/chapter_linear-classification/softmax-regression-concise.md
+++ b/chapter_linear-classification/softmax-regression-concise.md
@@ -39,6 +39,7 @@ import tensorflow as tf
 %%tab jax
 from d2l import jax as d2l
 from flax import linen as nn
+from functools import partial
 import jax
 from jax import numpy as jnp
 import optax
@@ -190,8 +191,9 @@ def loss(self, Y_hat, Y, averaged=True):
 ```{.python .input}
 %%tab jax
 @d2l.add_to_class(d2l.Classifier)  #@save
-def loss(self, params, X, Y, averaged=True, rngs=None):
-    Y_hat = self.apply(params, X, rngs=rngs)
+@partial(jax.jit, static_argnums=(0,4))
+def loss(self, params, X, Y, averaged=True):
+    Y_hat = self.apply(params, X, rngs=None)
     Y_hat = d2l.reshape(Y_hat, (-1, Y_hat.shape[-1]))
     fn = optax.softmax_cross_entropy_with_integer_labels
     return fn(Y_hat, Y).mean() if averaged else fn(Y_hat, Y)

--- a/chapter_multilayer-perceptrons/dropout.md
+++ b/chapter_multilayer-perceptrons/dropout.md
@@ -358,14 +358,6 @@ according to the specified dropout probability.
 When not in training mode,
 the `Dropout` layer simply passes the data through during testing.
 
-:begin_tab:`jax`
-Note that we need to redefine the loss function since a network
-with a dropout layer needs a PRNGKey when using `Module.apply()`,
-this RNG seed should be explicitly named `dropout`. This key is
-used by the `dropout` layer in Flax to generate the random dropout
-mask internally.
-:end_tab:
-
 ```{.python .input}
 %%tab mxnet
 class DropoutMLP(d2l.Classifier):
@@ -431,10 +423,18 @@ class DropoutMLP(d2l.Classifier):
         return nn.Dense(self.num_outputs)(x)
 ```
 
+:begin_tab:`jax`
+Note that we need to redefine the loss function since a network
+with a dropout layer needs a PRNGKey when using `Module.apply()`,
+and this RNG seed should be explicitly named `dropout`. This key is
+used by the `dropout` layer in Flax to generate the random dropout
+mask internally.
+:end_tab:
+
 ```{.python .input}
 %%tab jax
 @d2l.add_to_class(d2l.Classifier)  #@save
-@partial(jax.jit, static_argnums=(0,4))
+@partial(jax.jit, static_argnums=(0, 4))
 def loss(self, params, X, Y, averaged=True):
     Y_hat = self.apply(params, X, rngs={'dropout': jax.random.PRNGKey(0)})
     Y_hat = d2l.reshape(Y_hat, (-1, Y_hat.shape[-1]))

--- a/chapter_multilayer-perceptrons/dropout.md
+++ b/chapter_multilayer-perceptrons/dropout.md
@@ -361,7 +361,9 @@ the `Dropout` layer simply passes the data through during testing.
 :begin_tab:`jax`
 Note that we need to redefine the loss function since a network
 with a dropout layer needs a PRNGKey when using `Module.apply()`,
-this RNG seed should be explicitly named `dropout`.
+this RNG seed should be explicitly named `dropout`. This key is
+used by the `dropout` layer in Flax to generate the random dropout
+mask internally.
 :end_tab:
 
 ```{.python .input}

--- a/chapter_multilayer-perceptrons/dropout.md
+++ b/chapter_multilayer-perceptrons/dropout.md
@@ -198,8 +198,10 @@ def dropout_layer(X, dropout):
 %%tab jax
 from d2l import jax as d2l
 from flax import linen as nn
+from functools import partial
 import jax
 from jax import numpy as jnp
+import optax
 
 def dropout_layer(X, dropout, key=d2l.get_key()):
     assert 0 <= dropout <= 1
@@ -311,7 +313,7 @@ class DropoutMLPScratch(d2l.Classifier):
     dropout_1: float
     dropout_2: float
     lr: float
-    training: bool
+    training: bool = True
 
     def setup(self):
         self.lin1 = nn.Dense(self.num_hiddens_1)
@@ -335,12 +337,8 @@ The following is similar to the training of MLPs described previously.
 
 ```{.python .input}
 %%tab all
-if tab.selected('pytorch', 'mxnet', 'tensorflow'):
-    hparams = {'num_outputs':10, 'num_hiddens_1':256, 'num_hiddens_2':256,
-               'dropout_1':0.5, 'dropout_2':0.5, 'lr':0.1}
-if tab.selected('jax'):
-    hparams = {'num_outputs':10, 'num_hiddens_1':256, 'num_hiddens_2':256,
-               'dropout_1':0.5, 'dropout_2':0.5, 'lr':0.1, 'training': True}
+hparams = {'num_outputs':10, 'num_hiddens_1':256, 'num_hiddens_2':256,
+           'dropout_1':0.5, 'dropout_2':0.5, 'lr':0.1}
 model = DropoutMLPScratch(**hparams)
 data = d2l.FashionMNIST(batch_size=256)
 trainer = d2l.Trainer(max_epochs=10)
@@ -359,6 +357,12 @@ drop out outputs of the previous layer
 according to the specified dropout probability.
 When not in training mode,
 the `Dropout` layer simply passes the data through during testing.
+
+:begin_tab:`jax`
+Note that we need to redefine the loss function since a network
+with a dropout layer needs a PRNGKey when using `Module.apply()`,
+this RNG seed should be explicitly named `dropout`.
+:end_tab:
 
 ```{.python .input}
 %%tab mxnet
@@ -414,7 +418,7 @@ class DropoutMLP(d2l.Classifier):
     dropout_1: float
     dropout_2: float
     lr: float
-    training: bool
+    training: bool = True
 
     @nn.compact
     def __call__(self, X):
@@ -423,10 +427,17 @@ class DropoutMLP(d2l.Classifier):
         x = nn.relu(nn.Dense(self.num_hiddens_2)(x))
         x = nn.Dropout(self.dropout_2, deterministic=not self.training)(x)
         return nn.Dense(self.num_outputs)(x)
+```
 
-@d2l.add_to_class(DropoutMLP)
-def loss(self, params, X, Y, averaged=True, rngs={'dropout': d2l.get_key()}):
-    return super(DropoutMLP, self).loss(params, X, Y, averaged, rngs)
+```{.python .input}
+%%tab jax
+@d2l.add_to_class(d2l.Classifier)  #@save
+@partial(jax.jit, static_argnums=(0,4))
+def loss(self, params, X, Y, averaged=True):
+    Y_hat = self.apply(params, X, rngs={'dropout': jax.random.PRNGKey(0)})
+    Y_hat = d2l.reshape(Y_hat, (-1, Y_hat.shape[-1]))
+    fn = optax.softmax_cross_entropy_with_integer_labels
+    return fn(Y_hat, Y).mean() if averaged else fn(Y_hat, Y)
 ```
 
 Next, we [**train the model**].

--- a/chapter_preface/index.md
+++ b/chapter_preface/index.md
@@ -471,6 +471,7 @@ import tensorflow as tf
 #@tab jax
 #@save
 from dataclasses import field
+from functools import partial
 import flax
 from flax import linen as nn
 from flax.training.train_state import TrainState

--- a/d2l/jax.py
+++ b/d2l/jax.py
@@ -489,7 +489,7 @@ class Classifier(d2l.Module):
         self.plot('acc', self.accuracy(params, *batch[:-1], batch[-1]),
                   train=False)
 
-    @partial(jax.jit, static_argnums=(0,4))
+    @partial(jax.jit, static_argnums=(0, 4))
     def accuracy(self, params, X, Y, averaged=True):
         """Compute the number of correct predictions.
     
@@ -500,7 +500,7 @@ class Classifier(d2l.Module):
         compare = d2l.astype(preds == d2l.reshape(Y, -1), d2l.float32)
         return d2l.reduce_mean(compare) if averaged else compare
 
-    @partial(jax.jit, static_argnums=(0,4))
+    @partial(jax.jit, static_argnums=(0, 4))
     def loss(self, params, X, Y, averaged=True):
         """Defined in :numref:`sec_softmax_concise`"""
         Y_hat = self.apply(params, X, rngs=None)
@@ -508,7 +508,7 @@ class Classifier(d2l.Module):
         fn = optax.softmax_cross_entropy_with_integer_labels
         return fn(Y_hat, Y).mean() if averaged else fn(Y_hat, Y)
 
-    @partial(jax.jit, static_argnums=(0,4))
+    @partial(jax.jit, static_argnums=(0, 4))
     def loss(self, params, X, Y, averaged=True):
         """Defined in :numref:`sec_dropout`"""
         Y_hat = self.apply(params, X, rngs={'dropout': jax.random.PRNGKey(0)})

--- a/d2l/jax.py
+++ b/d2l/jax.py
@@ -40,6 +40,7 @@ from matplotlib_inline import backend_inline
 d2l = sys.modules[__name__]
 
 from dataclasses import field
+from functools import partial
 import flax
 import jax
 import numpy as np
@@ -264,8 +265,8 @@ class DataModule(d2l.HyperParameters):
     def get_tensorloader(self, tensors, train, indices=slice(0, None)):
         """Defined in :numref:`sec_synthetic-regression-data`"""
         tensors = tuple(a[indices] for a in tensors)
-        # Use Tensorflow Datasets & Dataloader
-        # JAX or Flax do not provide any dataloading functionality
+        # Use Tensorflow Datasets & Dataloader. JAX or Flax do not provide
+        # any dataloading functionality
         shuffle_buffer = tensors[0].shape[0] if train else 1
         return tfds.as_numpy(
             tf.data.Dataset.from_tensor_slices(tensors).shuffle(
@@ -488,6 +489,7 @@ class Classifier(d2l.Module):
         self.plot('acc', self.accuracy(params, *batch[:-1], batch[-1]),
                   train=False)
 
+    @partial(jax.jit, static_argnums=(0,4))
     def accuracy(self, params, X, Y, averaged=True):
         """Compute the number of correct predictions.
     
@@ -498,9 +500,10 @@ class Classifier(d2l.Module):
         compare = d2l.astype(preds == d2l.reshape(Y, -1), d2l.float32)
         return d2l.reduce_mean(compare) if averaged else compare
 
-    def loss(self, params, X, Y, averaged=True, rngs=None):
+    @partial(jax.jit, static_argnums=(0,4))
+    def loss(self, params, X, Y, averaged=True):
         """Defined in :numref:`sec_softmax_concise`"""
-        Y_hat = self.apply(params, X, rngs=rngs)
+        Y_hat = self.apply(params, X, rngs=None)
         Y_hat = d2l.reshape(Y_hat, (-1, Y_hat.shape[-1]))
         fn = optax.softmax_cross_entropy_with_integer_labels
         return fn(Y_hat, Y).mean() if averaged else fn(Y_hat, Y)

--- a/d2l/jax.py
+++ b/d2l/jax.py
@@ -508,6 +508,14 @@ class Classifier(d2l.Module):
         fn = optax.softmax_cross_entropy_with_integer_labels
         return fn(Y_hat, Y).mean() if averaged else fn(Y_hat, Y)
 
+    @partial(jax.jit, static_argnums=(0,4))
+    def loss(self, params, X, Y, averaged=True):
+        """Defined in :numref:`sec_dropout`"""
+        Y_hat = self.apply(params, X, rngs={'dropout': jax.random.PRNGKey(0)})
+        Y_hat = d2l.reshape(Y_hat, (-1, Y_hat.shape[-1]))
+        fn = optax.softmax_cross_entropy_with_integer_labels
+        return fn(Y_hat, Y).mean() if averaged else fn(Y_hat, Y)
+
     def layer_summary(self, X_shape, key=jax.random.PRNGKey(d2l.get_seed())):
         """Defined in :numref:`sec_lenet`"""
         X = jnp.zeros(X_shape)


### PR DESCRIPTION
*Description of changes:*

This PR updates the D2L API, enabling `jax.jit` for the `train`/`val` step. This speeds up the training process a lot, and in the future, we can potentially further improve this by targetting jit to a larger block, giving XLA more opportunity to optimize, if the D2L API becomes less of a constraint.

Also, it would be nice todo to use jax profiler to understand and analyse memory and time across the ModernCNN networks.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
