### PR TITLE
Fix encoding error in TokenEmbedding

### DIFF
--- a/chapter_natural-language-processing-pretraining/similarity-analogy.md
+++ b/chapter_natural-language-processing-pretraining/similarity-analogy.md
@@ -82,7 +82,7 @@ class TokenEmbedding:
         data_dir = d2l.download_extract(embedding_name)
         # GloVe website: https://nlp.stanford.edu/projects/glove/
         # fastText website: https://fasttext.cc/
-        with open(os.path.join(data_dir, 'vec.txt'), 'r') as f:
+        with open(os.path.join(data_dir, 'vec.txt'), 'r', encoding='utf-8') as f:
             for line in f:
                 elems = line.rstrip().split(' ')
                 token, elems = elems[0], [float(elem) for elem in elems[1:]]


### PR DESCRIPTION
*Description of changes:*

Some operating systems don't use `utf-8` as the default encoding, and a `UnicodeDecodeError` is raised when reading embedding vectors.

The issue is also described in [this discussion](https://discuss.d2l.ai/t/sentiment-analysis-using-recurrent-neural-networks/1424/3).

Related PR: #2287 

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
