### PR TITLE
Update lstm.md

### DIFF
--- a/chapter_recurrent-modern/lstm.md
+++ b/chapter_recurrent-modern/lstm.md
@@ -9,7 +9,7 @@ became salient, with Bengio and Hochreiter
 discussing the problem
 :cite:`bengio1994learning,Hochreiter.Bengio.Frasconi.ea.2001`.
 Hochreiter had articulated this problem as early 
-as in his 1991 masters thesis, although the results 
+as 1991 in his masters thesis, although the results 
 were not widely known because the thesis was written in German.
 While gradient clipping helps with exploding gradients, 
 handling vanishing gradients appears 


### PR DESCRIPTION
Rearrange the order of the words to improve clarity

Original: "Hochreiter had articulated this problem __as early as in his 1991 masters thesis__, although the results were not widely known because the thesis was written in German. "

Changed to: "Hochreiter had articulated this problem __as early as 1991 in his masters thesis__, although the results were not widely known because the thesis was written in German. "

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
