### PR TITLE
JAX: Refactor JAX D2L API to support BatchNorm

### DIFF
--- a/chapter_builders-guide/custom-layer.md
+++ b/chapter_builders-guide/custom-layer.md
@@ -145,9 +145,8 @@ tf.reduce_mean(Y)
 
 ```{.python .input}
 %%tab jax
-Y, _ = net.init_with_output(jax.random.PRNGKey(d2l.get_seed()),
-                            jax.random.uniform(jax.random.PRNGKey(d2l.get_seed()),
-                            (4, 8)))
+Y, _ = net.init_with_output(d2l.get_key(), jax.random.uniform(d2l.get_key(),
+                                                              (4, 8)))
 Y.mean()
 ```
 
@@ -265,7 +264,7 @@ dense.get_weights()
 ```{.python .input}
 %%tab jax
 dense = MyDense(5, 3)
-params = dense.init(jax.random.PRNGKey(d2l.get_seed()), jnp.zeros((3, 5)))
+params = dense.init(d2l.get_key(), jnp.zeros((3, 5)))
 params
 ```
 
@@ -289,7 +288,7 @@ dense(tf.random.uniform((2, 5)))
 
 ```{.python .input}
 %%tab jax
-dense.apply(params, jax.random.uniform(jax.random.PRNGKey(d2l.get_seed()),
+dense.apply(params, jax.random.uniform(d2l.get_key(),
                                        (2, 5)))
 ```
 
@@ -320,9 +319,8 @@ net(tf.random.uniform((2, 64)))
 ```{.python .input}
 %%tab jax
 net = nn.Sequential([MyDense(64, 8), MyDense(8, 1)])
-Y, _ = net.init_with_output(jax.random.PRNGKey(d2l.get_seed()),
-                            jax.random.uniform(jax.random.PRNGKey(d2l.get_seed()),
-                                               (2, 64)))
+Y, _ = net.init_with_output(d2l.get_key(), jax.random.uniform(d2l.get_key(),
+                                                              (2, 64)))
 Y
 ```
 

--- a/chapter_builders-guide/init-param.md
+++ b/chapter_builders-guide/init-param.md
@@ -89,8 +89,8 @@ import jax
 from jax import numpy as jnp
 
 net = nn.Sequential([nn.Dense(8), nn.relu, nn.Dense(1)])
-X = jax.random.uniform(jax.random.PRNGKey(d2l.get_seed()), (2, 4))
-params = net.init(jax.random.PRNGKey(d2l.get_seed()), X)
+X = jax.random.uniform(d2l.get_key(), (2, 4))
+params = net.init(d2l.get_key(), X)
 net.apply(params, X).shape
 ```
 
@@ -345,7 +345,7 @@ def my_init(key, shape, dtype=jnp.float_):
     return data * (jnp.abs(data) >= 5)
 
 net = nn.Sequential([nn.Dense(8, kernel_init=my_init), nn.relu, nn.Dense(1)])
-params = net.init(jax.random.PRNGKey(d2l.get_seed()), X)
+params = net.init(d2l.get_key(), X)
 print(params['params']['layers_0']['kernel'][:, :2])
 ```
 

--- a/chapter_builders-guide/lazy-init.md
+++ b/chapter_builders-guide/lazy-init.md
@@ -176,7 +176,7 @@ net(X)
 
 ```{.python .input}
 %%tab jax
-params = net.init(jax.random.PRNGKey(d2l.get_seed()), jnp.zeros((2, 20)))
+params = net.init(d2l.get_key(), jnp.zeros((2, 20)))
 jax.tree_util.tree_map(lambda x: x.shape, params).tree_flatten()
 ```
 

--- a/chapter_builders-guide/model-construction.md
+++ b/chapter_builders-guide/model-construction.md
@@ -153,8 +153,9 @@ from jax import numpy as jnp
 
 net = nn.Sequential([nn.Dense(256), nn.relu, nn.Dense(10)])
 
