### PR TITLE
pytorch: enable gpu for apple mps

### DIFF
--- a/d2l/torch.py
+++ b/d2l/torch.py
@@ -522,12 +522,16 @@ def gpu(i=0):
     """Get a GPU device.
 
     Defined in :numref:`sec_use_gpu`"""
+    if torch.backends.mps.is_available():
+        return torch.device(f'mps:{i}')
     return torch.device(f'cuda:{i}')
 
 def num_gpus():
     """Get the number of available GPUs.
 
     Defined in :numref:`sec_use_gpu`"""
+    if torch.backends.mps.is_available():
+        return 1
     return torch.cuda.device_count()
 
 def try_gpu(i=0):


### PR DESCRIPTION
This commit roughly enable `mps` for the d2l's pytorch implementation. 
Tested on mac 13.2.1 (intel chip), with pytorch 1.12 and 1.13.

You may want to have a look at the references here:
- https://pytorch.org/docs/stable/notes/mps.html
- https://developer.apple.com/metal/pytorch/

How to test on MacOS:
`
import sys
sys.path.append('/path/to/local/d2l-en/pytorch/')
from d2l import torch as d2l
d2l.num_gpus()
`
1