### PR TITLE
fix expectation for densities

### DIFF
--- a/chapter_preliminaries/probability.md
+++ b/chapter_preliminaries/probability.md
@@ -892,7 +892,7 @@ of the random variable $X$ is defined as
 
 $$E[X] = E_{x \sim P}[x] = \sum_{x} x P(X = x).$$
 
-Likewise, for densities we obtain $E[X] = \int x \;dp(x)$.
+Likewise, for densities we obtain $E[X] = \int x p(x) \; dx$.
 Sometimes we are interested in the expected value
 of some function of $x$.
 We can calculate these expectations as


### PR DESCRIPTION
*Description of changes:*
Current version shows the following:

$E[X] = \int x \;dp(x)$

Updated to:

$E[X] = \int x p(x)\;dx$

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your
choice.
