### PR TITLE
fix: Update setup.py to support Python 3.12.4 and NumPy 2.0.0.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,13 @@ from setuptools import setup, find_packages
 import d2l
 
 requirements = [
-    'jupyter==1.0.0',
-    'numpy==1.23.5',
-    'matplotlib==3.7.2',
-    'matplotlib-inline==0.1.6',
-    'requests==2.31.0',
-    'pandas==2.0.3',
-    'scipy==1.10.1'
+    'jupyterlab==4.2.2',
+    'numpy==2.0.0',
+    'matplotlib==3.9.1',
+    'matplotlib-inline==0.1.7',
+    'requests==2.32.3',
+    'pandas==2.2.2',
+    'scipy==1.14.0'
 ]
 
 setup(


### PR DESCRIPTION
Update setup.py for Python 3.12.4 and NumPy 2.0.0.  
This PR is compatible with the latest iterations of Python v3.10, v3.11 and v3.12.  Python v3.9 is not supported.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
