### PR TITLE
[BUG]  model is missing

### DIFF
--- a/chapter_computational-performance/multiple-gpus-concise.md
+++ b/chapter_computational-performance/multiple-gpus-concise.md
@@ -213,6 +213,7 @@ def train(net, num_gpus, batch_size, lr):
         if type(module) in [nn.Linear, nn.Conv2d]:
             nn.init.normal_(module.weight, std=0.01)
     net.apply(init_weights)
+    net = net.to(devices[0])
     # Set the model on multiple GPUs
     net = nn.DataParallel(net, device_ids=devices)
     trainer = torch.optim.SGD(net.parameters(), lr)


### PR DESCRIPTION
The error message is：
module must have its parameters and buffers on device cuda:0 (device_ids[0]) but found one of them on device: cpu

How to reproduce the error?
Run the multi-card code directly in this code snippet, instead of running the single-card code first and then running the multi-card code.

I am not familiar with other languages, so I won't be able to help if there are errors in them.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
