### PR TITLE
Remove unnecessary reshape

### DIFF
--- a/chapter_recurrent-neural-networks/sequence.md
+++ b/chapter_recurrent-neural-networks/sequence.md
@@ -518,7 +518,7 @@ multistep_preds = d2l.zeros(data.T)
 multistep_preds[:] = data.x
 for i in range(data.num_train + data.tau, data.T):
     multistep_preds[i] = model(
-        d2l.reshape(multistep_preds[i-data.tau : i], (1, -1)))
+        multistep_preds[i-data.tau : i])
 multistep_preds = d2l.numpy(multistep_preds)
 ```
 


### PR DESCRIPTION
*Description of changes:*
Please let me know if you need more details.
I tested removing the .reshape((-1, 1)) from the PyTorch version of the notebook. The `multistep_preds` plot remains the same. 

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