-X = jax.random.uniform(jax.random.PRNGKey(d2l.get_seed()), (2, 20))
-params = net.init(jax.random.PRNGKey(d2l.get_seed()), X)
+# get_key is a d2l saved function returning jax.random.PRNGKey(random_seed)
+X = jax.random.uniform(d2l.get_key(), (2, 20))
+params = net.init(d2l.get_key(), X)
 net.apply(params, X).shape
 ```
 
@@ -349,7 +350,7 @@ net(X).shape
 ```{.python .input}
 %%tab jax
 net = MLP()
-params = net.init(jax.random.PRNGKey(d2l.get_seed()), X)
+params = net.init(d2l.get_key(), X)
 net.apply(params, X).shape
 ```
 
@@ -488,7 +489,7 @@ net(X).shape
 ```{.python .input}
 %%tab jax
 net = MySequential([nn.Dense(256), nn.relu, nn.Dense(10)])
-params = net.init(jax.random.PRNGKey(d2l.get_seed()), X)
+params = net.init(d2l.get_key(), X)
 net.apply(params, X).shape
 ```
 
@@ -606,8 +607,7 @@ class FixedHiddenMLP(tf.keras.Model):
 class FixedHiddenMLP(nn.Module):
     # Random weight parameters that will not compute gradients and
     # therefore keep constant during training
-    rand_weight: jnp.array = jax.random.uniform(jax.random.PRNGKey(
-                                                d2l.get_seed()), (20, 20))
+    rand_weight: jnp.array = jax.random.uniform(d2l.get_key(), (20, 20))
 
     def setup(self):
         self.dense = nn.Dense(20)
@@ -659,7 +659,7 @@ net(X)
 ```{.python .input}
 %%tab jax
 net = FixedHiddenMLP()
-params = net.init(jax.random.PRNGKey(d2l.get_seed()), X)
+params = net.init(d2l.get_key(), X)
 net.apply(params, X)
 ```
 
@@ -736,7 +736,7 @@ class NestMLP(nn.Module):
 
 
 chimera = nn.Sequential([NestMLP(), nn.Dense(20), FixedHiddenMLP()])
-params = chimera.init(jax.random.PRNGKey(d2l.get_seed()), X)
+params = chimera.init(d2l.get_key(), X)
 chimera.apply(params, X)
 ```
 

--- a/chapter_builders-guide/parameters.md
+++ b/chapter_builders-guide/parameters.md
@@ -84,8 +84,8 @@ from jax import numpy as jnp
 
 net = nn.Sequential([nn.Dense(8), nn.relu, nn.Dense(1)])
 
