### PR TITLE
Update oo-design.md

### DIFF
--- a/chapter_linear-regression/oo-design.md
+++ b/chapter_linear-regression/oo-design.md
@@ -194,7 +194,7 @@ class Module(d2l.nn_Module, d2l.HyperParameters):  #@save
         raise NotImplementedError
 
     def forward(self, X):
-        assert hasattr(self, 'net'), 'Neural network is defined'
+        assert hasattr(self, 'net'), 'Neural network is not defined'
         return self.net(X)
 
     def plot(self, key, value, train):


### PR DESCRIPTION
I noticed a potential typo in the code. It seems like 'Neural network is defined' should be changed to 'Neural network is not defined'.

In the module class:
    def forward(self, X):
            assert hasattr(self, 'net'), 'Neural network is defined'
            return self.net(X)