### PR TITLE
Update pandas.md. Adapted for higher versions of the Pandas library

### DIFF
--- a/chapter_preliminaries/pandas.md
+++ b/chapter_preliminaries/pandas.md
@@ -110,7 +110,7 @@ the mean value of the corresponding column**].
 
 ```{.python .input}
 %%tab all
-inputs = inputs.fillna(inputs.mean())
+inputs = inputs.fillna(inputs.select_dtypes(include='number').mean())
 print(inputs)
 ```
 


### PR DESCRIPTION
In older versions of the Pandas library, when the mean() method is applied to 'inputs', it would skip uncomputable types and calculate the data directly, thus ignoring any errors. However, in higher versions of the Pandas library, strict data type checking is performed, which triggers the error 'TypeError: can only concatenate str (not "int") to str'. The revised code will filter and calculate the data based on the data types, avoiding the occurrence of this error.