-X = jax.random.uniform(jax.random.PRNGKey(d2l.get_seed()), (2, 4))
-params = net.init(jax.random.PRNGKey(d2l.get_seed()), X)
+X = jax.random.uniform(d2l.get_key(), (2, 4))
+params = net.init(d2l.get_key(), X)
 net.apply(params, X).shape
 ```
 

--- a/chapter_convolutional-modern/batch-norm.md
+++ b/chapter_convolutional-modern/batch-norm.md
@@ -670,14 +670,25 @@ variables.
 %%tab jax
 @d2l.add_to_class(d2l.Classifier)  #@save
 def training_step(self, params, batch, state):
-    (l, updates), grads = jax.value_and_grad(
-        self.loss, has_aux=True)(params, *batch[:-1], batch[-1], state)
+    if state.batch_stats:
+        # Used for Models with BatchNorm layers; when loss returns aux data
+        value, grads = jax.value_and_grad(
+            self.loss, has_aux=True)(params, *batch[:-1], batch[-1], state)
+        l, _ = value
+    else:
+        value, grads = jax.value_and_grad(self.loss)(params, *batch[:-1],
+                                                 batch[-1], state)
+        l = value
     self.plot("loss", l, train=True)
-    return (l, updates), grads
+    return value, grads
 
 @d2l.add_to_class(d2l.Classifier)  #@save
 def validation_step(self, params, batch, state):
-    l, _ = self.loss(params, *batch[:-1], batch[-1], state)
+    if state.batch_stats:
+        # Used for Models with BatchNorm layers; when loss returns aux data
+        l, _ = self.loss(params, *batch[:-1], batch[-1], state)
+    else:
+        l = self.loss(params, *batch[:-1], batch[-1], state)
     self.plot('loss', l, train=False)
     self.plot('acc', self.accuracy(params, *batch[:-1], batch[-1], state),
               train=False)

--- a/chapter_convolutional-modern/batch-norm.md
+++ b/chapter_convolutional-modern/batch-norm.md
@@ -659,10 +659,11 @@ class BNLeNet(d2l.Classifier):
 
 :begin_tab:`jax`
 Since `BatchNorm` layers need to calculate the batch statistics
-(mean and variance), Flax keeps a track of `batch_stats` dictionary, updating
-them with every batch. Collections like `batch_stats` can be stored in the
-`TrainState` object as an attribute and during the model's forward pass, these
-should be passed to the `mutable` arg, so that Flax returns the mutated
+(mean and variance), Flax keeps track of the `batch_stats` dictionary, updating
+them with every minibatch. Collections like `batch_stats` can be stored in the
+`TrainState` object (in the `d2l.Trainer` class defined in
+:numref:`oo-design-training`) as an attribute and during the model's forward pass,
+these should be passed to the `mutable` argument, so that Flax returns the mutated
 variables.
 :end_tab:
 

--- a/chapter_convolutional-modern/batch-norm.md
+++ b/chapter_convolutional-modern/batch-norm.md
@@ -669,31 +669,6 @@ variables.
 ```{.python .input}
 %%tab jax
 @d2l.add_to_class(d2l.Classifier)  #@save
