### PR TITLE
Fix typo in autograd.md

### DIFF
--- a/chapter_preliminaries/autograd.md
+++ b/chapter_preliminaries/autograd.md
@@ -422,7 +422,7 @@ has been wiped out.
 Thus `u` has no ancestors in the graph
 and gradients do not flow through `u` to `x`.
 For example, taking the gradient of `z = x * u`
-will yield the result `x`,
+will yield the result `u`,
 (not `3 * x * x` as you might have 
 expected since `z = x * x * x`).
 


### PR DESCRIPTION
In 2.5.3: Detaching computation, it is stated that "For example, taking the gradient of z = x * u will yield the result x" which is wrong and has been replaced by "u" instead.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
