### PR TITLE
Fixed incorrect "translation invariance" in problem in softmax-regression.md

### DIFF
--- a/chapter_linear-classification/softmax-regression.md
+++ b/chapter_linear-classification/softmax-regression.md
@@ -538,7 +538,7 @@ the item with the largest score is the most likely one to be chosen :cite:`Bradl
     1. Extend this to more than two numbers.
 1. The function $g(\mathbf{x}) \stackrel{\textrm{def}}{=} \log \sum_i \exp x_i$ is sometimes also referred to as the [log-partition function](https://en.wikipedia.org/wiki/Partition_function_(mathematics)).
     1. Prove that the function is convex. Hint: to do so, use the fact that the first derivative amounts to the probabilities from the softmax function and show that the second derivative is the variance.
-    1. Show that $g$ is translation invariant, i.e., $g(\mathbf{x} + b) = g(\mathbf{x})$.
+    1. Show that $g$ is translation equivariant, i.e., $g(\mathbf{x} - b) = g(\mathbf{x}) - b$.
     1. What happens if some of the coordinates $x_i$ are very large? What happens if they're all very small?
     1. Show that if we choose $b = \mathrm{max}_i x_i$ we end up with a numerically stable implementation.
 1. Assume that we have some probability distribution $P$. Suppose we pick another distribution $Q$ with $Q(i) \propto P(i)^\alpha$ for $\alpha > 0$.


### PR DESCRIPTION
Hello, when working through the exercises inside of softmax-regression.md I've noticed that one of the problem seems to have a small error, namely the function $g$ is not translation invariant, but rather translation equivariant. This means that there should be a $+b$ term outside of the function as well.

Also I've changed the sign of the b to align it closer to what should be done in the last subproblem: "Show that if we choose $b = \mathrm{max}_i x_i$ we end up with a numerically stable implementation."

As such the corrected version of the problem is $g(\underline{x} - b) = g(\underline{x}) - b$.

### Proof
```math
\begin{aligned}
g(\underline{x} - b) &= \log \sum_i \exp(x_i - b) \\
&= \log \sum_i \exp(x_i) \exp(-b) \\
&= \log \left( \left( \sum_i \exp(x_i) \right) \exp(-b) \right) \\
&\overset{1}{=} \log \left(\sum_i \exp(x_i)\right) + \log \exp(-b) \\
&\overset{2}{=} \log \left(\sum_i \exp(x_i)\right) - b = g(\underline{x}) - b.
\end{aligned}
```
Where we have used that (1) $\log(xy) = \log(x) + \log(y)$ and (2) $\log\exp x = x$.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