-def training_step(self, params, batch, state):
-    if state.batch_stats:
-        # Used for Models with BatchNorm layers; when loss returns aux data
-        value, grads = jax.value_and_grad(
-            self.loss, has_aux=True)(params, *batch[:-1], batch[-1], state)
-        l, _ = value
-    else:
-        value, grads = jax.value_and_grad(self.loss)(params, *batch[:-1],
-                                                 batch[-1], state)
-        l = value
-    self.plot("loss", l, train=True)
-    return value, grads
-
-@d2l.add_to_class(d2l.Classifier)  #@save
-def validation_step(self, params, batch, state):
-    if state.batch_stats:
-        # Used for Models with BatchNorm layers; when loss returns aux data
-        l, _ = self.loss(params, *batch[:-1], batch[-1], state)
-    else:
-        l = self.loss(params, *batch[:-1], batch[-1], state)
-    self.plot('loss', l, train=False)
-    self.plot('acc', self.accuracy(params, *batch[:-1], batch[-1], state),
-              train=False)
-
-@d2l.add_to_class(d2l.Classifier)  #@save
 @partial(jax.jit, static_argnums=(0, 5))
 def loss(self, params, X, Y, state, averaged=True):
     Y_hat, updates = state.apply_fn({'params': params,

--- a/chapter_convolutional-neural-networks/lenet.md
+++ b/chapter_convolutional-neural-networks/lenet.md
@@ -263,7 +263,7 @@ model.layer_summary((1, 28, 28, 1))
 def layer_summary(self, X_shape, key=d2l.get_key()):
     X = jnp.zeros(X_shape)
     params = self.init(key, X)
-    bound_model = self.clone().bind(params)
+    bound_model = self.clone().bind(params, mutable=['batch_stats'])
     _ = bound_model(X)
     for layer in bound_model.net.layers:
         X = layer(X)

--- a/chapter_linear-classification/softmax-regression-concise.md
+++ b/chapter_linear-classification/softmax-regression-concise.md
@@ -194,10 +194,11 @@ def loss(self, Y_hat, Y, averaged=True):
 @partial(jax.jit, static_argnums=(0, 5))
 def loss(self, params, X, Y, state, averaged=True):
     Y_hat = state.apply_fn({'params': params}, X,
-                           mutable=False, rngs=None)  # BN & Dropout used later
+                           mutable=False, rngs=None)  # To be used later (e.g., for batch norm)
     Y_hat = d2l.reshape(Y_hat, (-1, Y_hat.shape[-1]))
     fn = optax.softmax_cross_entropy_with_integer_labels
-    # Empty dict in return indicates aux data; to be used in BatchNorm later
+    # The returned empty dictionary is a placeholder for auxiliary data,
+    # which will be used later (e.g., for batch norm)
     return (fn(Y_hat, Y).mean(), {}) if averaged else (fn(Y_hat, Y), {})
 ```
 

--- a/chapter_linear-classification/softmax-regression-concise.md
+++ b/chapter_linear-classification/softmax-regression-concise.md
@@ -197,7 +197,8 @@ def loss(self, params, X, Y, state, averaged=True):
                            mutable=False, rngs=None)  # BN & Dropout used later
     Y_hat = d2l.reshape(Y_hat, (-1, Y_hat.shape[-1]))
     fn = optax.softmax_cross_entropy_with_integer_labels
-    return fn(Y_hat, Y).mean() if averaged else fn(Y_hat, Y)
+    # Empty dict in return indicates aux data; to be used in BatchNorm later
+    return (fn(Y_hat, Y).mean(), {}) if averaged else (fn(Y_hat, Y), {})
 ```
 
 ## Training

--- a/chapter_linear-classification/softmax-regression-concise.md
+++ b/chapter_linear-classification/softmax-regression-concise.md
@@ -191,9 +191,10 @@ def loss(self, Y_hat, Y, averaged=True):
 ```{.python .input}
 %%tab jax
 @d2l.add_to_class(d2l.Classifier)  #@save
-@partial(jax.jit, static_argnums=(0, 4))
-def loss(self, params, X, Y, averaged=True):
-    Y_hat = self.apply(params, X, rngs=None)
+@partial(jax.jit, static_argnums=(0, 5))
+def loss(self, params, X, Y, state, averaged=True):
+    Y_hat = state.apply_fn({'params': params}, X,
+                           mutable=False, rngs=None)  # BN & Dropout used later
     Y_hat = d2l.reshape(Y_hat, (-1, Y_hat.shape[-1]))
     fn = optax.softmax_cross_entropy_with_integer_labels
     return fn(Y_hat, Y).mean() if averaged else fn(Y_hat, Y)

--- a/chapter_linear-classification/softmax-regression-scratch.md
+++ b/chapter_linear-classification/softmax-regression-scratch.md
@@ -252,12 +252,11 @@ Now we can (**implement the cross-entropy loss function**) by averaging over the
 :begin_tab:`jax`
 Now we can (**implement the cross-entropy loss function**) by averaging over the logarithms of the selected probabilities.
 
-Note that to make use of `jax.jit` to speed up JAX implementation, and
+Note that to make use of `jax.jit` to speed up JAX implementations, and
 to make sure `loss` is a pure function, the `cross_entropy` function is re-defined
 inside the `loss` to avoid usage of any global variables or functions
 which may render the `loss` function impure.
-
-We'll refer you to the JAX documentation on `jax.jit` and pure functions [here](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#pure-functions).
+We refer interested readers to the [JAX documentation](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#pure-functions) on `jax.jit` and pure functions.
 :end_tab:
 
 ```{.python .input}
@@ -292,8 +291,8 @@ def loss(self, params, X, y, state):
     def cross_entropy(y_hat, y):
         return - d2l.reduce_mean(d2l.log(y_hat[list(range(len(y_hat))), y]))
     y_hat = state.apply_fn({'params': params}, X)
-    # Here we also return an empty dictionary indicating aux data for
-    # compatibility with BatchNorm models introduced in Section 8.5
+    # The returned empty dictionary is a placeholder for auxiliary data,
+    # which will be used later (e.g., for batch norm)
     return cross_entropy(y_hat, y), {}
 ```
 

--- a/chapter_linear-classification/softmax-regression-scratch.md
+++ b/chapter_linear-classification/softmax-regression-scratch.md
@@ -273,8 +273,8 @@ def loss(self, y_hat, y):
 ```{.python .input}
 %%tab jax
 @d2l.add_to_class(SoftmaxRegressionScratch)
-def loss(self, params, X, y):
-    y_hat = self.apply(params, X)
+def loss(self, params, X, y, state):
+    y_hat = state.apply_fn({'params': params}, X)
     return cross_entropy(y_hat, y)
 ```
 
@@ -319,7 +319,7 @@ X, y = next(iter(data.val_dataloader()))
 if tab.selected('pytorch', 'mxnet', 'tensorflow'):
     preds = d2l.argmax(model(X), axis=1)
 if tab.selected('jax'):
-    preds = d2l.argmax(model.apply(trainer.state.params, X), axis=1)
+    preds = d2l.argmax(model.apply({'params': trainer.state.params}, X), axis=1)
 preds.shape
 ```
 

--- a/chapter_linear-classification/softmax-regression-scratch.md
+++ b/chapter_linear-classification/softmax-regression-scratch.md
@@ -275,7 +275,9 @@ def loss(self, y_hat, y):
 @d2l.add_to_class(SoftmaxRegressionScratch)
 def loss(self, params, X, y, state):
     y_hat = state.apply_fn({'params': params}, X)
-    return cross_entropy(y_hat, y)
+    # Here we also return an empty dictionary indicating aux data for
+    # compatibility with BatchNorm models introduced in Section 8.5
+    return cross_entropy(y_hat, y), {}
 ```
 
 ## Training

--- a/chapter_linear-regression/linear-regression-concise.md
+++ b/chapter_linear-regression/linear-regression-concise.md
@@ -229,8 +229,8 @@ def loss(self, y_hat, y):
 ```{.python .input}
 %%tab jax
 @d2l.add_to_class(LinearRegression)  #@save
-def loss(self, params, X, y):
-    y_hat = self.apply(params, X)
+def loss(self, params, X, y, state):
+    y_hat = state.apply_fn({'params': params}, X)
     return d2l.reduce_mean(optax.l2_loss(y_hat, y))
 ```
 
@@ -344,7 +344,7 @@ w, b = model.get_w_b()
 %%tab jax
 @d2l.add_to_class(LinearRegression)  #@save
 def get_w_b(self, state):
-    net = state.params['params']['net']
+    net = state.params['net']
     return net['kernel'], net['bias']
 
 w, b = model.get_w_b(trainer.state)

--- a/chapter_linear-regression/linear-regression-scratch.md
+++ b/chapter_linear-regression/linear-regression-scratch.md
@@ -417,8 +417,7 @@ def fit_epoch(self):
 def fit_epoch(self):
     self.model.training = True
     if self.state.batch_stats:
-        # Models requiring mutable states e.g., BatchNorm
-        # To be introduced later in section 8.5
+        # Mutable states will be used later (e.g., for batch norm)
         for batch in self.train_dataloader:
             (_, mutated_vars), grads = self.model.training_step(self.state.params,
                                                            self.prepare_batch(batch),

--- a/chapter_linear-regression/oo-design.md
+++ b/chapter_linear-regression/oo-design.md
@@ -364,13 +364,13 @@ class Trainer(d2l.HyperParameters):  #@save
             params = variables['params']
 
             if 'batch_stats' in variables.keys():
-                # Model contains BatchNorm layer; Handle batch_stats collection
-                # To be used later in section 8.5
+                # Here batch_stats will be used later (e.g., for batch norm)
                 batch_stats = variables['batch_stats']
             else:
                 batch_stats = {}
 
             # Flax uses optax under the hood for a single state obj TrainState
+            # (more will be discussed later in the batch normalization section)
             class TrainState(train_state.TrainState):
                 batch_stats: Any
             self.state = TrainState.create(apply_fn=model.apply,

--- a/chapter_linear-regression/weight-decay.md
+++ b/chapter_linear-regression/weight-decay.md
@@ -305,9 +305,9 @@ class WeightDecayScratch(d2l.LinearRegressionScratch):
 class WeightDecayScratch(d2l.LinearRegressionScratch):
     lambd: int = 0
         
-    def loss(self, params, X, y):
-        return (super().loss(params, X, y) +
-                self.lambd * l2_penalty(params['params']['w']))
+    def loss(self, params, X, y, state):
+        return (super().loss(params, X, y, state) +
+                self.lambd * l2_penalty(params['w']))
 ```
 
 The following code fits our model on the training set with 20 examples and evaluates it on the validation set with 100 examples.
@@ -325,7 +325,7 @@ def train_scratch(lambd):
         print('L2 norm of w:', float(l2_penalty(model.w)))
     if tab.selected('jax'):
         print('L2 norm of w:',
-              float(l2_penalty(trainer.state.params['params']['w'])))
+              float(l2_penalty(trainer.state.params['w'])))
 ```
 
 ### [**Training without Regularization**]

--- a/chapter_multilayer-perceptrons/dropout.md
+++ b/chapter_multilayer-perceptrons/dropout.md
@@ -441,7 +441,8 @@ def loss(self, params, X, Y, state, averaged=True):
                            rngs={'dropout': jax.random.PRNGKey(0)})
     Y_hat = d2l.reshape(Y_hat, (-1, Y_hat.shape[-1]))
     fn = optax.softmax_cross_entropy_with_integer_labels
-    return fn(Y_hat, Y).mean() if averaged else fn(Y_hat, Y)
+    # Empty dict in return indicates aux data; to be used in BatchNorm later
+    return (fn(Y_hat, Y).mean(), {}) if averaged else (fn(Y_hat, Y), {})
 ```
 
 Next, we [**train the model**].

