### PR TITLE
Update softmax-regression.md

### DIFF
--- a/chapter_linear-classification/softmax-regression.md
+++ b/chapter_linear-classification/softmax-regression.md
@@ -316,7 +316,7 @@ Since $\mathbf{y}$ is a one-hot vector of length $q$,
 the sum over all its coordinates $j$ vanishes for all but one term.
 Note that the loss $l(\mathbf{y}, \hat{\mathbf{y}})$
 is bounded from below by $0$
-whenever $\hat{y}$ is a probability vector:
+whenever $\hat{\mathbf{y}}$ is a probability vector:
 no single entry is larger than $1$,
 hence their negative logarithm cannot be lower than $0$;
 $l(\mathbf{y}, \hat{\mathbf{y}}) = 0$ only if we predict


### PR DESCRIPTION
The probability vector should be noted as \hat{\mathbf{y}} instead of \hat{y}, which might mean an entry in the probability vector.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
