### PR TITLE
Correct typo in environment-and-distribution-shift.md

### DIFF
--- a/chapter_linear-classification/environment-and-distribution-shift.md
+++ b/chapter_linear-classification/environment-and-distribution-shift.md
@@ -142,7 +142,7 @@ when we believe that $y$ causes $\mathbf{x}$.
 For example, we may want to predict diagnoses
 given their symptoms (or other manifestations),
 even as the relative prevalence of diagnoses
-are changing over time.
+is changing over time.
 Label shift is the appropriate assumption here
 because diseases cause symptoms.
 In some degenerate cases the label shift


### PR DESCRIPTION
*Description of changes:*
'relative prevalence of diagnoses' is a singular noun. Thus, I changed the verb 'are' to 'is'.


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
