### PR TITLE
Fix pytorch version of custom-layer to allow auto grad

### DIFF
--- a/chapter_builders-guide/custom-layer.md
+++ b/chapter_builders-guide/custom-layer.md
@@ -204,7 +204,7 @@ class MyLinear(nn.Module):
         self.bias = nn.Parameter(torch.randn(units,))
         
     def forward(self, X):
-        linear = torch.matmul(X, self.weight.data) + self.bias.data
+        linear = torch.matmul(X, self.weight) + self.bias
         return F.relu(linear)
 ```
 


### PR DESCRIPTION
self.weight’ and ‘self.bias’ should be used instead of ‘self.weight.data’ and ‘self.bias.data’ to make sure that BP works for weight and bias.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
