### PR TITLE
JAX: Add Deep RNN, enable dropout for RNN concise

### DIFF
--- a/chapter_recurrent-modern/deep-rnn.md
+++ b/chapter_recurrent-modern/deep-rnn.md
@@ -216,7 +216,7 @@ rather than picking the default of a single layer.
 
 :begin_tab:`jax`
 Flax takes a minimalistic approach while implementing
-RNNs. Defining number of layers in an RNN or combining it with Dropout
+RNNs. Defining the number of layers in an RNN or combining it with dropout
 is not available out of the box.
 Our concise implementation will use all built-in functionalities and
 add `num_layers` and `dropout` features on top.

--- a/chapter_recurrent-modern/gru.md
+++ b/chapter_recurrent-modern/gru.md
@@ -323,7 +323,7 @@ class GRU(d2l.RNN):
     num_hiddens: int
 
     @nn.compact
-    def __call__(self, inputs, H=None):
+    def __call__(self, inputs, H=None, training=False):
         if H is None:
             batch_size = inputs.shape[1]
             H = nn.GRUCell.initialize_carry(jax.random.PRNGKey(0),

--- a/chapter_recurrent-modern/lstm.md
+++ b/chapter_recurrent-modern/lstm.md
@@ -458,7 +458,7 @@ class LSTM(d2l.RNN):
     num_hiddens: int
 
     @nn.compact
-    def __call__(self, inputs, H_C=None):
+    def __call__(self, inputs, H_C=None, training=False):
         if H_C is None:
             batch_size = inputs.shape[1]
             H_C = nn.OptimizedLSTMCell.initialize_carry(jax.random.PRNGKey(0),

--- a/chapter_recurrent-neural-networks/rnn-concise.md
+++ b/chapter_recurrent-neural-networks/rnn-concise.md
@@ -155,11 +155,18 @@ class RNNLM(d2l.RNNLMScratch):  #@save
 ```{.python .input}
 %%tab jax
 class RNNLM(d2l.RNNLMScratch):  #@save
+    training: bool = True
+
     def setup(self):
         self.linear = nn.Dense(self.vocab_size)
-        
+
     def output_layer(self, hiddens):
         return d2l.swapaxes(self.linear(hiddens), 0, 1)
+
+    def forward(self, X, state=None):
+        embs = self.one_hot(X)
+        rnn_outputs, _ = self.rnn(embs, state, self.training)
+        return self.output_layer(rnn_outputs)
 ```
 
 ## Training and Predicting


### PR DESCRIPTION
*Description of changes:*
Flax doesn't provide ability to couple dropout with an RNN cell out of the box. Also there is no `num_layers` notion since there are no layers in Flax. This means the concise implementation is not very concise but this is the best we can implement
until Flax implements these concise RNN layers itself.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
