### PR TITLE
Fix a reference

### DIFF
--- a/chapter_introduction/index.md
+++ b/chapter_introduction/index.md
@@ -1392,7 +1392,7 @@ Many scholars have asked whether one could explain
 and possibly reverse engineer this capacity.
 One of the oldest biologically inspired algorithms
 was formulated by [Donald Hebb (1904--1985)](https://en.wikipedia.org/wiki/Donald_O._Hebb).
-In his groundbreaking book *The Organization of Behavior* :cite:`Hebb.Hebb.1949`,
+In his groundbreaking book *The Organization of Behavior* :cite:`Hebb.1949`,
 he posited that neurons learn by positive reinforcement.
 This became known as the Hebbian learning rule.
 These ideas inspired later works like

--- a/d2l.bib
+++ b/d2l.bib
@@ -1080,9 +1080,9 @@
   organization	= {Springer}
 }
 
-@Book{		  Hebb.Hebb.1949,
+@Book{		  Hebb.1949,
   title		= {The organization of behavior},
-  author	= {Hebb, Donald Olding and Hebb, DO},
+  author	= {Hebb, Donald Olding},
   volume	= {65},
   year		= {1949},
   publisher	= {Wiley New York}


### PR DESCRIPTION
*Description of changes:*

The same author was referred to twice in the author field for this citation. The author of the referenced book is Hebb, Donald Olding, and the contents of the author field in this citation were "Hebb, Donald Olding and Hebb, DO".

Please, check the References in [(Morris, 1999), DOI: 10.1016/S0361-9230(99)00182-3](https://doi.org/10.1016/S0361-9230(99)00182-3), which corroborate that the author should only be stated once in this citation.

The citation link has been changed accordingly, from `Hebb.Hebb.1949`, to `Hebb.1949`

This citation is only linked in the introduction, so only the link from the introduction had to be changed. No other citation links need to be changed.



By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
