### PR TITLE
Fixed typo

### DIFF
--- a/chapter_appendix-mathematics-for-deep-learning/multivariable-calculus.md
+++ b/chapter_appendix-mathematics-for-deep-learning/multivariable-calculus.md
@@ -163,7 +163,7 @@ This brings us to one of the most important mathematical concepts in machine lea
 
 1. Start with a random choice for the initial parameters $\mathbf{w}$.
 2. Compute $\nabla_{\mathbf{w}} L(\mathbf{w})$.
-3. Take a small step in the opposite of that direction: $\mathbf{w} \rightarrow \mathbf{w} - \epsilon\nabla_{\mathbf{w}} L(\mathbf{w})$.
+3. Take a small step in the opposite of that direction: $\mathbf{w} \leftarrow \mathbf{w} - \epsilon\nabla_{\mathbf{w}} L(\mathbf{w})$.
 4. Repeat.
 
 


### PR DESCRIPTION
Changed the direction of the gradient descent arrow to match the more conventional notation (and the convention in the rest of the book).

*Description of changes:* Changed $\rightarrow$ to $\leftarrow$ so that you have $\mathbf{w} \leftarrow \mathbf{w} - \epsilon\nabla_{\mathbf{w}} L(\mathbf{w})$.


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
