### PR TITLE
Code consistency fix in linear-regression-scratch.md

### DIFF
--- a/chapter_linear-regression/linear-regression-scratch.md
+++ b/chapter_linear-regression/linear-regression-scratch.md
@@ -348,7 +348,7 @@ def prepare_batch(self, batch):
 %%tab pytorch
 @d2l.add_to_class(d2l.Trainer)  #@save
 def fit_epoch(self):
-    self.model.train()        
+    self.model.training = True
     for batch in self.train_dataloader:        
         loss = self.model.training_step(self.prepare_batch(batch))
         self.optim.zero_grad()
@@ -360,7 +360,7 @@ def fit_epoch(self):
         self.train_batch_idx += 1
     if self.val_dataloader is None:
         return
-    self.model.eval()
+    self.model.training = False
     for batch in self.val_dataloader:
         with torch.no_grad():            
             self.model.validation_step(self.prepare_batch(batch))


### PR DESCRIPTION
Model.train() and Model.eval() are used without explanation. In addition, the other parts of the section directly set Model.training = True/False instead of invoking the methods.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
