### PR TITLE
Update autograd.md

### DIFF
--- a/chapter_preliminaries/autograd.md
+++ b/chapter_preliminaries/autograd.md
@@ -270,7 +270,7 @@ This behavior comes in handy
 when we want to optimize the sum 
 of multiple objective functions.
 To reset the gradient buffer,
-we can call `x.grad.zero()` as follows:
+we can call `x.grad.zero_()` as follows:
 :end_tab:
 
 :begin_tab:`tensorflow`


### PR DESCRIPTION
typo in function name corrected

*Description of changes:*
x.grad.zero() -> x.grad.zero_()

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
