### PR TITLE
JAX: Improve `layer_summary`

### DIFF
--- a/chapter_convolutional-modern/alexnet.md
+++ b/chapter_convolutional-modern/alexnet.md
@@ -424,7 +424,7 @@ AlexNet().layer_summary((1, 224, 224, 1))
 
 ```{.python .input}
 %%tab jax
-AlexNet(training=False).layer_summary((1, 224, 224, 1), key=d2l.get_key())
+AlexNet(training=False).layer_summary((1, 224, 224, 1))
 ```
 
 ## Training

--- a/chapter_convolutional-modern/nin.md
+++ b/chapter_convolutional-modern/nin.md
@@ -198,28 +198,17 @@ We create a data example to see [**the output shape of each block**].
 
 ```{.python .input}
 %%tab mxnet, pytorch
-model = NiN()
-X = d2l.randn(1, 1, 224, 224)
-for layer in model.net:
-    X = layer(X)
-    print(layer.__class__.__name__,'output shape:\t', X.shape)
+NiN().layer_summary((1, 1, 224, 224))
 ```
 
 ```{.python .input}
 %%tab tensorflow
-model = NiN()
-X = d2l.normal((1, 224, 224, 1))
-for layer in model.net.layers:
-    X = layer(X)
-    print(layer.__class__.__name__,'output shape:\t', X.shape)
+NiN().layer_summary((1, 224, 224, 1))
 ```
 
 ```{.python .input}
 %%tab jax
-keys = d2l.get_key()
-model = NiN(training=False)
-params = model.init(keys, jnp.zeros((1, 224, 224, 1)))
-jax.tree_util.tree_map(lambda x: x.shape, params)
+NiN(training=False).layer_summary((1, 224, 224, 1))
 ```
 
 ## [**Training**]

--- a/chapter_convolutional-modern/vgg.md
+++ b/chapter_convolutional-modern/vgg.md
@@ -238,8 +238,8 @@ VGG(arch=((1, 64), (1, 128), (2, 256), (2, 512), (2, 512))).layer_summary(
 
 ```{.python .input}
 %%tab jax
-VGG(arch=((1, 64), (1, 128), (2, 256), (2, 512), (2, 512)), training=False).layer_summary(
-    (1, 224, 224, 1), key=d2l.get_key())
+VGG(arch=((1, 64), (1, 128), (2, 256), (2, 512), (2, 512)),
+    training=False).layer_summary((1, 224, 224, 1))
 ```
 
 As you can see, we halve height and width at each block,

--- a/chapter_convolutional-neural-networks/lenet.md
+++ b/chapter_convolutional-neural-networks/lenet.md
@@ -221,7 +221,7 @@ that its operations line up with
 what we expect from :numref:`img_lenet_vert`.
 Flax provides `nn.tabulate`, a nifty method to summarise the layers and
 parameters in our network. Here we use `bind()` to create a bounded model.
-The `variables` are now bound to the `Module`, i.e. this bouned model
+The `variables` are now bound to the `Module`, i.e. this bounded model
 becomes a stateful object which can then be used to access the `Sequential`
 object attribute `net` and the `layers` within. Note that `bind()` should
 only be used for interactive experimentation, and is not a direct

--- a/chapter_convolutional-neural-networks/lenet.md
+++ b/chapter_convolutional-neural-networks/lenet.md
@@ -220,12 +220,12 @@ we can [**inspect the model**] to make sure
 that its operations line up with
 what we expect from :numref:`img_lenet_vert`.
 Flax provides `nn.tabulate`, a nifty method to summarise the layers and
-parameters in our network. Here we use `bind()` to create a bounded model.
-The `variables` are now bound to the `Module`, i.e. this bounded model
+parameters in our network. Here we use the `bind` method to create a bounded model.
+The variables are now bound to the `d2l.Module` class, i.e., this bounded model
 becomes a stateful object which can then be used to access the `Sequential`
-object attribute `net` and the `layers` within. Note that `bind()` should
+object attribute `net` and the `layers` within. Note that the `bind` method should
 only be used for interactive experimentation, and is not a direct
-replacement for `apply()`.
+replacement for the `apply` method.
 :end_tab:
 
 ![Compressed notation for LeNet-5.](../img/lenet-vert.svg)

--- a/chapter_convolutional-neural-networks/lenet.md
+++ b/chapter_convolutional-neural-networks/lenet.md
@@ -263,7 +263,7 @@ model.layer_summary((1, 28, 28, 1))
 def layer_summary(self, X_shape, key=d2l.get_key()):
     X = jnp.zeros(X_shape)
     params = self.init(key, X)
-    bound_model = self.bind(params)
+    bound_model = self.clone().bind(params)
     _ = bound_model(X)
     for layer in bound_model.net.layers:
         X = layer(X)

--- a/d2l/jax.py
+++ b/d2l/jax.py
@@ -516,11 +516,15 @@ class Classifier(d2l.Module):
         fn = optax.softmax_cross_entropy_with_integer_labels
         return fn(Y_hat, Y).mean() if averaged else fn(Y_hat, Y)
 
-    def layer_summary(self, X_shape, key=jax.random.PRNGKey(d2l.get_seed())):
+    def layer_summary(self, X_shape, key=d2l.get_key()):
         """Defined in :numref:`sec_lenet`"""
         X = jnp.zeros(X_shape)
-        tabulate_fn = nn.tabulate(self, key, method=self.forward)
-        print(tabulate_fn(X))
+        params = self.init(key, X)
+        bound_model = self.bind(params)
+        _ = bound_model(X)
+        for layer in bound_model.net.layers:
+            X = layer(X)
+            print(layer.__class__.__name__, 'output shape:\t', X.shape)
 
 def cpu():
     """Defined in :numref:`sec_use_gpu`"""


### PR DESCRIPTION
*Description of changes:*
Use flax `.bind()` to generate layer summary for models.

Now:
<img width="507" alt="image" src="https://user-images.githubusercontent.com/23621655/203016797-465d7880-3265-469b-b3b8-3bb36a8ccf56.png">

The previous using `tabulate`, this doesn't give output shapes and completely ignores lambda functions used for pooling:
<img width="736" alt="image" src="https://user-images.githubusercontent.com/23621655/203017955-c19b89cb-3163-4d49-abba-8b35c5a7a710.png">



By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
