### PR TITLE
Remove matmul_H from gru.md

### DIFF
--- a/chapter_recurrent-modern/gru.md
+++ b/chapter_recurrent-modern/gru.md
@@ -207,7 +207,6 @@ except that the update equations are more complex.
 %%tab all
 @d2l.add_to_class(GRUScratch)
 def forward(self, inputs, H=None):
-    matmul_H = lambda A, B: d2l.matmul(A, B) if H is not None else 0
     outputs = []
     for X in inputs:
         Z = d2l.sigmoid(d2l.matmul(X, self.W_xz) + (


### PR DESCRIPTION
*Description of changes:*
The lambda function matmul_H is not used anywhere of the entire book, let alone the `GRUScratch` implementation. 
See the search result of the function name. 
https://d2l.ai/search.html?q=matmul_H&check_keywords=yes&area=default

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
