### PR TITLE
Update information-theory.md / fixing p_xy distribution in python example for conditional entropy

### DIFF
--- a/chapter_appendix-mathematics-for-deep-learning/information-theory.md
+++ b/chapter_appendix-mathematics-for-deep-learning/information-theory.md
@@ -272,7 +272,7 @@ def conditional_entropy(p_xy, p_x):
     out = nansum(cond_ent.as_nd_ndarray())
     return out
 
-conditional_entropy(np.array([[0.1, 0.5], [0.2, 0.3]]), np.array([0.2, 0.8]))
+conditional_entropy(np.array([[0.1, 0.5], [0.2, 0.2]]), np.array([0.2, 0.8]))
 ```
 
 ```{.python .input}
@@ -284,7 +284,7 @@ def conditional_entropy(p_xy, p_x):
     out = nansum(cond_ent)
     return out
 
-conditional_entropy(torch.tensor([[0.1, 0.5], [0.2, 0.3]]),
+conditional_entropy(torch.tensor([[0.1, 0.5], [0.2, 0.2]]),
                     torch.tensor([0.2, 0.8]))
 ```
 
@@ -297,7 +297,7 @@ def conditional_entropy(p_xy, p_x):
     out = nansum(cond_ent)
     return out
 
-conditional_entropy(tf.constant([[0.1, 0.5], [0.2, 0.3]]),
+conditional_entropy(tf.constant([[0.1, 0.5], [0.2, 0.2]]),
                     tf.constant([0.2, 0.8]))
 ```
 


### PR DESCRIPTION
the point probabilities should sum up to 1.
in the current version: 0.1 +0.5 + 0.2 + 0.3 = 1.1 so to fix this, we could replace 0.3 with 0.2: 0.1 +0.5 + 0.2 + 0.2 = 1.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