--- a/chapter_multilayer-perceptrons/dropout.md
+++ b/chapter_multilayer-perceptrons/dropout.md
@@ -434,9 +434,11 @@ mask internally.
 ```{.python .input}
 %%tab jax
 @d2l.add_to_class(d2l.Classifier)  #@save
-@partial(jax.jit, static_argnums=(0, 4))
-def loss(self, params, X, Y, averaged=True):
-    Y_hat = self.apply(params, X, rngs={'dropout': jax.random.PRNGKey(0)})
+@partial(jax.jit, static_argnums=(0, 5))
+def loss(self, params, X, Y, state, averaged=True):
+    Y_hat = state.apply_fn({'params': params}, X,
+                           mutable=False,  # Used in BN later
+                           rngs={'dropout': jax.random.PRNGKey(0)})
     Y_hat = d2l.reshape(Y_hat, (-1, Y_hat.shape[-1]))
     fn = optax.softmax_cross_entropy_with_integer_labels
     return fn(Y_hat, Y).mean() if averaged else fn(Y_hat, Y)

--- a/chapter_multilayer-perceptrons/dropout.md
+++ b/chapter_multilayer-perceptrons/dropout.md
@@ -437,11 +437,12 @@ mask internally.
 @partial(jax.jit, static_argnums=(0, 5))
 def loss(self, params, X, Y, state, averaged=True):
     Y_hat = state.apply_fn({'params': params}, X,
-                           mutable=False,  # Used in BN later
+                           mutable=False,  # To be used later (e.g., batch norm)
                            rngs={'dropout': jax.random.PRNGKey(0)})
     Y_hat = d2l.reshape(Y_hat, (-1, Y_hat.shape[-1]))
     fn = optax.softmax_cross_entropy_with_integer_labels
-    # Empty dict in return indicates aux data; to be used in BatchNorm later
+    # The returned empty dictionary is a placeholder for auxiliary data,
+    # which will be used later (e.g., for batch norm)
     return (fn(Y_hat, Y).mean(), {}) if averaged else (fn(Y_hat, Y), {})
 ```
 

