### PR TITLE
Remove [None, :]

### DIFF
--- a/chapter_attention-mechanisms-and-transformers/attention-scoring-functions.md
+++ b/chapter_attention-mechanisms-and-transformers/attention-scoring-functions.md
@@ -125,7 +125,7 @@ def masked_softmax(X, valid_lens):  #@save
     def _sequence_mask(X, valid_len, value=0):
         maxlen = X.size(1)
         mask = torch.arange((maxlen), dtype=torch.float32,
-                            device=X.device)[None, :] < valid_len[:, None]
+                            device=X.device) < valid_len[:, None]
         X[~mask] = value
         return X
     


### PR DESCRIPTION
*Description of changes:*
Minor code cleaning. 
The `[None, :]` is unnecessary, because without `[None, :]` PyTorch [broadcasting](https://pytorch.org/docs/stable/notes/broadcasting.html) will also prepend 1 to the dimensions of torch.arange()'s output. 

I tested the change by removing the `[None, :]` and running the `masked_softmax()`code below in 11.3.2.1. 
The output are the same as when we have `[None, :]`, in terms of the number of masked and unmasked elements. 
I pasted the output below. You can compare it with the output on the [website](https://d2l.ai/chapter_attention-mechanisms-and-transformers/attention-scoring-functions.html#masked-softmax-operation). 

```
masked_softmax(torch.rand(2, 2, 4), torch.tensor([2, 3]))
tensor([[[0.5670, 0.4330, 0.0000, 0.0000],
         [0.5983, 0.4017, 0.0000, 0.0000]],

        [[0.4297, 0.3518, 0.2185, 0.0000],
         [0.3578, 0.3347, 0.3075, 0.0000]]])
```

```
masked_softmax(torch.rand(2, 2, 4), torch.tensor([[1, 3], [2, 4]]))
tensor([[[1.0000, 0.0000, 0.0000, 0.0000],
         [0.4129, 0.3338, 0.2533, 0.0000]],

        [[0.4291, 0.5709, 0.0000, 0.0000],
         [0.2964, 0.2290, 0.1903, 0.2844]]])
```

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
