### PR TITLE
Fix deprecated use of torch.norm

### DIFF
--- a/chapter_appendix-mathematics-for-deep-learning/eigendecomposition.md
+++ b/chapter_appendix-mathematics-for-deep-learning/eigendecomposition.md
@@ -412,10 +412,10 @@ d2l.plot(np.arange(0, 100), norm_list, 'Iteration', 'Value')
 # Calculate the sequence of norms after repeatedly applying `A`
 v_in = torch.randn(k, 1, dtype=torch.float64)
 
-norm_list = [torch.norm(v_in).item()]
+norm_list = [torch.linalg.matrix_norm(v_in).item()]
 for i in range(1, 100):
     v_in = A @ v_in
-    norm_list.append(torch.norm(v_in).item())
+    norm_list.append(torch.linalg.matrix_norm(v_in).item())
 
 d2l.plot(torch.arange(0, 100), norm_list, 'Iteration', 'Value')
 ```
@@ -578,10 +578,10 @@ A /= norm_eigs[-1]
 # Do the same experiment again
 v_in = torch.randn(k, 1, dtype=torch.float64)
 
-norm_list = [torch.norm(v_in).item()]
+norm_list = [torch.linalg.matrix_norm(v_in).item()]
 for i in range(1, 100):
     v_in = A @ v_in
-    norm_list.append(torch.norm(v_in).item())
+    norm_list.append(torch.linalg.matrix_norm(v_in).item())
 
 d2l.plot(torch.arange(0, 100), norm_list, 'Iteration', 'Value')
 ```

--- a/chapter_appendix-mathematics-for-deep-learning/geometry-linear-algebraic-ops.md
+++ b/chapter_appendix-mathematics-for-deep-learning/geometry-linear-algebraic-ops.md
@@ -170,7 +170,7 @@ from torchvision import transforms
 import torchvision
 
 def angle(v, w):
-    return torch.acos(v.dot(w) / (torch.norm(v) * torch.norm(w)))
+    return torch.acos(v.dot(w) / (torch.linalg.vector_norm(v) * torch.linalg.vector_norm(w)))
 
 angle(torch.tensor([0, 1, 2], dtype=torch.float32), torch.tensor([2.0, 3, 4]))
 ```

--- a/chapter_preliminaries/linear-algebra.md
+++ b/chapter_preliminaries/linear-algebra.md
@@ -973,7 +973,7 @@ np.linalg.norm(u)
 ```{.python .input}
 %%tab pytorch
 u = torch.tensor([3.0, -4.0])
-torch.norm(u)
+torch.linalg.vector_norm(u)
 ```
 
 ```{.python .input}
@@ -1051,7 +1051,7 @@ np.linalg.norm(np.ones((4, 9)))
 
 ```{.python .input}
 %%tab pytorch
-torch.norm(torch.ones((4, 9)))
+torch.linalg.matrix_norm(torch.ones((4, 9)))
 ```
 
 ```{.python .input}


### PR DESCRIPTION
*Description of changes:*

Update uses of deprecated `torch.norm` to `torch.linalg.vector_norm` if the `ndim` of the value passed is 1 or `torch.linalg.matrix_norm` if the `ndim` of the value passed is >= 2 in:
- chapter_appendix-mathematics-for-deep-learning\geometry-linear-algebraic-ops.md
- chapter_appendix-mathematics-for-deep-learning\eigendecomposition.md
- chapter_preliminaries\linear-algebra.md

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
