### PR TITLE
Fixed uci.edu dataset link for Airfoil dataset

### DIFF
--- a/chapter_optimization/minibatch-sgd.md
+++ b/chapter_optimization/minibatch-sgd.md
@@ -261,7 +261,7 @@ As we can see, the computation on the minibatch is essentially as efficient as o
 
 ## Reading the Dataset
 
-Let's have a look at how minibatches are efficiently generated from data. In the following we use a dataset developed by NASA to test the wing [noise from different aircraft](https://archive.ics.uci.edu/ml/datasets/Airfoil+Self-Noise) to compare these optimization algorithms. For convenience we only use the first $1,500$ examples. The data is whitened for preprocessing, i.e., we remove the mean and rescale the variance to $1$ per coordinate.
+Let's have a look at how minibatches are efficiently generated from data. In the following we use a dataset developed by NASA to test the wing [noise from different aircraft](https://archive.ics.uci.edu/dataset/291/airfoil+self+noise) to compare these optimization algorithms. For convenience we only use the first $1,500$ examples. The data is whitened for preprocessing, i.e., we remove the mean and rescale the variance to $1$ per coordinate.
 
 ```{.python .input}
 #@tab mxnet


### PR DESCRIPTION
This is probably related to when the link fixed in #2568 broke.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
