### PR TITLE
Fixed a small typo

### DIFF
--- a/chapter_introduction/index.md
+++ b/chapter_introduction/index.md
@@ -1209,7 +1209,7 @@ for video games.
 *Deep reinforcement learning*, which applies
 deep learning to reinforcement learning problems,
 has surged in popularity.
-The breakthrough deep Q-network, that beat humans
+The breakthrough deep Q-network, that beats humans
 at Atari games using only the visual input :cite:`mnih2015human`,
 and the AlphaGo program, which dethroned the world champion
 at the board game Go :cite:`Silver.Huang.Maddison.ea.2016`,


### PR DESCRIPTION
There was a missing "s" in "The breakthrough deep Q-network, that beat humans"