### PR TITLE
add torchviz library to draw computational graph

### DIFF
--- a/chapter_multilayer-perceptrons/backprop.md
+++ b/chapter_multilayer-perceptrons/backprop.md
@@ -116,6 +116,32 @@ are primarily rightward and upward.
 ![Computational graph of forward propagation.](../img/forward.svg)
 :label:`fig_forward`
 
+## Computational Graph Visualization
+A computational graph in PyTorch is a graphical representation of the sequence of operations or computations performed on tensors. It captures the flow of data and the dependencies between tensors, providing a mechanism for automatic differentiation and gradient computation.
+
+In PyTorch, when you define a computation using tensor operations, the computational graph is automatically constructed in the background. This graph keeps track of the tensors involved in the computation, the operations performed on them, and the relationships between them.
+
+The computational graph consists of nodes and edges, where nodes represent tensors and edges represent the operations applied to those tensors. Each node in the graph represents a tensor and includes information such as the tensor's shape, data type, and the operation that created it. The edges connect the nodes and represent the flow of data between tensors.
+
+Here we will use the `torchviz` package to visualize the computational graph of forward propagation. For install `torchviz`, you can refer to [here](https://www.graphviz.org/download/). Linux user can simply run "sudo apt-get install graphviz" to install it from the terminal.
+
+```{.python .input}
+%%tab pytorch
+# "sudo apt-get install graphviz" to install graphviz
+import torch
+from torchviz import make_dot
+# Create some tensors and perform operations
+x = torch.tensor([2.0], requires_grad=True)
+y = torch.tensor([3.0], requires_grad=True)
+z = x + y
+output = z * z
+# Visualize the computational graph
+dot = make_dot(output, params={"x": x, "y": y})
+# Save the graph as a PDF file
+dot.render("computational_graph", format="png")
+```
+
+
 ## Backpropagation
 
 *Backpropagation* refers to the method of calculating


### PR DESCRIPTION
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.

Add several paragraph to discuss the computational graph in pytorch and show an example of using torchviz to automatically generate a computational graph. Here is an example and a screenshot of the generated graph:
`import torch
from torchviz import make_dot

# Create some tensors and perform operations
x = torch.tensor([2.0], requires_grad=True)
y = torch.tensor([3.0], requires_grad=True)
z = x + y
output = z * z

# Visualise the computational graph
dot = make_dot(output, params={"x": x, "y": y})

# Save the graph as a PDF file
dot.render("computational_graph", format="png")`

[generated graph](https://drive.google.com/file/d/1PWCXS2anXhMJM3XtZi6HNeGyjsTJB9Ex/view?usp=sharing)
