### PR TITLE
Update linear-algebra.md

### DIFF
--- a/chapter_preliminaries/linear-algebra.md
+++ b/chapter_preliminaries/linear-algebra.md
@@ -789,7 +789,7 @@ we use the `mv` function.
 Note that the column dimension of `A` 
 (its length along axis 1)
 must be the same as the dimension of `x` (its length). 
-PyTorch has a convenience operator `@` 
+Python has a convenience operator `@` 
 that can execute both matrix-vector
 and matrix-matrix products
 (depending on its arguments). 


### PR DESCRIPTION
The matrix multiplication operator is not due to PyTorch, but due to https://peps.python.org/pep-0465. PyTorch's tensor classes simply overrides the __matmul__ method. 

Best regards

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
