### PR TITLE
Fix word omission and LaTeX in `2.3 Norms`

### DIFF
--- a/chapter_preliminaries/linear-algebra.md
+++ b/chapter_preliminaries/linear-algebra.md
@@ -926,9 +926,9 @@ and should not be confused with the Hadamard product.
 
 Some of the most useful operators in linear algebra are *norms*.
 Informally, the norm of a vector tells us how *big* it is. 
-For instance, the $\\ell_2$ norm measures
+For instance, the $\ell_2$ norm measures
 the (Euclidean) length of a vector.
-Here, we are employing a notion of *size* that concerns the magnitude a vector's components
+Here, we are employing a notion of *size* that concerns the magnitude of a vector's components
 (not its dimensionality). 
 
 A norm is a function $\| \cdot \|$ that maps a vector


### PR DESCRIPTION
*Description of changes:*

In `2.3 Norms`, a sentence is missing a word, and a nearby sentence has a typographical error in LaTeX that causes a rendering issue (displaying `ell` instead of the intended cursive `l`). See the rendering issue below or live at the time of this writing [here](https://d2l.ai/chapter_preliminaries/linear-algebra.html#norms).

<img width="350" alt="Screenshot 2022-12-14 at 17 40 07" src="https://user-images.githubusercontent.com/4722424/207547964-4cf81861-e818-402d-9b93-c1104e4a5b6d.png">


<hr>

_By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice._