### PR TITLE
Remove unnecessary reshape

### DIFF
--- a/chapter_multilayer-perceptrons/kaggle-house-price.md
+++ b/chapter_multilayer-perceptrons/kaggle-house-price.md
@@ -307,7 +307,7 @@ def get_dataloader(self, train):
     get_tensor = lambda x: d2l.tensor(x.values, dtype=d2l.float32)
     # Logarithm of prices 
     tensors = (get_tensor(data.drop(columns=[label])),  # X
-               d2l.reshape(d2l.log(get_tensor(data[label])), (-1, 1)))  # Y
+               d2l.log(get_tensor(data[label])))  # Y
     return self.get_tensorloader(tensors, train)
 ```
 


### PR DESCRIPTION
*Description of changes:*
Please let me know if you need more details. 
I tested removing the `.reshape((-1, 1))` from the PyTorch version of the notebook. The train loss and validation loss remain the same after the removal. But I'm unsure how the code changed here translates to other framework versions like JAX or TF. Can you double check if the change will work for non-PyTorch versions?

Removal of the unnecessary `reshape` helps ease the burden on the learners at this early chapter of the book. 

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
