### PR TITLE
Update linear-regression-scratch.md

### DIFF
--- a/chapter_linear-regression/linear-regression-scratch.md
+++ b/chapter_linear-regression/linear-regression-scratch.md
@@ -478,12 +478,19 @@ with those that we learned**] through our training loop.
 Indeed they turn out to be very close to each other.
 
 ```{.python .input  n=21}
-%%tab pytorch, mxnet, tensorflow
+%%tab pytorch
+with torch.no_grad():
+    print(f'error in estimating w: {data.w - d2l.reshape(model.w, data.w.shape)}')
+    print(f'error in estimating b: {data.b - model.b}')
+```
+
+```{.python .input  n=22}
+%%tab mxnet, tensorflow
 print(f'error in estimating w: {data.w - d2l.reshape(model.w, data.w.shape)}')
 print(f'error in estimating b: {data.b - model.b}')
 ```
 
-```{.python .input  n=22}
+```{.python .input  n=23}
 %%tab jax
 params = trainer.state.params
 print(f"error in estimating w: {data.w - d2l.reshape(params['w'], data.w.shape)}")


### PR DESCRIPTION
Here, we used `torch.no_grad()` to avoid tracking the gradient.  When performing any external operations outside of the training loop on model parameters, we don't want to accumulate the gradient of those operations.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
