### PR TITLE
A small typo

### DIFF
--- a/chapter_appendix-mathematics-for-deep-learning/multivariable-calculus.md
+++ b/chapter_appendix-mathematics-for-deep-learning/multivariable-calculus.md
@@ -15,7 +15,7 @@ Now, let's take this and change $w_2$ a little bit to $w_2 + \epsilon_2$:
 
 $$
 \begin{aligned}
-L(w_1+\epsilon_1, w_2+\epsilon_2, \ldots, w_N) & \approx L(w_1, w_2+\epsilon_2, \ldots, w_N) + \epsilon_1 \frac{\partial}{\partial w_1} L(w_1, w_2+\epsilon_2, \ldots, w_N+\epsilon_N) \\
+L(w_1+\epsilon_1, w_2+\epsilon_2, \ldots, w_N) & \approx L(w_1, w_2+\epsilon_2, \ldots, w_N) + \epsilon_1 \frac{\partial}{\partial w_1} L(w_1, w_2+\epsilon_2, \ldots, w_N) \\
 & \approx L(w_1, w_2, \ldots, w_N) \\
 & \quad + \epsilon_2\frac{\partial}{\partial w_2} L(w_1, w_2, \ldots, w_N) \\
 & \quad + \epsilon_1 \frac{\partial}{\partial w_1} L(w_1, w_2, \ldots, w_N) \\


### PR DESCRIPTION
You are saying that you "change $w_2$ a little bit", but then the equation also updates $w_N$, which is wrong at this point.  (This is only done later.)

*Description of changes:* I am just removing $+\epsilon_N$ from the end of the equation $L(w_1+\epsilon_1, w_2+\epsilon_2, \ldots, w_N) \approx L(w_1, w_2+\epsilon_2, \ldots, w_N) + \epsilon_1 \frac{\partial}{\partial w_1} L(w_1, w_2+\epsilon_2, \ldots, w_N+\epsilon_N)$ so that it nou reads $L(w_1+\epsilon_1, w_2+\epsilon_2, \ldots, w_N) \approx L(w_1, w_2+\epsilon_2, \ldots, w_N) + \epsilon_1 \frac{\partial}{\partial w_1} L(w_1, w_2+\epsilon_2, \ldots, w_N)$.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the  terms of your choice.