--- a/chapter_multilayer-perceptrons/kaggle-house-price.md
+++ b/chapter_multilayer-perceptrons/kaggle-house-price.md
@@ -406,7 +406,7 @@ if tab.selected('pytorch', 'mxnet', 'tensorflow'):
     preds = [model(d2l.tensor(data.val.values, dtype=d2l.float32))
              for model in models]
 if tab.selected('jax'):
-    preds = [model.apply(trainer.state.params,
+    preds = [model.apply({'params': trainer.state.params},
              d2l.tensor(data.val.values, dtype=d2l.float32))
              for model in models]
 # Taking exponentiation of predictions in the logarithm scale

--- a/chapter_preface/index.md
+++ b/chapter_preface/index.md
@@ -472,9 +472,10 @@ import tensorflow as tf
 #@save
 from dataclasses import field
 from functools import partial
+from typing import Any
 import flax
 from flax import linen as nn
-from flax.training.train_state import TrainState
+from flax.training import train_state
 import jax
 from jax import numpy as jnp
 from jax import grad, vmap

--- a/chapter_preface/index.md
+++ b/chapter_preface/index.md
@@ -472,7 +472,6 @@ import tensorflow as tf
 #@save
 from dataclasses import field
 from functools import partial
-from typing import Any
 import flax
 from flax import linen as nn
 from flax.training import train_state
@@ -483,6 +482,7 @@ import numpy as np
 import optax
 import tensorflow as tf
 import tensorflow_datasets as tfds
+from typing import Any
 ```
 
 ### Target Audience

--- a/chapter_recurrent-neural-networks/sequence.md
+++ b/chapter_recurrent-neural-networks/sequence.md
@@ -471,7 +471,7 @@ d2l.plot(data.time[data.tau:], [data.labels, onestep_preds], 'time', 'x',
 
 ```{.python .input}
 %%tab jax
-onestep_preds = model.apply(trainer.state.params, data.features)
+onestep_preds = model.apply({'params': trainer.state.params}, data.features)
 d2l.plot(data.time[data.tau:], [data.labels, onestep_preds], 'time', 'x',
          legend=['labels', '1-step preds'], figsize=(6, 3))
 ```
@@ -536,7 +536,7 @@ for i in range(data.num_train + data.tau, data.T):
 multistep_preds = d2l.zeros(data.T)
 multistep_preds = multistep_preds.at[:].set(data.x)
 for i in range(data.num_train + data.tau, data.T):
-    pred = model.apply(trainer.state.params,
+    pred = model.apply({'params': trainer.state.params},
                        d2l.reshape(multistep_preds[i-data.tau : i], (1, -1)))
     multistep_preds = multistep_preds.at[i].set(pred.item())
 ```
@@ -594,7 +594,7 @@ def k_step_pred(k):
         features.append(data.x[i : i+data.T-data.tau-k+1])
     # The (i+tau)-th element stores the (i+1)-step-ahead predictions
     for i in range(k):
-        preds = model.apply(trainer.state.params,
+        preds = model.apply({'params': trainer.state.params},
                             d2l.stack(features[i : i+data.tau], 1))
         features.append(d2l.reshape(preds, -1))
     return features[data.tau:]

--- a/d2l/jax.py
+++ b/d2l/jax.py
@@ -567,7 +567,7 @@ class Classifier(d2l.Module):
         """Defined in :numref:`sec_lenet`"""
         X = jnp.zeros(X_shape)
         params = self.init(key, X)
-        bound_model = self.clone().bind(params)
+        bound_model = self.clone().bind(params, mutable=['batch_stats'])
         _ = bound_model(X)
         for layer in bound_model.net.layers:
             X = layer(X)


### PR DESCRIPTION
*Description of changes:*

1. Use `d2l.get_key` for simpler concise code.
2. Rewrite `fit` and `fit_epoch`, handling batchnorm
3. Explain pure functions and use JIT in softmax regression scratch section
4. `Classifier` class overwrites the `training_step` and `validation_step` from d2l.Module which is reusable for all models including ones with BatchNorm.
5. Add BatchNorm concise implementation



By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
