### PR TITLE
PyTorch: Avoid creating ragged tensors; support numpy>=1.24

### DIFF
--- a/chapter_optimization/sgd.md
+++ b/chapter_optimization/sgd.md
@@ -72,12 +72,23 @@ def f_grad(x1, x2):  # Gradient of the objective function
 ```
 
 ```{.python .input}
-#@tab mxnet, pytorch
+#@tab mxnet
 def sgd(x1, x2, s1, s2, f_grad):
     g1, g2 = f_grad(x1, x2)
     # Simulate noisy gradient
     g1 += d2l.normal(0.0, 1, (1,))
     g2 += d2l.normal(0.0, 1, (1,))
+    eta_t = eta * lr()
+    return (x1 - eta_t * g1, x2 - eta_t * g2, 0, 0)
+```
+
+```{.python .input}
+#@tab pytorch
+def sgd(x1, x2, s1, s2, f_grad):
+    g1, g2 = f_grad(x1, x2)
+    # Simulate noisy gradient
+    g1 += torch.normal(0.0, 1, (1,)).item()
+    g2 += torch.normal(0.0, 1, (1,)).item()
     eta_t = eta * lr()
     return (x1 - eta_t * g1, x2 - eta_t * g2, 0, 0)
 ```


### PR DESCRIPTION
*Description of changes:*
After https://github.com/numpy/numpy/pull/22004/ , ragged array creation in `numpy>=1.24` raises a value error. This PR fixes one such instance of ragged arrays used in d2l code.


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
